### PR TITLE
[SPARK-59187][SQL][4.3] Compare partition key rows at types with the naming erased

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/physical/partitioning.scala
@@ -632,35 +632,42 @@ case class KeyedPartitioning(
   @transient lazy val expressionDataTypes: Seq[DataType] = expressions.map(_.dataType)
 
   /**
-   * The types the `partitionKeys` rows were built with. Anything reading those rows should take its
-   * types from here. It is a driver-side value, since `partitionKeys` is `@transient`.
+   * The types the `partitionKeys` rows are compared at, which is what anything reading those rows
+   * should take its types from. It is a driver-side value, since `partitionKeys` is `@transient`.
    *
-   * They differ from the `expressionDataTypes` in two cases. A join that reduced both sides' keys
-   * onto a key space no transform names leaves a marked expression whose type can be anything, see
-   * `expressionsDescribeKeys`. A one-side reduce keeps them equal, because the expression the
-   * partitioning then reports is the target transform and `EnsureRequirements` refuses a reducer
-   * whose result type disagrees with it. `KeyedShuffleSpec.createPartitioning` is the other case.
-   * It puts the other child's expressions over these keys with no reducer in sight, so a struct
-   * field can be named differently on the two sides. With no key at all the expressions are all
-   * there is, and there is no row to read or to place.
+   * These are `InternalRowComparableWrapper.comparableTypes`, so the naming is erased: two
+   * partitionings whose keys describe one space have one answer here, whatever the columns those
+   * keys came from were called. With no key row to read, the expressions answer, erased the same
+   * way.
    *
-   * The two cases can meet, and then the fallback is not truthful. A marked partitioning can end up
-   * with no key, for instance when `v2BucketingPartitionFilterEnabled` intersects two sides that
-   * hold disjoint keys, and this then reports the un-reduced transform's type. What it reports is a
-   * fact about the key rows, so with no key row there is no fact, and a caller must not hold the
-   * fallback against a real answer. The reduced-types comparison in `EnsureRequirements` leaves out
-   * a marked side that has no key for that reason (SPARK-59176). An unmarked one still answers,
-   * since its expressions describe the keys it would have had, and stays in the comparison.
+   * They differ from the `expressionDataTypes` in two ways. The naming is one, since those are not
+   * erased. The other is a join that reduced both sides' keys onto a key space no transform names.
+   * It leaves a marked expression whose type can be anything, see `expressionsDescribeKeys`. A
+   * one-side reduce keeps the two equal up to the naming, because the expression the partitioning
+   * then reports is the target transform and `EnsureRequirements` refuses a reducer whose result
+   * type disagrees with it.
+   *
+   * A marked partitioning can end up with no key, and then the fallback is not truthful. That
+   * happens when `v2BucketingPartitionFilterEnabled` intersects two sides that hold disjoint keys,
+   * and this then reports the un-reduced transform's type. What it reports is a fact about the key
+   * rows, so with no key row there is no fact, and a caller must not hold the fallback against a
+   * real answer. The reduced-types comparison in `EnsureRequirements` leaves out a marked side that
+   * has no key for that reason (SPARK-59176). An unmarked one still answers, since its expressions
+   * describe the keys it would have had, and stays in the comparison.
    *
    * `ShuffleExchangeExec` is the one reader that stays on `expressionDataTypes`. It evaluates the
    * expressions to place the other child's rows, and it runs on executors, where this value is not
    * available. `expressionsDescribeKeys` is what keeps that site sound.
    *
-   * Only the first key's types are read, and nothing enforces that the rest match. SPARK-59187 is
-   * to carry the types on the partitioning instead of sampling a key row.
+   * Only the first key's types are read, and nothing enforces that the rest match. The fallback is
+   * also the one erasure outside `InternalRowComparableWrapper`, since there is no factory here to
+   * read the types off and building one just to ask would be two cache lookups for no row.
+   * SPARK-59285 carries the types on the partitioning instead, and both go with it.
    */
   @transient lazy val keyDataTypes: Seq[DataType] =
-    partitionKeys.headOption.map(_.dataTypes).getOrElse(expressionDataTypes)
+    partitionKeys.headOption
+      .map(_.dataTypes)
+      .getOrElse(InternalRowComparableWrapper.comparableTypes(expressionDataTypes))
 
   /** Driver-side, like the `keyDataTypes` it comes from. */
   @transient lazy val keyRowOrdering =
@@ -940,9 +947,10 @@ object KeyedPartitioning {
       keys: Seq[InternalRowComparableWrapper],
       dataTypes: Seq[DataType],
       positions: Seq[Int]): (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
-    val projectedDataTypes = positions.map(dataTypes)
     val comparableKeyWrapperFactory =
-      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(projectedDataTypes)
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(positions.map(dataTypes))
+    // The factory is what reports the types, so they are the ones its keys compare at.
+    val projectedDataTypes = comparableKeyWrapperFactory.dataTypes
     val positionsWithTypes = positions.zip(projectedDataTypes)
     val projectedKeys = keys.map { key =>
       val projectedKey = positionsWithTypes.map {
@@ -961,12 +969,14 @@ object KeyedPartitioning {
       keys: Seq[InternalRowComparableWrapper],
       dataTypes: Seq[DataType],
       reducers: Seq[Option[KeyReducer]]): (Seq[DataType], Seq[InternalRowComparableWrapper]) = {
-    val reducedDataTypes = dataTypes.zip(reducers).map {
-      case (_, Some(KeyReducer(reducer: Reducer[Any, Any], _))) => reducer.resultType()
-      case (t, _) => t
-    }
+    // A reducer's result type comes from the connector, so it goes through the same erasure the
+    // keys below are built at, and the factory is what reports it. See `projectKeys`.
     val comparableKeyWrapperFactory =
-      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(reducedDataTypes)
+      InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(
+        dataTypes.zip(reducers).map {
+          case (_, Some(KeyReducer(reducer: Reducer[Any, Any], _))) => reducer.resultType()
+          case (t, _) => t
+        })
     val reducedKeys = keys.map { key =>
       val keyValues = key.row.toSeq(dataTypes)
       val reducedKey = keyValues.zip(reducers).map {
@@ -976,7 +986,7 @@ object KeyedPartitioning {
       comparableKeyWrapperFactory(new GenericInternalRow(reducedKey))
     }
 
-    (reducedDataTypes, reducedKeys)
+    (comparableKeyWrapperFactory.dataTypes, reducedKeys)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapper.scala
@@ -29,7 +29,9 @@ import org.apache.spark.util.NonFateSharingCache
  * It uses Spark's internal murmur hash to compute hash code from an row, and uses [[RowOrdering]]
  * to perform equality checks.
  *
- * @param dataTypes the data types for the row
+ * @param dataTypes the types this row is compared at, always `comparableTypes` of the types the row
+ *                  was built from. No constructor can produce a raw list, and the two caches below
+ *                  are keyed by erased lists for the same reason.
  */
 class InternalRowComparableWrapper private (
     val row: InternalRow,
@@ -44,10 +46,8 @@ class InternalRowComparableWrapper private (
    */
   @deprecated
   def this(row: InternalRow, dataTypes: Seq[DataType]) = this(
-    row,
-    dataTypes,
-    InternalRowComparableWrapper.structTypeCache.get(dataTypes),
-    InternalRowComparableWrapper.orderingCache.get(dataTypes))
+    // Erases like the factory, so a wrapper built here compares with the ones the factory built.
+    row, InternalRowComparableWrapper.comparableTypes(dataTypes), null, null)
 
   // `structType` and `ordering` cannot cross the wire (the ordering may be generated code), so
   // they are transient and re-derived from the shared caches on first use after deserialization.
@@ -105,21 +105,68 @@ object InternalRowComparableWrapper {
   def apply(
       partition: InputPartition with HasPartitionKey,
       partitionExpression: Seq[Expression]): InternalRowComparableWrapper = {
-    new InternalRowComparableWrapper(
-      partition.asInstanceOf[HasPartitionKey].partitionKey(), partitionExpression.map(_.dataType))
+    apply(partition.partitionKey(), partitionExpression)
   }
 
   def apply(
       partitionRow: InternalRow,
       partitionExpression: Seq[Expression]): InternalRowComparableWrapper = {
-    new InternalRowComparableWrapper(partitionRow, partitionExpression.map(_.dataType))
+    getInternalRowComparableWrapperFactory(partitionExpression.map(_.dataType))(partitionRow)
   }
 
-  /** Creates a shared factory method for a given row schema to avoid excessive cache lookups. */
-  def getInternalRowComparableWrapperFactory(
-      dataTypes: Seq[DataType]): InternalRow => InternalRowComparableWrapper = {
-    val structType = structTypeCache.get(dataTypes)
-    val ordering = orderingCache.get(dataTypes)
-    row: InternalRow => new InternalRowComparableWrapper(row, dataTypes, structType, ordering)
+  /**
+   * The types a row is compared at, which is the given types with their naming erased: struct field
+   * names and every nullability go, and nothing else does.
+   *
+   * Two rows of the same value belong together whatever the columns they came from were called. A
+   * storage-partitioned join relies on that: an equi-join across two structs whose fields are named
+   * differently is legal, `identity` carries that name into the key type, and
+   * `KeyedShuffleSpec.createPartitioning` puts one side's expressions over the other side's keys.
+   * So the naming is erased once, here, and every wrapper compares at these types.
+   *
+   * Everything else is kept exactly, since it decides where a value belongs: a collation and a
+   * decimal precision still tell two rows apart.
+   */
+  private[catalyst] def comparableTypes(dataTypes: Seq[DataType]): Seq[DataType] = {
+    val erased = dataTypes.map(t => erasePositionalNames(t.asNullable))
+    // Erasing is idempotent, and a list that was already erased is returned as it is rather than
+    // rebuilt. Callers pass their own types here and then hand the result back in, so keeping the
+    // instance is what lets `equals` settle two wrappers of one list by reference.
+    if (erased == dataTypes) dataTypes else erased
   }
+
+  /**
+   * `asNullable` above is the nullability half. This is the naming half: positional field names, so
+   * two structs that agree field by field agree here. A field's metadata goes with its name, since
+   * nothing that compares or hashes a row reads either. `transformRecursively` stops at the first
+   * match, so a nested struct is reached by the recursive call rather than by the walk.
+   */
+  private def erasePositionalNames(dataType: DataType): DataType =
+    dataType.transformRecursively {
+      case s: StructType => StructType(s.fields.zipWithIndex.map { case (field, i) =>
+        StructField(i.toString, erasePositionalNames(field.dataType))
+      })
+    }
+
+  /**
+   * Builds wrappers over one row schema, holding the cache lookups that schema needs so a caller
+   * does not repeat them per row.
+   *
+   * `dataTypes` is what the rows it builds compare at, which is `comparableTypes` of what it was
+   * given. A caller reporting a type list beside those rows takes it from here rather than erasing
+   * on its own, so the two cannot answer differently.
+   */
+  final class Factory private[InternalRowComparableWrapper] (val dataTypes: Seq[DataType])
+    extends (InternalRow => InternalRowComparableWrapper) {
+
+    private[this] val structType = structTypeCache.get(dataTypes)
+    private[this] val ordering = orderingCache.get(dataTypes)
+
+    override def apply(row: InternalRow): InternalRowComparableWrapper =
+      new InternalRowComparableWrapper(row, dataTypes, structType, ordering)
+  }
+
+  /** Creates a shared factory for a given row schema to avoid excessive cache lookups. */
+  def getInternalRowComparableWrapperFactory(dataTypes: Seq[DataType]): Factory =
+    new Factory(comparableTypes(dataTypes))
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/ShuffleSpecSuite.scala
@@ -888,4 +888,22 @@ class ShuffleSpecSuite extends SparkFunSuite with SQLHelper {
       assert(e.getMessage.contains("expected all specs in the collection to have the same number"))
     }
   }
+
+  test("SPARK-59187: reduceKeys reports the types its keys are compared at") {
+    // A reducer's result type comes from the connector, so it can name a struct field. See
+    // `KeyedPartitioning.reduceKeys`.
+    val named = new StructType().add("reduced", IntegerType)
+    val reducer = new Reducer[Int, InternalRow] {
+      override def resultType(): DataType = named
+      override def reduce(value: Int): InternalRow = InternalRow(value)
+    }
+    val transform = TransformExpression(TestBucketFunction, Seq($"a".int), Some(4))
+    val partitioning = KeyedPartitioning(Seq($"a".int), Seq(InternalRow(1), InternalRow(2)))
+
+    val (reducedDataTypes, reducedKeys) =
+      partitioning.reduceKeys(Seq(Some(KeyReducer(reducer, transform))))
+    assert(reducedDataTypes !== Seq(named), "test setup: the reducer names a field to erase")
+    assert(reducedKeys.map(_.dataTypes).distinct === Seq(reducedDataTypes),
+      "the reported types are the ones the keys hold")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/InternalRowComparableWrapperSuite.scala
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types._
+
+class InternalRowComparableWrapperSuite extends SparkFunSuite {
+
+  private val structA = new StructType().add("a", IntegerType)
+  private val structB = new StructType().add("b", IntegerType)
+
+  test("SPARK-59187: comparableTypes erases the naming and nothing else") {
+    // The erasure has to answer exactly what `DataType.equalsStructurally` answers with
+    // `ignoreNullability`, since that is the question two rows are asking of each other. Anything
+    // erased beyond the naming would call two different values equal.
+    val pairs = Seq(
+      (IntegerType, IntegerType),
+      (IntegerType, LongType),
+      (structA, structB),
+      (structA, new StructType().add("a", IntegerType, nullable = false)),
+      (structA, new StructType().add("a", LongType)),
+      (structA, new StructType().add("a", IntegerType).add("c", IntegerType)),
+      (structA, IntegerType),
+      (ArrayType(structA), ArrayType(structB)),
+      (ArrayType(structA, containsNull = false), ArrayType(structB)),
+      (ArrayType(structA), ArrayType(IntegerType)),
+      (MapType(structA, structB), MapType(structB, structA)),
+      (MapType(IntegerType, structA, valueContainsNull = false), MapType(IntegerType, structB)),
+      (DecimalType(10, 2), DecimalType(10, 2)),
+      (DecimalType(10, 2), DecimalType(12, 2)),
+      (StringType, StringType("UTF8_LCASE")),
+      // A char length and a UDT decide where a value belongs too, and a UDT's own `sqlType` names
+      // its fields, so the erasure must not descend into one.
+      (new StructType().add("c", CharType(5)), new StructType().add("x", CharType(5))),
+      (CharType(5), CharType(6)),
+      (CharType(5), VarcharType(5)),
+      (new TestUDT.MyDenseVectorUDT, new TestUDT.MyDenseVectorUDT),
+      (new ExampleBaseTypeUDT, new ExampleSubTypeUDT),
+      // Metadata goes with the field name, and `equalsStructurally` ignores it too.
+      (structA, new StructType().add(
+        "a", IntegerType, nullable = true, new MetadataBuilder().putString("k", "v").build())))
+
+    pairs.foreach { case (left, right) =>
+      val erasedAgree = InternalRowComparableWrapper.comparableTypes(Seq(left)) ==
+        InternalRowComparableWrapper.comparableTypes(Seq(right))
+      assert(erasedAgree === DataType.equalsStructurally(left, right, ignoreNullability = true),
+        s"$left and $right")
+    }
+
+    // Position by position, so two lists of different length are different.
+    assert(InternalRowComparableWrapper.comparableTypes(Seq(IntegerType)) !=
+      InternalRowComparableWrapper.comparableTypes(Seq(IntegerType, LongType)))
+  }
+
+  test("SPARK-59187: erasing is idempotent, and keeps the list it was given") {
+    // Callers pass their own types in and hand the result back to another factory, so the erasure
+    // has to settle on the second pass and give that pass its own list back.
+    val exact = Seq(structA, ArrayType(structB, containsNull = false), IntegerType)
+    val erased = InternalRowComparableWrapper.comparableTypes(exact)
+    assert(erased != exact, "test setup: this list has something to erase")
+    assert(InternalRowComparableWrapper.comparableTypes(erased) eq erased)
+
+    val alreadyErased = Seq(IntegerType, ArrayType(LongType))
+    assert(InternalRowComparableWrapper.comparableTypes(alreadyErased) eq alreadyErased)
+  }
+
+  test("SPARK-59187: a factory answers for the types it settled on") {
+    // A caller that reports a type list beside the rows a factory built takes it from here, so the
+    // two cannot answer differently.
+    val factory = InternalRowComparableWrapper.getInternalRowComparableWrapperFactory(Seq(structA))
+    assert(factory.dataTypes !== Seq(structA), "test setup: this type has a name to erase")
+    assert(factory.dataTypes === InternalRowComparableWrapper.comparableTypes(Seq(structA)))
+    assert(factory(InternalRow(InternalRow(1))).dataTypes eq factory.dataTypes)
+  }
+
+  test("SPARK-59187: two rows of one value are equal however their columns were named") {
+    // What the erasure is for. A storage-partitioned join compares key rows that came from two
+    // sides' own columns, and the same value has to land in the same partition group either way.
+    def wrap(dataType: DataType, value: InternalRow): InternalRowComparableWrapper =
+      InternalRowComparableWrapper
+        .getInternalRowComparableWrapperFactory(Seq(dataType))(value)
+
+    val fromA = wrap(structA, InternalRow(InternalRow(1)))
+    val fromB = wrap(structB, InternalRow(InternalRow(1)))
+    assert(fromA === fromB, "the field names must not decide")
+    assert(fromA.hashCode === fromB.hashCode, "and they must agree on the bucket too")
+    assert(Set(fromA, fromB).size === 1, "so a set of them holds one")
+
+    assert(fromA !== wrap(structA, InternalRow(InternalRow(2))), "two values are still two")
+    assert(wrap(IntegerType, InternalRow(1)) !== wrap(LongType, InternalRow(1L)),
+      "and a type that decides where a value belongs still tells them apart")
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -589,7 +589,7 @@ case class EnsureRequirements(
         )(rightPartitioning.reduceKeys)
         // The reduced types are the types of the key rows the merge below sees. A side with no key
         // still answers for them while its expressions describe the keys it would have had, and
-        // `keyDataTypes` falls back to exactly those types. After a reduce the expressions no
+        // `keyDataTypes` falls back to those types, erased. After a reduce the expressions no
         // longer describe them, so the fallback is a type no key of that partitioning would hold,
         // and comparing it against a real answer fails a co-partitioned query (SPARK-59176). Only
         // such a side is left out. An empty one that is not marked stays in, which is what keeps
@@ -603,6 +603,9 @@ case class EnsureRequirements(
         } else if (!rightTypesDescribeKeys || leftReducedDataTypes == rightReducedDataTypes) {
           leftReducedDataTypes
         } else {
+          // The two lists are the erased ones, so a struct in the message prints positional field
+          // names. That is deliberate: the names do not decide where a key belongs, so printing the
+          // connector's own would point a reader at a difference that is not the cause.
           throw QueryExecutionErrors.storagePartitionJoinIncompatibleReducedTypesError(
             leftReducers = leftReducers,
             leftReducedDataTypes = leftReducedDataTypes,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/ShuffleExchangeExec.scala
@@ -411,10 +411,9 @@ object ShuffleExchangeExec {
         // wrapped through the same `InternalRowComparableWrapper` factory over this
         // partitioning's expression data types, so map lookups share the exact equivalence
         // (`RowOrdering`, e.g. binary keys by content, -0.0 == 0.0, NaNs equal) that grouped and
-        // de-duplicated `partitionKeys`. Re-wrapping the stored keys matters: `KeyedShuffleSpec
-        // .createPartitioning` substitutes this side's expressions but retains the other side's
-        // `partitionKeys`, whose wrappers may carry a schema that differs in struct field names,
-        // which wrapper equality would reject.
+        // de-duplicated `partitionKeys`. Re-wrapping the stored keys, which were built at
+        // `keyDataTypes`, is what makes the two type lists agree, and a mismatch is silent:
+        // `KeyGroupedPartitioner.getPartition` answers a miss with the key's hash (SPARK-59054).
         val wrapperFactory = InternalRowComparableWrapper
           .getInternalRowComparableWrapperFactory(k.expressionDataTypes)
         val valueMap = k.partitionKeys.map(key => wrapperFactory(key.row)).zipWithIndex

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -75,6 +75,11 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
   private val emptyProps: java.util.Map[String, String] = {
     Collections.emptyMap[String, String]
   }
+
+  /** Two structs of one shape, named differently, which is legal to join across. */
+  private val structA = new StructType().add("a", IntegerType)
+  private val structB = new StructType().add("b", IntegerType)
+
   private val table: String = "tbl"
 
   private val columns: Array[Column] = Array(
@@ -2207,7 +2212,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
     // the field names.
     val items_partitions = Array(identity("id"))
     createTable(items, Array(
-      Column.create("id", new StructType().add("a", IntegerType)),
+      Column.create("id", structA),
       Column.create("name", StringType),
       Column.create("price", DoubleType)), items_partitions)
 
@@ -2218,7 +2223,7 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
       "(named_struct('a', 4), 'dd', 20.0)")
 
     createTable(purchases, Array(
-      Column.create("item_id", new StructType().add("b", IntegerType)),
+      Column.create("item_id", structB),
       Column.create("price", DoubleType)), Array.empty)
     sql(s"INSERT INTO testcat.ns.$purchases VALUES " +
       "(named_struct('b', 1), 42.0), (named_struct('b', 2), 19.5), " +
@@ -2240,6 +2245,113 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase with 
           Row(Row(2), "bb", 10.0, 19.5),
           Row(Row(3), "cc", 15.5, 26.0),
           Row(Row(4), "dd", 20.0, 50.0)))
+      }
+    }
+  }
+
+  test("SPARK-59187: a union of a key that repeats across children under two namings joins right") {
+    // Two keyed sides holding one logical key under two namings, `struct<a:int>` and
+    // `struct<b:int>`. Struct equality ignores field names, so the union merges their keys and the
+    // merged list holds that key twice. It has to report that it does, or nothing regroups it and
+    // `s4` is shuffled straight onto it. `KeyGroupedPartitioner`'s map keeps one partition per key,
+    // so the union partition holding the earlier copy gets no rows and its row is dropped.
+    withTable("t1", "t2", "s4") {
+      createTable("t1", Array(Column.create("k1", structA)), Array(identity("k1")))
+      sql("INSERT INTO testcat.ns.t1 VALUES (named_struct('a', 1)), (named_struct('a', 2))")
+      createTable("t2", Array(Column.create("k2", structB)), Array(identity("k2")))
+      sql("INSERT INTO testcat.ns.t2 VALUES (named_struct('b', 1))")
+      createTable("s4", Array(
+        Column.create("k4", structB),
+        Column.create("w", StringType)), Array.empty)
+      sql("INSERT INTO testcat.ns.s4 VALUES " +
+        "(named_struct('b', 1), 'x'), (named_struct('b', 2), 'y')")
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.UNION_OUTPUT_PARTITIONING.key -> "true") {
+        val unionSql =
+          """SELECT k1 AS k FROM testcat.ns.t1
+            |UNION ALL
+            |SELECT k2 AS k FROM testcat.ns.t2
+            |""".stripMargin
+        val df = sql(s"""SELECT u.k, s.w FROM ($unionSql) u JOIN testcat.ns.s4 s ON u.k = s.k4""")
+        checkAnswer(df, Seq(Row(Row(1), "x"), Row(Row(1), "x"), Row(Row(2), "y")))
+
+        val union = sql(unionSql).queryExecution.executedPlan
+          .collectFirst { case u: UnionExec => u }.get
+        union.outputPartitioning match {
+          case kp: physical.KeyedPartitioning =>
+            assert(kp.numPartitions === 3, "two children's keys, concatenated")
+            assert(!kp.isGrouped,
+              "the key `t1` and `t2` share is in the list twice, however each named it")
+          case other => fail(s"Expected the union to merge the children's keys, got $other")
+        }
+      }
+    }
+  }
+
+  test("SPARK-59187: two keyed sides whose struct field names differ join without a shuffle") {
+    // The join is legal, since struct equality ignores field names, and the two sides hold the same
+    // key values. Key rows are compared at types with the naming erased, so the two sides' keys
+    // pair and the join needs no shuffle. Before that erasure this threw
+    // STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES, for a join that reduced nothing.
+    withTable("s1", "s2") {
+      createTable("s1", Array(Column.create("id", structA), Column.create("v", StringType)),
+        Array(identity("id")))
+      sql("INSERT INTO testcat.ns.s1 VALUES " +
+        "(named_struct('a', 1), 'x'), (named_struct('a', 2), 'y')")
+      createTable("s2", Array(Column.create("k", structB), Column.create("w", StringType)),
+        Array(identity("k")))
+      sql("INSERT INTO testcat.ns.s2 VALUES " +
+        "(named_struct('b', 1), 'p'), (named_struct('b', 2), 'q')")
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true") {
+        val df = sql("SELECT s1.v, s2.w FROM testcat.ns.s1 JOIN testcat.ns.s2 ON s1.id = s2.k")
+        assert(collectShuffles(df.queryExecution.executedPlan).isEmpty,
+          "the two sides are laid out on the same keys")
+        checkAnswer(df, Seq(Row("x", "p"), Row("y", "q")))
+      }
+    }
+  }
+
+  test("SPARK-59187: a shuffled side keeps its own struct field names over shared empty keys") {
+    // End to end because the point is that the planner reaches this shape, not that two hand-built
+    // partitionings agree. `createPartitioning` puts the other child's expressions over this side's
+    // keys, so the two members of the join's partitioning carry `struct<a:int>` and `struct<b:int>`
+    // over one shared key list. Struct equality ignores field names, so the join is legal, and with
+    // the keys pruned to nothing each member answers for its key types from its own expressions.
+    // The two answers describe the same key space and must not be held against each other.
+    withTable("a1", "b1", "c1") {
+      createTable("a1", Array(Column.create("id", structA)), Array(identity("id")))
+      sql("INSERT INTO testcat.ns.a1 VALUES (named_struct('a', 1))")
+      createTable("b1", Array(Column.create("id", structA)), Array(identity("id")))
+      sql("INSERT INTO testcat.ns.b1 VALUES (named_struct('a', 2))")
+      createTable("c1", Array(Column.create("k", structB)), Array.empty)
+      sql("INSERT INTO testcat.ns.c1 VALUES (named_struct('b', 1))")
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_PARTITION_FILTER_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true") {
+        // The GROUP BY is what asks the join for its `outputPartitioning`.
+        val df = sql(
+          """SELECT id, count(*) FROM (
+            |  SELECT j.id, c1.k FROM
+            |    (SELECT a1.id AS id FROM testcat.ns.a1 JOIN testcat.ns.b1 ON a1.id = b1.id) j
+            |    JOIN testcat.ns.c1 ON j.id = c1.k
+            |) GROUP BY id
+            |""".stripMargin)
+        val plan = df.queryExecution.executedPlan
+        val members = keyedPartitioningsOf(collect(plan) { case j: SortMergeJoinExec => j })
+        assert(members.map(_.expressions).distinct.size > 1,
+          "test setup: a join reports the two sides' expressions over one layout")
+        assert(members.map(_.keyDataTypes).distinct.size === 1,
+          "and they answer for one key space, whatever each side calls its struct field")
+        checkAnswer(df, Nil)
       }
     }
   }


### PR DESCRIPTION
This is the `branch-4.3` backport of #58501 (master `c6e2d26ac66`). The cherry-pick was not clean, so it is a separate PR.

**What was tailored.** `branch-4.3` does not have SPARK-59123's per-key loops in `KeyedPartitioning.projectKeys` and `reduceKeys`, so those two methods keep their 4.3 shape and only take the type list off the wrapper factory. Nothing else differs from master.

**Both defects are live here**, verified rather than assumed: with the erasure ablated on this branch, all three `KeyGroupedPartitioningSuite` tests fail.

### What changes were proposed in this pull request?

`InternalRowComparableWrapper`'s factory builds every partition key row at `comparableTypes`, the given types with struct field names, every nullability and a field's metadata erased and nothing else touched. It is `asNullable` for the nullability half plus a positional `StructType` rename for the naming half. Three places that report a key list's types alongside it erase them the same way, so a partitioning's key types are always the types its keys are compared at: `KeyedPartitioning.keyDataTypes`, in its no-key fallback, and `KeyedPartitioning.projectKeys` and `reduceKeys`, the latter over types that come from a connector's `Reducer`.

The erasure is idempotent and keeps the list it was given, so a caller that hands its own types in and the result back to another factory gets one instance, and `equals` keeps its reference fast path.

### Why are the changes needed?

`InternalRowComparableWrapper.equals` compares its `dataTypes` before its values, so two key rows of one value never matched when the columns they came from were named differently. A storage-partitioned join is about the opposite: a key value belongs where its value says, not where its column name says. Two consequences, both measured on master.

**A join between two keyed sides whose struct key fields are named differently throws.** `identity` carries the column's own struct type into the key type, and the analyzer accepts an equi-join across `struct<a:int>` and `struct<b:int>` -- `BinaryComparison.sameType` is `DataType.equalsStructurally(_, _, ignoreNullability = true)`, so no `Cast` is inserted. Both sides are keyed and the values match, but the key rows never matched, so the co-partitioned fast path in `KeyedShuffleSpec.isCompatibleWith` was out, and a pair of attributes has no reducer, so the reduced-types check threw `STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES` for a join that reduced nothing:

    s1(id struct<a:int>, v string) partitioned by identity(id), keys named_struct('a',1), ('a',2)
    s2(k  struct<b:int>, w string) partitioned by identity(k),  keys named_struct('b',1), ('b',2)

    SELECT s1.v, s2.w FROM s1 JOIN s2 ON s1.id = s2.k   -- threw, now runs with no shuffle

**A union over a key that two children hold under two namings silently drops rows.** `KeyedPartitioning.concat` puts the children's key rows in one list and asks whether any repeats. Rows of two namings never matched, so the merged partitioning reported unique keys when they were not. Nothing regroups it then, so `KeyedShuffleSpec.canCreatePartitioning` accepts it and the other side is shuffled straight onto those keys. `KeyGroupedPartitioner`'s map holds one partition per key, so the union partition holding the earlier copy of the repeated key receives no rows at all:

    t1(k1 struct<a:int>)           partitioned by identity(k1), keys ('a',1), ('a',2)
    t2(k2 struct<b:int>)           partitioned by identity(k2), key ('b',1)
    s4(k4 struct<b:int>, w string) unpartitioned, rows (('b',1),'x'), (('b',2),'y')

    SELECT u.k, s.w FROM (
      SELECT k1 AS k FROM t1 UNION ALL SELECT k2 AS k FROM t2
    ) u JOIN s4 s ON u.k = s.k4

returns 2 rows on master and 3 with this change. An inner join loses a row it should return.

`ShuffleExchangeExec` already knew about this and worked around it, re-wrapping the partitioner's map keys through the same factory as its per-row lookup keys so the naming could not decide (SPARK-59054). Doing the erasure where rows are built removes that workaround's reason. This PR leaves the re-wrap in place under a different one: the stored keys were built at `keyDataTypes`, and re-wrapping is what makes that list and the lookups' list agree. A mismatch there is silent, since `KeyGroupedPartitioner.getPartition` answers a miss with the key's hash.

The factory is a chokepoint: six sites in production build partition-key wrappers, none of them wants un-erased types, and the only readers of a wrapper's `dataTypes` are its own `equals` and `keyDataTypes`. No site can opt out. The class already erased half of this: `structTypeCache` names every top-level field `"f"`, and `RowOrdering.createNaturalAscendingOrdering` forces `nullable = true`, so `hashCode` was naming-blind while `equals` was not.

What goes is the struct field names, every nullability, and a field's metadata, which travels with its name. Nothing else: a collation, a decimal precision, a `char` length and a UDT all decide where a value belongs, so they still tell two rows apart. Metadata goes because nothing that compares or hashes a row reads it, and because `DataType.equalsStructurally` ignores it too, so keeping it would make the erasure answer differently from the predicate it stands for. The erasure is exactly `DataType.equalsStructurally(_, _, ignoreNullability = true)` expressed as a canonical value rather than a predicate, and the new suite pins it against that primitive. A value is what is needed rather than a predicate, because the result is a `NonFateSharingCache` key, the `dataTypes` field two wrappers compare, and what `keyDataTypes` reports.

Nothing that compares or hashes a row reads a field name: `GenerateOrdering.genComparisons` rebuilds each field's `SortOrder` positionally, and `Murmur3HashFunction` hashes through the field types. So the erasure cannot move a row or change a sort order, and the `KeyedPartitioning.toGrouped` / `GroupPartitionsExec.groupAndSortByKeys` sort contract is unaffected. It can only make more keys compare equal, so `isGrouped` moves toward "not unique" and a regroup is added, never skipped.

### Does this PR introduce _any_ user-facing change?

Yes, three things.

- The join above ran into an error and now returns its rows without a shuffle.
- The union above dropped a row and now returns it.
- `STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES` prints a struct key's field names positionally, ``STRUCT<`0`: INT>`` rather than `STRUCT<a: INT>`. Deliberate: the message fires only on a real structural mismatch now, and the connector's own names would point a reader at a difference that is not the cause.

### How was this patch tested?

`InternalRowComparableWrapperSuite`, new:

- "comparableTypes erases the naming and nothing else", over 22 type pairs including collation, decimal precision, `char` length, two UDTs, field metadata, struct nullability and nested arrays and maps, each checked against `DataType.equalsStructurally(ignoreNullability = true)`.
- "erasing is idempotent, and keeps the list it was given".
- "two rows of one value are equal however their columns were named", which also asserts they hash alike and collapse in a set.

`KeyGroupedPartitioningSuite`, three end-to-end tests, all failing on master:

- "two keyed sides whose struct field names differ join without a shuffle" -- the first query above. Fails with `STORAGE_PARTITION_JOIN_INCOMPATIBLE_REDUCED_TYPES`.
- "a union of a key that repeats across children under two namings joins right" -- the second query above. Fails on the answer, 2 rows where 3 are correct, and then on `isGrouped`.
- "a shuffled side keeps its own struct field names over shared empty keys" -- a join whose two members carry the two sides' own expressions over one shared, pruned-to-nothing key list. Fails because the members answer for two key spaces.

`ShuffleSpecSuite`, "reduceKeys reports the types its keys are compared at", for a `Reducer` whose result type names a struct field.

Each production hunk was ablated in turn and each has a test that fails without it.

`KeyGroupedPartitioningSuite`, `KeyGroupedPartitioningRuntimeFilterSuite`, `EnsureRequirementsSuite`, `GroupPartitionsExecSuite`, `PlannerSuite`, `ExchangeSuite`, `ExplainSuite`, `DataFrameSetOperationsSuite`, `DataSourceV2Suite`, `DataSourceV2CatalystRuntimeFilterSuite`, `ProjectedOrderingAndPartitioningSuite`, `DistributionSuite`, `ShuffleSpecSuite`, `TransformExpressionSuite` and `InternalRowComparableWrapperSuite` on master. On this branch: `KeyGroupedPartitioningSuite`, `GroupPartitionsExecSuite`, `EnsureRequirementsSuite`, `DistributionSuite`, `ShuffleSpecSuite` and `InternalRowComparableWrapperSuite`, 284 tests. Scalastyle and scalafmt clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
