### PR TITLE
[SPARK-59311][SQL] Avoid StackOverflowError when parsing the Catalyst type in an Avro schema property

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -21,9 +21,44 @@ import org.apache.avro.SchemaBuilder
 import org.apache.spark.sql.avro.AvroUtils.AvroMatchedField
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{ArrayType, IntegerType, StringType, StructField, StructType}
 
 class AvroSchemaHelperSuite extends SharedSparkSession {
+
+  test("Catalyst type carried in the avro property parses normally") {
+    // An INT Avro field carrying a nested Catalyst type in the spark.sql.catalyst.type property.
+    val deepType = "array<" * 8 + "int" + ">" * 8
+    val avroSchema = SchemaBuilder.builder().intType()
+    avroSchema.addProp("spark.sql.catalyst.type", deepType)
+    assert(SchemaConverters.toSqlType(avroSchema).dataType.isInstanceOf[ArrayType])
+  }
+
+  test("a pathologically nested Catalyst type fails as a schema error, not StackOverflowError") {
+    // A backquoted identifier may itself contain '>', so a character scan of the type string
+    // cannot bound the real nesting -- only parsing it can. Parse on a small-stack thread so the
+    // recursive-descent parser overflows deterministically, and assert the overflow surfaces as
+    // an IncompatibleSchemaException instead of escaping as a StackOverflowError.
+    val depth = 6000
+    val deepType = "struct<`>`:" * depth + "int" + ">" * depth
+    val avroSchema = SchemaBuilder.builder().intType()
+    avroSchema.addProp("spark.sql.catalyst.type", deepType)
+
+    @volatile var thrown: Throwable = null
+    val runnable = new Runnable {
+      override def run(): Unit = {
+        try {
+          SchemaConverters.toSqlType(avroSchema)
+        } catch {
+          case t: Throwable => thrown = t
+        }
+      }
+    }
+    val t = new Thread(null, runnable, "avro-deep-catalyst-type", 256 * 1024)
+    t.start()
+    t.join()
+    assert(thrown.isInstanceOf[IncompatibleSchemaException],
+      s"expected IncompatibleSchemaException but got: $thrown")
+  }
 
   test("ensure schema is a record") {
     val avroSchema = SchemaBuilder.builder().intType()

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -115,8 +115,25 @@ object SchemaConverters extends Logging {
     mapSchema
   }
 
+  // Parses the Catalyst type carried in the `spark.sql.catalyst.type` Avro property with the
+  // recursive-descent Catalyst parser. A pathologically deep type string can exhaust the stack
+  // while parsing; the parser only converts `ParseException`, so such a `StackOverflowError`
+  // would otherwise escape as an unhandled error. Convert it into an `IncompatibleSchemaException`
+  // so it surfaces as a normal schema error. This runs on both the driver (schema inference) and
+  // executors (`AvroDeserializer`).
+  private def parseCatalystType(catalystTypeAttrValue: String): DataType = {
+    try {
+      CatalystSqlParser.parseDataType(catalystTypeAttrValue)
+    } catch {
+      case e: StackOverflowError =>
+        throw new IncompatibleSchemaException(
+          s"Cannot parse the $CATALYST_TYPE_PROP_NAME Avro schema property because it is nested " +
+            "too deeply.", e)
+    }
+  }
+
   private def parseStampedStringType(catalystTypeAttrValue: String): StringType = {
-    CatalystSqlParser.parseDataType(catalystTypeAttrValue) match {
+    parseCatalystType(catalystTypeAttrValue) match {
       case s: StringType => s
       case other =>
         throw new IncompatibleSchemaException(
@@ -138,7 +155,7 @@ object SchemaConverters extends Logging {
           val catalystType = if (catalystTypeAttrValue == null) {
             IntegerType
           } else {
-            CatalystSqlParser.parseDataType(catalystTypeAttrValue)
+            parseCatalystType(catalystTypeAttrValue)
           }
           SchemaType(catalystType, nullable = false)
       }
@@ -173,7 +190,7 @@ object SchemaConverters extends Logging {
           val nanosType = if (catalystTypeAttrValue == null) {
             TimestampLTZNanosType()
           } else {
-            CatalystSqlParser.parseDataType(catalystTypeAttrValue)
+            parseCatalystType(catalystTypeAttrValue)
               .asInstanceOf[TimestampLTZNanosType]
           }
           SchemaType(nanosType, nullable = false)
@@ -182,7 +199,7 @@ object SchemaConverters extends Logging {
           val nanosType = if (catalystTypeAttrValue == null) {
             TimestampNTZNanosType()
           } else {
-            CatalystSqlParser.parseDataType(catalystTypeAttrValue)
+            parseCatalystType(catalystTypeAttrValue)
               .asInstanceOf[TimestampNTZNanosType]
           }
           SchemaType(nanosType, nullable = false)
@@ -193,7 +210,7 @@ object SchemaConverters extends Logging {
           val timeType = if (catalystTypeAttrValue == null) {
             TimeType(TimeType.MICROS_PRECISION)
           } else {
-            CatalystSqlParser.parseDataType(catalystTypeAttrValue).asInstanceOf[TimeType]
+            parseCatalystType(catalystTypeAttrValue).asInstanceOf[TimeType]
           }
           SchemaType(timeType, nullable = false)
         case _ =>
@@ -201,7 +218,7 @@ object SchemaConverters extends Logging {
           val catalystType = if (catalystTypeAttrValue == null) {
             LongType
           } else {
-            CatalystSqlParser.parseDataType(catalystTypeAttrValue)
+            parseCatalystType(catalystTypeAttrValue)
           }
           SchemaType(catalystType, nullable = false)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The Catalyst type carried in the `spark.sql.catalyst.type` Avro schema property is parsed with the
recursive-descent Catalyst parser (`CatalystSqlParser.parseDataType`). A pathologically deep type
string can exhaust the stack while parsing, and `AbstractParser.parse` only converts
`ParseException`, so the resulting `StackOverflowError` escapes as an unhandled error rather than a
normal schema error.

This wraps the single parse call (`SchemaConverters.parseCatalystType`, which all
`spark.sql.catalyst.type` sites now route through) to catch `StackOverflowError` and convert it into
an `IncompatibleSchemaException`, following the existing precedent in
`AbstractSqlParser.withErrorHandling` and `SqlStatementSplitter`. It runs on both the driver (schema
inference) and executors (`AvroDeserializer`).

An earlier revision of this PR added an `spark.sql.avro.catalystTypeParsingMaxDepth` config that
counted `<`/`(` characters before parsing. That approach was both bypassable (a backquoted
identifier may itself contain `>`, so a character scan does not reflect the real nesting) and prone
to false positives (`decimal(p,s)`, `COMMENT` strings), so it has been removed in favor of handling
the actual overflow.

### Why are the changes needed?

So an excessively nested Catalyst type in an Avro schema property surfaces as a normal schema error
instead of an unhandled `StackOverflowError`.

### Does this PR introduce _any_ user-facing change?

No behavior change for valid input. Input that previously crashed the parse with a
`StackOverflowError` now fails with an `IncompatibleSchemaException`. No new configuration.

### How was this patch tested?

`AvroSchemaHelperSuite`: a valid nested type still parses, and a pathologically nested type (using
backquoted identifiers that defeat a character-based depth scan) now fails as an
`IncompatibleSchemaException` instead of escaping as a `StackOverflowError`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.

Co-authored-by: Isaac <no-reply@databricks.com>
