### PR TITLE
[SPARK-59309][ML] Add spark.sql.ml.maxNumFeatures to bound feature counts read from data

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/attribute/AttributeGroup.scala
@@ -20,6 +20,7 @@ package org.apache.spark.ml.attribute
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.ml.linalg.SQLDataTypes
+import org.apache.spark.ml.util.MLMaxNumFeatures
 import org.apache.spark.sql.types.{Metadata, MetadataBuilder, StructField}
 import org.apache.spark.util.ArrayImplicits._
 
@@ -193,8 +194,24 @@ object AttributeGroup {
   /** Creates an attribute group from a [[Metadata]] instance with name. */
   private[attribute] def fromMetadata(metadata: Metadata, name: String): AttributeGroup = {
     import org.apache.spark.ml.attribute.AttributeType._
+
+    // `NUM_ATTRIBUTES` is read from column metadata that may originate from a data
+    // file. A negative or out-of-Int-range value would otherwise silently truncate on `.toInt`
+    // and drive a negative/wrong array allocation (NegativeArraySizeException / corrupt indexing).
+    // Reject such clearly-malformed values; any valid Int count is accepted unchanged.
+    // Additionally, when `spark.sql.ml.maxNumFeatures` is set to a positive value, reject counts
+    // above it: a valid-but-huge count (near Int.MaxValue) still drives an excessive allocation.
+    // The default (-1) disables that cap and preserves the previous behavior.
+    def numAttributes(): Int = {
+      val n = metadata.getLong(NUM_ATTRIBUTES)
+      require(n >= 0 && n <= Int.MaxValue,
+        s"$NUM_ATTRIBUTES must be in [0, ${Int.MaxValue}] but got $n.")
+      MLMaxNumFeatures.check(n, NUM_ATTRIBUTES)
+      n.toInt
+    }
+
     if (metadata.contains(ATTRIBUTES)) {
-      val numAttrs = metadata.getLong(NUM_ATTRIBUTES).toInt
+      val numAttrs = numAttributes()
       val attributes = new Array[Attribute](numAttrs)
       val attrMetadata = metadata.getMetadata(ATTRIBUTES)
       if (attrMetadata.contains(Numeric.name)) {
@@ -227,7 +244,7 @@ object AttributeGroup {
       }
       new AttributeGroup(name, attributes)
     } else if (metadata.contains(NUM_ATTRIBUTES)) {
-      new AttributeGroup(name, metadata.getLong(NUM_ATTRIBUTES).toInt)
+      new AttributeGroup(name, numAttributes())
     } else {
       new AttributeGroup(name)
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/linalg/VectorUDT.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/linalg/VectorUDT.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.linalg
 
+import org.apache.spark.ml.util.MLMaxNumFeatures
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData}
 import org.apache.spark.sql.types._
@@ -59,6 +60,11 @@ private[spark] class VectorUDT extends UserDefinedType[Vector] {
         tpe match {
           case 0 =>
             val size = row.getInt(1)
+            // The declared size becomes the dense length on densification, so a very large
+            // declared size can drive an excessive allocation. `MLMaxNumFeatures.get` is a cached
+            // read of a static conf (no per-row allocation), and the check is a no-op unless the
+            // limit is set. Only the sparse branch pays it; dense vectors are unaffected.
+            MLMaxNumFeatures.check(size, "Sparse vector size")
             val indices = row.getArray(2).toIntArray()
             val values = row.getArray(3).toDoubleArray()
             new SparseVector(size, indices, values)

--- a/mllib/src/main/scala/org/apache/spark/ml/util/MLMaxNumFeatures.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/MLMaxNumFeatures.scala
@@ -32,8 +32,9 @@ import org.apache.spark.sql.internal.StaticSQLConf
  */
 private[spark] object MLMaxNumFeatures {
 
-  @volatile private var cachedEnv: SparkEnv = _
-  @volatile private var cachedValue: Int = -1
+  // A single volatile so the env and its value are always published together: reading a value
+  // paired with a different env is impossible. Initialized to a null env so the first call reads.
+  @volatile private var cached: (SparkEnv, Int) = (null, -1)
 
   /** The configured maximum, or -1 (no limit) when unset or when no `SparkEnv` is active. */
   def get: Int = {
@@ -44,11 +45,14 @@ private[spark] object MLMaxNumFeatures {
       // Reference-compare the active env against the cached one: on an executor there is a single
       // env for the application's lifetime, so this reads the config exactly once and then only
       // does a volatile read plus a reference comparison per call.
-      if (!env.eq(cachedEnv)) {
-        cachedValue = env.conf.get(StaticSQLConf.ML_MAX_NUM_FEATURES)
-        cachedEnv = env
+      val snapshot = cached
+      if (env.eq(snapshot._1)) {
+        snapshot._2
+      } else {
+        val value = env.conf.get(StaticSQLConf.ML_MAX_NUM_FEATURES)
+        cached = (env, value)
+        value
       }
-      cachedValue
     }
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/util/MLMaxNumFeatures.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/MLMaxNumFeatures.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.util
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.sql.internal.StaticSQLConf
+
+/**
+ * Reads `spark.sql.ml.maxNumFeatures` once per [[SparkEnv]] and caches it, so hot paths - notably
+ * the per-row `VectorUDT.deserialize` - can enforce the limit without calling `SQLConf.get` on
+ * every row. `SQLConf.get` allocates a `ReadOnlySQLConf` on RDD-based executor paths, so reading it
+ * per row would add an allocation to a hot path for a limit that is disabled by default.
+ *
+ * The config is a static conf, so its value is immutable for the lifetime of a `SparkContext` and
+ * is therefore safe to cache. The cache is keyed on the active `SparkEnv` so it refreshes if the
+ * context is stopped and a new one is created (for example across tests).
+ */
+private[spark] object MLMaxNumFeatures {
+
+  @volatile private var cachedEnv: SparkEnv = _
+  @volatile private var cachedValue: Int = -1
+
+  /** The configured maximum, or -1 (no limit) when unset or when no `SparkEnv` is active. */
+  def get: Int = {
+    val env = SparkEnv.get
+    if (env == null) {
+      -1
+    } else {
+      // Reference-compare the active env against the cached one: on an executor there is a single
+      // env for the application's lifetime, so this reads the config exactly once and then only
+      // does a volatile read plus a reference comparison per call.
+      if (!env.eq(cachedEnv)) {
+        cachedValue = env.conf.get(StaticSQLConf.ML_MAX_NUM_FEATURES)
+        cachedEnv = env
+      }
+      cachedValue
+    }
+  }
+
+  /**
+   * Throws an [[IllegalArgumentException]] if `count` exceeds the configured maximum. When the
+   * limit is disabled (`-1`, the default) the check is skipped entirely, so there is no behavior
+   * change and no exception message is constructed unless the limit is both set and exceeded.
+   */
+  def check(count: Long, what: String): Unit = {
+    val max = get
+    if (max > 0 && count > max) {
+      throw new IllegalArgumentException(
+        s"$what ($count) exceeds the configured maximum ${StaticSQLConf.ML_MAX_NUM_FEATURES.key} " +
+          s"($max).")
+    }
+  }
+}

--- a/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/linalg/Vectors.scala
@@ -32,6 +32,7 @@ import org.json4s.jackson.JsonMethods.{compact, parse => parseJson, render}
 import org.apache.spark.SparkException
 import org.apache.spark.annotation.{AlphaComponent, Since}
 import org.apache.spark.ml.{linalg => newlinalg}
+import org.apache.spark.ml.util.MLMaxNumFeatures
 import org.apache.spark.mllib.util.NumericParser
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeArrayData}
@@ -312,6 +313,9 @@ class VectorUDT extends UserDefinedType[Vector] {
         tpe match {
           case 0 =>
             val size = row.getInt(1)
+            // See ml.linalg.VectorUDT.deserialize: cached read of a static conf, no-op unless set,
+            // sparse branch only.
+            MLMaxNumFeatures.check(size, "Sparse vector size")
             val indices = row.getArray(2).toIntArray()
             val values = row.getArray(3).toDoubleArray()
             new SparseVector(size, indices, values)

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -25,7 +25,7 @@ import org.apache.spark.annotation.Since
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.LogKeys.OPTIMIZER_CLASS_NAME
 import org.apache.spark.ml.linalg.{MatrixUDT => MLMatrixUDT, VectorUDT => MLVectorUDT}
-import org.apache.spark.ml.util.Instrumentation
+import org.apache.spark.ml.util.{Instrumentation, MLMaxNumFeatures}
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.linalg.BLAS.dot
 import org.apache.spark.mllib.regression.LabeledPoint
@@ -93,9 +93,16 @@ object MLUtils extends Logging {
   }
 
   private[spark] def computeNumFeatures(rdd: RDD[(Double, Array[Int], Array[Double])]): Int = {
-    rdd.map { case (label, indices, values) =>
+    val numFeatures = rdd.map { case (label, indices, values) =>
       indices.lastOption.getOrElse(0)
     }.reduce(math.max) + 1
+    // The feature dimension is inferred from the largest index in a libsvm file, and
+    // then used as the (dense) size of every parsed vector. A file with a very large index can
+    // force an excessive allocation. When `spark.sql.ml.maxNumFeatures` is set to a positive
+    // value, reject files whose inferred dimension exceeds it. The default (-1) preserves the
+    // previous behavior.
+    MLMaxNumFeatures.check(numFeatures, "The number of features inferred from the input")
+    numFeatures
   }
 
   private[spark] def parseLibSVMFile(

--- a/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/mllib/util/MLUtils.scala
@@ -93,16 +93,18 @@ object MLUtils extends Logging {
   }
 
   private[spark] def computeNumFeatures(rdd: RDD[(Double, Array[Int], Array[Double])]): Int = {
-    val numFeatures = rdd.map { case (label, indices, values) =>
+    val maxIndex = rdd.map { case (label, indices, values) =>
       indices.lastOption.getOrElse(0)
-    }.reduce(math.max) + 1
+    }.reduce(math.max)
     // The feature dimension is inferred from the largest index in a libsvm file, and
     // then used as the (dense) size of every parsed vector. A file with a very large index can
-    // force an excessive allocation. When `spark.sql.ml.maxNumFeatures` is set to a positive
-    // value, reject files whose inferred dimension exceeds it. The default (-1) preserves the
-    // previous behavior.
+    // force an excessive allocation. Compute the dimension in `Long` so a maximum index near
+    // `Int.MaxValue` does not overflow before it is checked. When `spark.sql.ml.maxNumFeatures`
+    // is set to a positive value, reject files whose inferred dimension exceeds it. The default
+    // (-1) preserves the previous behavior.
+    val numFeatures = maxIndex.toLong + 1
     MLMaxNumFeatures.check(numFeatures, "The number of features inferred from the input")
-    numFeatures
+    numFeatures.toInt
   }
 
   private[spark] def parseLibSVMFile(

--- a/mllib/src/test/scala/org/apache/spark/ml/attribute/AttributeGroupSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/attribute/AttributeGroupSuite.scala
@@ -18,8 +18,24 @@
 package org.apache.spark.ml.attribute
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.types.MetadataBuilder
 
 class AttributeGroupSuite extends SparkFunSuite {
+
+  test("fromMetadata rejects a negative or out-of-Int-range NUM_ATTRIBUTES") {
+    val negative = new MetadataBuilder().putLong(AttributeKeys.NUM_ATTRIBUTES, -1L).build()
+    intercept[IllegalArgumentException] {
+      AttributeGroup.fromMetadata(negative, "g")
+    }
+    val tooLarge = new MetadataBuilder()
+      .putLong(AttributeKeys.NUM_ATTRIBUTES, Int.MaxValue.toLong + 1L).build()
+    intercept[IllegalArgumentException] {
+      AttributeGroup.fromMetadata(tooLarge, "g")
+    }
+    // A valid count is accepted unchanged.
+    val ok = new MetadataBuilder().putLong(AttributeKeys.NUM_ATTRIBUTES, 3L).build()
+    assert(AttributeGroup.fromMetadata(ok, "g").size === 3)
+  }
 
   test("attribute group") {
     val attrs = Array(

--- a/mllib/src/test/scala/org/apache/spark/ml/attribute/MLMaxNumFeaturesSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/attribute/MLMaxNumFeaturesSuite.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This suite lives in the ml.attribute package so it can exercise the package-private
+// AttributeGroup.fromMetadata; the other checked APIs are private[spark].
+package org.apache.spark.ml.attribute
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.mllib.util.MLUtils
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.types.MetadataBuilder
+
+class MLMaxNumFeaturesSuite extends SparkFunSuite {
+
+  // spark.sql.ml.maxNumFeatures is a static conf, so it must be set when the session is created.
+  private def withCappedSession(cap: Int)(f: SparkSession => Unit): Unit = {
+    SparkSession.clearActiveSession()
+    SparkSession.clearDefaultSession()
+    val spark = SparkSession.builder()
+      .master("local[2]")
+      .appName("MLMaxNumFeaturesSuite")
+      .config(StaticSQLConf.ML_MAX_NUM_FEATURES.key, cap.toString)
+      .getOrCreate()
+    try {
+      // If another suite's SparkContext were reused, the static conf would be ignored; fail fast.
+      assert(spark.conf.get(StaticSQLConf.ML_MAX_NUM_FEATURES.key) === cap.toString)
+      f(spark)
+    } finally {
+      spark.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    }
+  }
+
+  test("spark.sql.ml.maxNumFeatures caps feature counts and vector sizes") {
+    withCappedSession(10) { spark =>
+      val sc = spark.sparkContext
+
+      // libsvm-inferred feature dimension (max index 50 -> 51 > 10)
+      val big = sc.parallelize(Seq((1.0, Array(0, 50), Array(1.0, 1.0))))
+      assert(intercept[IllegalArgumentException](MLUtils.computeNumFeatures(big))
+        .getMessage.contains("maxNumFeatures"))
+
+      // attribute-metadata count
+      val meta = new MetadataBuilder().putLong(AttributeKeys.NUM_ATTRIBUTES, 100L).build()
+      assert(intercept[IllegalArgumentException](AttributeGroup.fromMetadata(meta, "g"))
+        .getMessage.contains("maxNumFeatures"))
+
+      // stored sparse-vector size, both ml.linalg and mllib.linalg
+      val mlUDT = new org.apache.spark.ml.linalg.VectorUDT
+      val mlVec = org.apache.spark.ml.linalg.Vectors.sparse(1000, Array(0), Array(1.0))
+      assert(intercept[IllegalArgumentException](mlUDT.deserialize(mlUDT.serialize(mlVec)))
+        .getMessage.contains("maxNumFeatures"))
+      val oldUDT = new org.apache.spark.mllib.linalg.VectorUDT
+      val oldVec = org.apache.spark.mllib.linalg.Vectors.sparse(1000, Array(0), Array(1.0))
+      assert(intercept[IllegalArgumentException](oldUDT.deserialize(oldUDT.serialize(oldVec)))
+        .getMessage.contains("maxNumFeatures"))
+
+      // Within the cap, everything is accepted unchanged.
+      val small = sc.parallelize(Seq((1.0, Array(0, 3), Array(1.0, 1.0))))
+      assert(MLUtils.computeNumFeatures(small) === 4)
+      val smallVec = org.apache.spark.ml.linalg.Vectors.sparse(5, Array(0), Array(1.0))
+      assert(mlUDT.deserialize(mlUDT.serialize(smallVec)) === smallVec)
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -53,8 +53,10 @@ object StaticSQLConf {
       "allocation. This is a static conf so the value can be read once and cached, keeping the " +
       "per-row vector-deserialization check allocation-free. The default of -1 disables the " +
       "check and preserves the previous behavior; set a positive value to reject larger counts.")
-    .version("4.3.0")
+    .version("4.4.0")
+    .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
     .intConf
+    .checkValue(v => v == -1 || v > 0, "Must be -1 (disabled) or a positive value.")
     .createWithDefault(-1)
 
   val CATALOG_DEFAULT_DATABASE =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -42,6 +42,21 @@ object StaticSQLConf {
     .stringConf
     .createWithDefault(Utils.resolveURI("spark-warehouse").toString)
 
+  val ML_MAX_NUM_FEATURES = buildStaticConf("spark.sql.ml.maxNumFeatures")
+    .internal()
+    .doc("The maximum number of features accepted from ML inputs, where a " +
+      "feature/attribute/vector count is derived from a data file, column metadata, or a " +
+      "stored vector: the number of features inferred from a " +
+      "libsvm file, the number of attributes declared in ML column metadata, and the declared " +
+      "size of a sparse vector deserialized from storage (which becomes the dense length on " +
+      "densification). An input can otherwise declare a very large count and drive an excessive " +
+      "allocation. This is a static conf so the value can be read once and cached, keeping the " +
+      "per-row vector-deserialization check allocation-free. The default of -1 disables the " +
+      "check and preserves the previous behavior; set a positive value to reject larger counts.")
+    .version("4.3.0")
+    .intConf
+    .createWithDefault(-1)
+
   val CATALOG_DEFAULT_DATABASE =
     buildStaticConf(s"spark.sql.catalog.$SESSION_CATALOG_NAME.defaultDatabase")
     .doc("The default database for session catalog.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a new static SQL config `spark.sql.ml.maxNumFeatures` (default `-1`, disabled) that bounds a
feature/attribute/vector count when it is derived from data rather than fixed by the caller:
- `MLUtils.computeNumFeatures`: the feature dimension inferred from a libsvm file,
- `AttributeGroup.fromMetadata`: the number of attributes declared in ML column metadata,
- `VectorUDT.deserialize`: the declared size of a sparse vector read from storage (which becomes
  the dense array length on densification).

The value is read through a small helper (`MLMaxNumFeatures`) that reads it once per `SparkEnv` and
caches it, so the per-row check in `VectorUDT.deserialize` does no per-row config lookup or
allocation. `AttributeGroup.fromMetadata` also now rejects a negative or out-of-`Int`-range
`NUM_ATTRIBUTES` (which would otherwise truncate to a negative/wrong array size).

### Why are the changes needed?

When a feature count is read from a data file or column metadata, a very large value can drive an
excessive driver allocation. This lets operators optionally cap it. The check is off by default, so
there is no behavior change unless it is set.

### Does this PR introduce _any_ user-facing change?

Yes: a new opt-in static conf `spark.sql.ml.maxNumFeatures`, default `-1` (disabled), which
preserves the previous behavior. When set to a positive value, inputs whose inferred/declared
feature count exceeds it are rejected. `AttributeGroup.fromMetadata` also rejects a negative or
out-of-`Int`-range attribute count with a clear error instead of failing later.

### How was this patch tested?

Added `MLMaxNumFeaturesSuite` (a session configured with the cap; asserts libsvm inference,
attribute metadata, and both `VectorUDT`s reject over-cap inputs and accept within-cap ones) and a
case in `AttributeGroupSuite` for the negative / out-of-range attribute count.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

This pull request and its description were written by Isaac.

