### PR TITLE
[SPARK-59307][ML] Detect cyclic node ids when loading decision tree and bisecting k-means models

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
@@ -159,39 +159,33 @@ object BisectingKMeansModel extends Loader[BisectingKMeansModel] {
   }
 
   private def buildTree(rootId: Int, nodes: Map[Int, Data]): ClusteringTreeNode =
-    buildTree(rootId, nodes, mutable.Set.empty, mutable.Map.empty)
+    buildTree(rootId, nodes, mutable.Set.empty)
 
   /**
-   * `visiting` tracks the node ids currently on the recursion stack and `built` memoizes nodes
-   * already constructed. A saved model whose child ids form a cycle (which never happens for a
-   * valid tree) would otherwise recurse until the driver hits a StackOverflowError; detecting the
-   * cycle turns that into a clear failure. Memoization additionally prevents a model that
-   * references the same child id from many parents (a DAG) from expanding exponentially. Valid
-   * trees have neither cycles nor shared children, so their construction is unchanged.
+   * `visiting` accumulates every node id reached while building the tree. A valid tree reaches each
+   * id exactly once, so encountering an id that is already present means the saved data is not a
+   * tree: either its child ids form a cycle (which would otherwise recurse until the driver hits a
+   * StackOverflowError) or a child id is shared by more than one parent. Either way we fail with a
+   * clear message. Valid trees build unchanged.
    */
   private def buildTree(
       rootId: Int,
       nodes: Map[Int, Data],
-      visiting: mutable.Set[Int],
-      built: mutable.Map[Int, ClusteringTreeNode]): ClusteringTreeNode = {
-    built.get(rootId) match {
-      case Some(node) => node
-      case None =>
-        require(visiting.add(rootId),
-          s"Cycle detected among node ids while loading the bisecting k-means model " +
-            s"(node id = $rootId).")
-        val root = nodes(rootId)
-        val result = if (root.children.isEmpty) {
-          new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
-            root.cost, root.height, new Array[ClusteringTreeNode](0))
-        } else {
-          val children = root.children.map(c => buildTree(c, nodes, visiting, built))
-          new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
-            root.cost, root.height, children.toArray)
-        }
-        visiting -= rootId
-        built(rootId) = result
-        result
+      visiting: mutable.Set[Int]): ClusteringTreeNode = {
+    if (!visiting.add(rootId)) {
+      throw new IllegalArgumentException(
+        s"Node id $rootId is reached more than once while loading the bisecting k-means " +
+          s"model; the saved node data is not a tree (its child ids form a cycle, or a child " +
+          s"id is shared by more than one parent).")
+    }
+    val root = nodes(rootId)
+    if (root.children.isEmpty) {
+      new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
+        root.cost, root.height, new Array[ClusteringTreeNode](0))
+    } else {
+      val children = root.children.map(c => buildTree(c, nodes, visiting))
+      new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
+        root.cost, root.height, children.toArray)
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/clustering/BisectingKMeansModel.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.mllib.clustering
 
+import scala.collection.mutable
+
 import org.json4s._
 import org.json4s.DefaultFormats
 import org.json4s.JsonDSL._
@@ -156,15 +158,40 @@ object BisectingKMeansModel extends Loader[BisectingKMeansModel] {
     }
   }
 
