### PR TITLE
[SPARK-59320][UI] Optionally require an expiration claim in JWSFilter

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/JWSFilter.scala
+++ b/core/src/main/scala/org/apache/spark/ui/JWSFilter.scala
@@ -33,6 +33,13 @@ import jakarta.servlet.http.{HttpServletRequest, HttpServletResponse}
  *   - spark.ui.filters=org.apache.spark.ui.JWSFilter
  *   - spark.org.apache.spark.ui.JWSFilter.param.secretKey=BASE64URL-ENCODED-YOUR-PROVIDED-KEY
  * }}}
+ * An optional parameter can require tokens to carry an expiration:
+ * {{{
+ *   - spark.org.apache.spark.ui.JWSFilter.param.requireExpiration=true
+ * }}}
+ * When set to {@code true}, a token without an {@code exp} claim is rejected (the default,
+ * {@code false}, accepts tokens with or without one). Tokens whose {@code exp} is in the past are
+ * always rejected regardless of this parameter.
  * The HTTP request should have {@code Authorization: Bearer <jws>} header.
  * {{{
  *   - <jws> is a string with three fields, '<header>.<payload>.<signature>'.
@@ -46,6 +53,10 @@ private class JWSFilter extends Filter {
 
   private var key: SecretKey = null
 
+  // When true, a token must carry an `exp` (expiration) claim. Default false preserves the
+  // previous behavior of accepting tokens with or without one.
+  private var requireExpiration: Boolean = false
+
   /**
    * Load and validate the configurtions:
    * - IllegalArgumentException will happen if the user didn't provide this argument
@@ -53,6 +64,7 @@ private class JWSFilter extends Filter {
    */
   override def init(config: FilterConfig): Unit = {
     key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(config.getInitParameter("secretKey")));
+    requireExpiration = "true".equalsIgnoreCase(config.getInitParameter("requireExpiration"))
   }
 
   override def doFilter(req: ServletRequest, res: ServletResponse, chain: FilterChain): Unit = {
@@ -67,7 +79,12 @@ private class JWSFilter extends Filter {
           hres.sendError(HttpServletResponse.SC_FORBIDDEN, s"${AUTHORIZATION} header is missing.")
         case s"Bearer $token" =>
           val claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token)
-          chain.doFilter(req, res)
+          if (requireExpiration && claims.getPayload.getExpiration == null) {
+            hres.sendError(HttpServletResponse.SC_FORBIDDEN,
+              s"${AUTHORIZATION} token does not carry a required expiration.")
+          } else {
+            chain.doFilter(req, res)
+          }
         case _ =>
           hres.sendError(HttpServletResponse.SC_FORBIDDEN, s"Malformed ${AUTHORIZATION} header.")
       }

--- a/core/src/test/scala/org/apache/spark/ui/JWSFilterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ui/JWSFilterSuite.scala
@@ -93,6 +93,25 @@ class JWSFilterSuite extends SparkFunSuite {
     verify(chain, times(1)).doFilter(any(), any())
   }
 
+  test("Should reject a token without expiration when requireExpiration is set") {
+    val req = mockRequest()
+    val res = mock(classOf[HttpServletResponse])
+    val chain = mock(classOf[FilterChain])
+
+    val filter = new JWSFilter()
+    val params = new JHashMap[String, String]
+    params.put("secretKey", TEST_KEY)
+    params.put("requireExpiration", "true")
+    filter.init(new DummyFilterConfig(params))
+
+    // TOKEN has an empty payload, so it carries no expiration.
+    when(req.getHeader("Authorization")).thenReturn(s"Bearer $TOKEN")
+    filter.doFilter(req, res, chain)
+    verify(res).sendError(meq(HttpServletResponse.SC_FORBIDDEN),
+      meq("Authorization token does not carry a required expiration."))
+    verify(chain, times(0)).doFilter(any(), any())
+  }
+
   private def mockRequest(params: Map[String, Array[String]] = Map()): HttpServletRequest = {
     val req = mock(classOf[HttpServletRequest])
     when(req.getParameterMap()).thenReturn(params.asJava)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an opt-in init parameter `requireExpiration` (default `false` = unchanged) to `JWSFilter`.
When set to `true`, a token whose payload has no `exp` claim is rejected with `403`.

### Why are the changes needed?

Lets a deployment require that JWS tokens carry an expiration, so a token cannot be presented
indefinitely. Off by default, so there is no behavior change unless enabled.

### Does this PR introduce _any_ user-facing change?

No by default. When the new parameter is enabled, tokens without an `exp` claim are rejected.

### How was this patch tested?

New `JWSFilterSuite` case: a token without an `exp` claim is rejected when the parameter is on.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

This pull request and its description were written by Isaac.

Co-authored-by: Isaac <no-reply@databricks.com>
