### PR TITLE
[SPARK-59308][ML] Avoid Int overflow when computing the decoded image size

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Interaction.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Interaction.scala
@@ -88,7 +88,11 @@ class Interaction @Since("1.6.0") (@Since("1.6.0") override val uid: String) ext
         val currentEncoder = featureEncoders(featureIndex)
         indices = ArrayBuilder.make[Int]
         values = ArrayBuilder.make[Double]
-        size *= currentEncoder.outputSize
+        // Use an overflow-checked multiplication: declared nominal attribute sizes in
+        // column metadata can multiply past Int.MaxValue, which would otherwise wrap to a bogus
+        // (possibly negative) output-vector size and produce corrupt indices. Legitimate feature
+        // interactions must fit in an Int-indexed vector, so this never rejects valid input.
+        size = Math.multiplyExact(size, currentEncoder.outputSize)
         currentEncoder.foreachNonzeroOutput(row(featureIndex), (i, a) => {
           var j = 0
           while (j < prevIndices.length) {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Interaction.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Interaction.scala
@@ -88,11 +88,7 @@ class Interaction @Since("1.6.0") (@Since("1.6.0") override val uid: String) ext
         val currentEncoder = featureEncoders(featureIndex)
         indices = ArrayBuilder.make[Int]
         values = ArrayBuilder.make[Double]
-        // Use an overflow-checked multiplication: declared nominal attribute sizes in
-        // column metadata can multiply past Int.MaxValue, which would otherwise wrap to a bogus
-        // (possibly negative) output-vector size and produce corrupt indices. Legitimate feature
-        // interactions must fit in an Int-indexed vector, so this never rejects valid input.
-        size = Math.multiplyExact(size, currentEncoder.outputSize)
+        size *= currentEncoder.outputSize
         currentEncoder.foreachNonzeroOutput(row(featureIndex), (i, a) => {
           var j = 0
           while (j < prevIndices.length) {

--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -157,9 +157,12 @@ object ImageSchema {
         (3, ocvTypes("CV_8UC3"))
       }
 
-      val imageSize = height * width * nChannels
+      // Compute in Long so that an image with very large dimensions cannot overflow the Int
+      // multiplication and slip past the size assertion below (which would then allocate a
+      // wrongly-sized or negative array). Legitimate images (< 1e9 bytes) are unaffected.
+      val imageSize = height.toLong * width * nChannels
       assert(imageSize < 1e9, "image is too large")
-      val decoded = Array.ofDim[Byte](imageSize)
+      val decoded = Array.ofDim[Byte](imageSize.toInt)
 
       // Grayscale images in Java require special handling to get the correct intensity
       if (isGray) {

--- a/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/image/ImageSchema.scala
@@ -157,9 +157,8 @@ object ImageSchema {
         (3, ocvTypes("CV_8UC3"))
       }
 
-      // Compute in Long so that an image with very large dimensions cannot overflow the Int
-      // multiplication and slip past the size assertion below (which would then allocate a
-      // wrongly-sized or negative array). Legitimate images (< 1e9 bytes) are unaffected.
+      // Compute in Long so a large image cannot overflow the multiplication and slip past the
+      // size assertion below.
       val imageSize = height.toLong * width * nChannels
       assert(imageSize < 1e9, "image is too large")
       val decoded = Array.ofDim[Byte](imageSize.toInt)


### PR DESCRIPTION

### What changes were proposed in this pull request?

`ImageSchema.decode` computed the decoded byte-array length as `height * width * nChannels` in
`Int`. For a large image this multiplication can overflow to a wrong (possibly negative) value,
slip past the `assert(imageSize < 1e9, ...)` guard, and then drive `Array.ofDim[Byte]` with a
wrong or negative length (`NegativeArraySizeException`). The size is now computed in `Long` so the
assertion sees the true value and rejects an oversized image with the intended message.

### Why are the changes needed?

`BufferedImage` allows a pixel count near `Int.MaxValue`, and with `nChannels` the byte count can
exceed `Int.MaxValue` and wrap negative. Computing in `Long` keeps the existing `< 1e9` guard
effective. Legitimate images (well under 1e9 bytes) are unaffected.

Note: an earlier revision of this PR also guarded the `size *= currentEncoder.outputSize`
multiplication in `Interaction`. That path is not actually reachable -- `Interaction.transform`
first materializes the full attribute cross product on the driver (`getFeatureAttrs` -> column
metadata), whose size is the same product, so the driver runs out of heap long before that
multiplication could overflow. That change was dropped to keep this PR to the reachable fix.

### Does this PR introduce _any_ user-facing change?

No, other than a clear "image is too large" error (instead of a `NegativeArraySizeException`) for
an image whose decoded size would exceed the existing limit.

### How was this patch tested?

Existing `ImageSchema` tests continue to pass; the module compiles. The overflow guard only
changes behavior for an image larger than the existing `1e9`-byte limit, which already failed
(previously with a less clear error).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac (Claude Code, Opus 4.8)

This pull request and its description were written by Isaac.

Co-authored-by: Isaac <no-reply@databricks.com>