-  private def buildTree(rootId: Int, nodes: Map[Int, Data]): ClusteringTreeNode = {
-    val root = nodes(rootId)
-    if (root.children.isEmpty) {
-      new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
-        root.cost, root.height, new Array[ClusteringTreeNode](0))
-    } else {
-      val children = root.children.map(c => buildTree(c, nodes))
-      new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
-        root.cost, root.height, children.toArray)
+  private def buildTree(rootId: Int, nodes: Map[Int, Data]): ClusteringTreeNode =
+    buildTree(rootId, nodes, mutable.Set.empty, mutable.Map.empty)
+
+  /**
+   * `visiting` tracks the node ids currently on the recursion stack and `built` memoizes nodes
+   * already constructed. A saved model whose child ids form a cycle (which never happens for a
+   * valid tree) would otherwise recurse until the driver hits a StackOverflowError; detecting the
+   * cycle turns that into a clear failure. Memoization additionally prevents a model that
+   * references the same child id from many parents (a DAG) from expanding exponentially. Valid
+   * trees have neither cycles nor shared children, so their construction is unchanged.
+   */
+  private def buildTree(
+      rootId: Int,
+      nodes: Map[Int, Data],
+      visiting: mutable.Set[Int],
+      built: mutable.Map[Int, ClusteringTreeNode]): ClusteringTreeNode = {
+    built.get(rootId) match {
+      case Some(node) => node
+      case None =>
+        require(visiting.add(rootId),
+          s"Cycle detected among node ids while loading the bisecting k-means model " +
+            s"(node id = $rootId).")
+        val root = nodes(rootId)
+        val result = if (root.children.isEmpty) {
+          new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
+            root.cost, root.height, new Array[ClusteringTreeNode](0))
+        } else {
+          val children = root.children.map(c => buildTree(c, nodes, visiting, built))
+          new ClusteringTreeNode(root.index, root.size, new VectorWithNorm(root.center, root.norm),
+            root.cost, root.height, children.toArray)
+        }
+        visiting -= rootId
+        built(rootId) = result
+        result
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -285,10 +285,12 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
     /**
      * Builds a node from the node data map and adds new nodes to the input nodes map.
      *
-     * `visiting` tracks the node ids currently on the recursion stack. A saved model whose
-     * left/right node ids form a cycle (which never happens for a valid tree) would otherwise
-     * recurse until the driver hits a StackOverflowError; detecting the cycle turns that into a
-     * clear, contained failure. Valid models (including shared leaves) are unaffected.
+     * `visiting` records the node ids currently being constructed (a fully constructed node is in
+     * `nodes` and every later visit short-circuits on it before `visiting` is consulted). A saved
+     * model whose left/right node ids form a cycle (which never happens for a valid tree) would
+     * otherwise recurse until the driver hits a StackOverflowError; detecting a node reached while
+     * it is still being constructed turns that into a clear, contained failure. Valid models
+     * (including shared leaves, which are served from `nodes`) are unaffected.
      */
     private def constructNode(
       id: Int,
@@ -298,8 +300,10 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
       if (nodes.contains(id)) {
         return nodes(id)
       }
-      require(visiting.add(id),
-        s"Cycle detected among node ids while loading the decision tree model (node id = $id).")
+      if (!visiting.add(id)) {
+        throw new IllegalArgumentException(
+          s"Cycle detected among node ids while loading the decision tree model (node id = $id).")
+      }
       val data = dataMap(id)
       val node =
         if (data.isLeaf) {
@@ -312,7 +316,6 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
           new Node(data.nodeId, data.predict.toPredict, data.impurity, data.isLeaf,
             data.split.map(_.toSplit), Some(leftNode), Some(rightNode), Some(stats))
         }
-      visiting -= id
       nodes += node.id -> node
       node
     }

--- a/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/tree/model/DecisionTreeModel.scala
@@ -279,31 +279,40 @@ object DecisionTreeModel extends Loader[DecisionTreeModel] with Logging {
       val dataMap: Map[Int, NodeData] = data.map(n => n.nodeId -> n).toMap
       assert(dataMap.contains(1),
         s"DecisionTree missing root node (id = 1).")
-      constructNode(1, dataMap, mutable.Map.empty)
+      constructNode(1, dataMap, mutable.Map.empty, mutable.Set.empty)
     }
 
     /**
      * Builds a node from the node data map and adds new nodes to the input nodes map.
+     *
+     * `visiting` tracks the node ids currently on the recursion stack. A saved model whose
+     * left/right node ids form a cycle (which never happens for a valid tree) would otherwise
+     * recurse until the driver hits a StackOverflowError; detecting the cycle turns that into a
+     * clear, contained failure. Valid models (including shared leaves) are unaffected.
      */
     private def constructNode(
       id: Int,
       dataMap: Map[Int, NodeData],
-      nodes: mutable.Map[Int, Node]): Node = {
+      nodes: mutable.Map[Int, Node],
+      visiting: mutable.Set[Int]): Node = {
       if (nodes.contains(id)) {
         return nodes(id)
       }
+      require(visiting.add(id),
+        s"Cycle detected among node ids while loading the decision tree model (node id = $id).")
       val data = dataMap(id)
       val node =
         if (data.isLeaf) {
           Node(data.nodeId, data.predict.toPredict, data.impurity, data.isLeaf)
         } else {
-          val leftNode = constructNode(data.leftNodeId.get, dataMap, nodes)
-          val rightNode = constructNode(data.rightNodeId.get, dataMap, nodes)
+          val leftNode = constructNode(data.leftNodeId.get, dataMap, nodes, visiting)
+          val rightNode = constructNode(data.rightNodeId.get, dataMap, nodes, visiting)
           val stats = new InformationGainStats(data.infoGain.get, data.impurity, leftNode.impurity,
             rightNode.impurity, leftNode.predict, rightNode.predict)
           new Node(data.nodeId, data.predict.toPredict, data.impurity, data.isLeaf,
             data.split.map(_.toSplit), Some(leftNode), Some(rightNode), Some(stats))
         }
+      visiting -= id
       nodes += node.id -> node
       node
     }

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
@@ -17,13 +17,50 @@
 
 package org.apache.spark.mllib.clustering
 
+import org.apache.hadoop.fs.{FileUtil, Path => HadoopPath}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.util.MLlibTestSparkContext
 import org.apache.spark.mllib.util.TestingUtils._
+import org.apache.spark.sql.functions.{array, col, lit, when}
 import org.apache.spark.util.Utils
 
 class BisectingKMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  test("load rejects a model whose node ids form a cycle") {
+    val srcDir = Utils.createTempDir()
+    val dstDir = Utils.createTempDir()
+    try {
+      val src = srcDir.toURI.toString
+      val dst = dstDir.toURI.toString
+      val data = sc.parallelize((1 until 8).map(i => Vectors.dense(i.toDouble)), 2)
+      val model = new BisectingKMeans().run(data)
+      model.save(sc, src)
+      val rootId = model.root.index
+
+      // Copy the metadata verbatim, and write a modified data set where the root node lists
+      // itself as its own child (a cycle). Reading src and writing dst avoids a self-overwrite.
+      val hadoopConf = sc.hadoopConfiguration
+      val srcMeta = new HadoopPath(s"$src/metadata")
+      val dstMeta = new HadoopPath(s"$dst/metadata")
+      FileUtil.copy(
+        srcMeta.getFileSystem(hadoopConf), srcMeta,
+        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
+      spark.read.parquet(s"$src/data")
+        .withColumn("children",
+          when(col("index") === rootId, array(lit(rootId))).otherwise(col("children")))
+        .write.parquet(s"$dst/data")
+
+      val e = intercept[IllegalArgumentException] {
+        BisectingKMeansModel.load(sc, dst)
+      }
+      assert(e.getMessage.contains("Cycle detected"))
+    } finally {
+      Utils.deleteRecursively(srcDir)
+      Utils.deleteRecursively(dstDir)
+    }
+  }
 
   test("default values") {
     val bkm0 = new BisectingKMeans()

--- a/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/clustering/BisectingKMeansSuite.scala
@@ -21,46 +21,12 @@ import org.apache.hadoop.fs.{FileUtil, Path => HadoopPath}
 
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.mllib.linalg.Vectors
-import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.{Loader, MLlibTestSparkContext}
 import org.apache.spark.mllib.util.TestingUtils._
 import org.apache.spark.sql.functions.{array, col, lit, when}
 import org.apache.spark.util.Utils
 
 class BisectingKMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
-
-  test("load rejects a model whose node ids form a cycle") {
-    val srcDir = Utils.createTempDir()
-    val dstDir = Utils.createTempDir()
-    try {
-      val src = srcDir.toURI.toString
-      val dst = dstDir.toURI.toString
-      val data = sc.parallelize((1 until 8).map(i => Vectors.dense(i.toDouble)), 2)
-      val model = new BisectingKMeans().run(data)
-      model.save(sc, src)
-      val rootId = model.root.index
-
-      // Copy the metadata verbatim, and write a modified data set where the root node lists
-      // itself as its own child (a cycle). Reading src and writing dst avoids a self-overwrite.
-      val hadoopConf = sc.hadoopConfiguration
-      val srcMeta = new HadoopPath(s"$src/metadata")
-      val dstMeta = new HadoopPath(s"$dst/metadata")
-      FileUtil.copy(
-        srcMeta.getFileSystem(hadoopConf), srcMeta,
-        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
-      spark.read.parquet(s"$src/data")
-        .withColumn("children",
-          when(col("index") === rootId, array(lit(rootId))).otherwise(col("children")))
-        .write.parquet(s"$dst/data")
-
-      val e = intercept[IllegalArgumentException] {
-        BisectingKMeansModel.load(sc, dst)
-      }
-      assert(e.getMessage.contains("Cycle detected"))
-    } finally {
-      Utils.deleteRecursively(srcDir)
-      Utils.deleteRecursively(dstDir)
-    }
-  }
 
   test("default values") {
     val bkm0 = new BisectingKMeans()
@@ -234,6 +200,40 @@ class BisectingKMeansSuite extends SparkFunSuite with MLlibTestSparkContext {
       assert(model.trainingCost == sameModel.trainingCost)
     } finally {
       Utils.deleteRecursively(tempDir)
+    }
+  }
+
+  test("load rejects a model whose node ids form a cycle") {
+    val srcDir = Utils.createTempDir()
+    val dstDir = Utils.createTempDir()
+    try {
+      val src = srcDir.toURI.toString
+      val dst = dstDir.toURI.toString
+      val data = sc.parallelize((1 until 8).map(i => Vectors.dense(i.toDouble)), 2)
+      val model = new BisectingKMeans().run(data)
+      model.save(sc, src)
+      val rootId = model.root.index
+
+      // Copy the metadata verbatim, and write a modified data set where the root node lists
+      // itself as its own child (a cycle). Reading src and writing dst avoids a self-overwrite.
+      val hadoopConf = sc.hadoopConfiguration
+      val srcMeta = new HadoopPath(Loader.metadataPath(src))
+      val dstMeta = new HadoopPath(Loader.metadataPath(dst))
+      FileUtil.copy(
+        srcMeta.getFileSystem(hadoopConf), srcMeta,
+        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
+      spark.read.parquet(Loader.dataPath(src))
+        .withColumn("children",
+          when(col("index") === rootId, array(lit(rootId))).otherwise(col("children")))
+        .write.parquet(Loader.dataPath(dst))
+
+      val e = intercept[IllegalArgumentException] {
+        BisectingKMeansModel.load(sc, dst)
+      }
+      assert(e.getMessage.contains("is reached more than once"))
+    } finally {
+      Utils.deleteRecursively(srcDir)
+      Utils.deleteRecursively(dstDir)
     }
   }
 }

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.mllib.tree
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.hadoop.fs.{FileUtil, Path => HadoopPath}
+
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.ml.tree.impl.DecisionTreeMetadata
 import org.apache.spark.mllib.linalg.Vectors
@@ -29,11 +31,52 @@ import org.apache.spark.mllib.tree.configuration.Strategy
 import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, Variance}
 import org.apache.spark.mllib.tree.model._
 import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.sql.functions.{col, lit, when}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
 
 class DecisionTreeSuite extends SparkFunSuite with MLlibTestSparkContext {
+
+  test("load rejects a model whose node ids form a cycle") {
+    val srcDir = Utils.createTempDir()
+    val dstDir = Utils.createTempDir()
+    try {
+      val src = srcDir.toURI.toString
+      val dst = dstDir.toURI.toString
+      val arr = Array(
+        LabeledPoint(0.0, Vectors.dense(0.0)),
+        LabeledPoint(1.0, Vectors.dense(1.0)),
+        LabeledPoint(0.0, Vectors.dense(0.0)),
+        LabeledPoint(1.0, Vectors.dense(1.0)))
+      val strategy =
+        new Strategy(algo = Classification, impurity = Gini, maxDepth = 4, numClasses = 2)
+      val model = DecisionTree.train(sc.parallelize(arr.toImmutableArraySeq), strategy)
+      model.save(sc, src)
+
+      // Copy the metadata verbatim, and write a modified data set where the root (nodeId 1)
+      // points its left child at itself (a cycle). Reading src and writing dst avoids a
+      // self-overwrite.
+      val hadoopConf = sc.hadoopConfiguration
+      val srcMeta = new HadoopPath(s"$src/metadata")
+      val dstMeta = new HadoopPath(s"$dst/metadata")
+      FileUtil.copy(
+        srcMeta.getFileSystem(hadoopConf), srcMeta,
+        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
+      spark.read.parquet(s"$src/data")
+        .withColumn("leftNodeId",
+          when(col("nodeId") === 1, lit(1)).otherwise(col("leftNodeId")))
+        .write.parquet(s"$dst/data")
+
+      val e = intercept[IllegalArgumentException] {
+        DecisionTreeModel.load(sc, dst)
+      }
+      assert(e.getMessage.contains("Cycle detected"))
+    } finally {
+      Utils.deleteRecursively(srcDir)
+      Utils.deleteRecursively(dstDir)
+    }
+  }
 
   /////////////////////////////////////////////////////////////////////////////
   // Tests calling train()

--- a/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/mllib/tree/DecisionTreeSuite.scala
@@ -30,53 +30,13 @@ import org.apache.spark.mllib.tree.configuration.FeatureType._
 import org.apache.spark.mllib.tree.configuration.Strategy
 import org.apache.spark.mllib.tree.impurity.{Entropy, Gini, Variance}
 import org.apache.spark.mllib.tree.model._
-import org.apache.spark.mllib.util.MLlibTestSparkContext
+import org.apache.spark.mllib.util.{Loader, MLlibTestSparkContext}
 import org.apache.spark.sql.functions.{col, lit, when}
 import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
 
 class DecisionTreeSuite extends SparkFunSuite with MLlibTestSparkContext {
-
-  test("load rejects a model whose node ids form a cycle") {
-    val srcDir = Utils.createTempDir()
-    val dstDir = Utils.createTempDir()
-    try {
-      val src = srcDir.toURI.toString
-      val dst = dstDir.toURI.toString
-      val arr = Array(
-        LabeledPoint(0.0, Vectors.dense(0.0)),
-        LabeledPoint(1.0, Vectors.dense(1.0)),
-        LabeledPoint(0.0, Vectors.dense(0.0)),
-        LabeledPoint(1.0, Vectors.dense(1.0)))
-      val strategy =
-        new Strategy(algo = Classification, impurity = Gini, maxDepth = 4, numClasses = 2)
-      val model = DecisionTree.train(sc.parallelize(arr.toImmutableArraySeq), strategy)
-      model.save(sc, src)
-
-      // Copy the metadata verbatim, and write a modified data set where the root (nodeId 1)
-      // points its left child at itself (a cycle). Reading src and writing dst avoids a
-      // self-overwrite.
-      val hadoopConf = sc.hadoopConfiguration
-      val srcMeta = new HadoopPath(s"$src/metadata")
-      val dstMeta = new HadoopPath(s"$dst/metadata")
-      FileUtil.copy(
-        srcMeta.getFileSystem(hadoopConf), srcMeta,
-        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
-      spark.read.parquet(s"$src/data")
-        .withColumn("leftNodeId",
-          when(col("nodeId") === 1, lit(1)).otherwise(col("leftNodeId")))
-        .write.parquet(s"$dst/data")
-
-      val e = intercept[IllegalArgumentException] {
-        DecisionTreeModel.load(sc, dst)
-      }
-      assert(e.getMessage.contains("Cycle detected"))
-    } finally {
-      Utils.deleteRecursively(srcDir)
-      Utils.deleteRecursively(dstDir)
-    }
-  }
 
   /////////////////////////////////////////////////////////////////////////////
   // Tests calling train()
@@ -472,6 +432,46 @@ class DecisionTreeSuite extends SparkFunSuite with MLlibTestSparkContext {
       } finally {
         Utils.deleteRecursively(tempDir)
       }
+    }
+  }
+
+  test("load rejects a model whose node ids form a cycle") {
+    val srcDir = Utils.createTempDir()
+    val dstDir = Utils.createTempDir()
+    try {
+      val src = srcDir.toURI.toString
+      val dst = dstDir.toURI.toString
+      val arr = Array(
+        LabeledPoint(0.0, Vectors.dense(0.0)),
+        LabeledPoint(1.0, Vectors.dense(1.0)),
+        LabeledPoint(0.0, Vectors.dense(0.0)),
+        LabeledPoint(1.0, Vectors.dense(1.0)))
+      val strategy =
+        new Strategy(algo = Classification, impurity = Gini, maxDepth = 4, numClasses = 2)
+      val model = DecisionTree.train(sc.parallelize(arr.toImmutableArraySeq), strategy)
+      model.save(sc, src)
+
+      // Copy the metadata verbatim, and write a modified data set where the root (nodeId 1)
+      // points its left child at itself (a cycle). Reading src and writing dst avoids a
+      // self-overwrite.
+      val hadoopConf = sc.hadoopConfiguration
+      val srcMeta = new HadoopPath(Loader.metadataPath(src))
+      val dstMeta = new HadoopPath(Loader.metadataPath(dst))
+      FileUtil.copy(
+        srcMeta.getFileSystem(hadoopConf), srcMeta,
+        dstMeta.getFileSystem(hadoopConf), dstMeta, false, hadoopConf)
+      spark.read.parquet(Loader.dataPath(src))
+        .withColumn("leftNodeId",
+          when(col("nodeId") === 1, lit(1)).otherwise(col("leftNodeId")))
+        .write.parquet(Loader.dataPath(dst))
+
+      val e = intercept[IllegalArgumentException] {
+        DecisionTreeModel.load(sc, dst)
+      }
+      assert(e.getMessage.contains("Cycle detected"))
+    } finally {
+      Utils.deleteRecursively(srcDir)
+      Utils.deleteRecursively(dstDir)
     }
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

When loading a saved `DecisionTreeModel` or `BisectingKMeansModel`, the node graph is rebuilt by
following child node ids recursively. This adds a check so that a set of node rows whose child ids
do not form a tree fails fast with a clear "Cycle detected ..." error instead of recursing until
the driver hits a `StackOverflowError`.

- `DecisionTreeModel.SaveLoadV1_0.constructNode` tracks the node ids currently being constructed
  and throws if it re-enters one (a back edge / cycle). Already-built nodes are served from the
  existing `nodes` map, so legitimately shared leaves are unaffected.
- `BisectingKMeansModel.buildTree` now accumulates every node id it reaches and throws on any
  repeat. A valid bisecting k-means tree reaches each id exactly once, so this rejects both a
  cycle (back edge) and a child shared by more than one parent (cross edge) -- both of which are
  inconsistent node data, matching the fail-fast intent. This replaces the earlier memoization,
  which silently normalized a shared-child DAG instead of rejecting it.

### Why are the changes needed?

`spark.mllib` persistence has no schema-level guarantee that the persisted node rows form a tree:
the rows can come from an older or external writer, a hand-edited/partially-written data file, or
a corrupted copy. When the child ids are inconsistent, the recursive loader either recurses until
the driver throws a `StackOverflowError` or (for the bisecting k-means DAG case) rebuilds shared
subtrees repeatedly. Turning that into a clear `IllegalArgumentException` at load time makes the
failure mode obvious. Valid models -- which have neither cycles nor shared children -- load
exactly as before.

### Does this PR introduce _any_ user-facing change?

No, other than a clearer error when loading a model whose persisted node ids are inconsistent.

### How was this patch tested?

Added tests to `DecisionTreeSuite` and `BisectingKMeansSuite` (next to the existing save/load
tests) that save a real model, then load a copy whose node data has been made self-referential,
and assert loading fails with "Cycle detected". The tests use `Loader.metadataPath` /
`Loader.dataPath` for the on-disk layout.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac (Claude Code, Opus 4.8)

This pull request and its description were written by Isaac.

Co-authored-by: Isaac <no-reply@databricks.com>
