### PR TITLE
[SPARK-59322][SQL] Handle deep nesting during XML schema inference

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlInferSchema.scala
@@ -208,6 +208,11 @@ class XmlInferSchema(private val options: XmlOptions, private val caseSensitive:
       case e @ (_: IOException | _: RuntimeException) if options.ignoreCorruptFiles =>
         logWarning("Skipped the rest of the content in the corrupted file", e)
         Some(StructType(Nil))
+      case e: StackOverflowError =>
+        // A record nested too deeply to infer without exhausting the stack is handled as a
+        // malformed record per the parse mode, rather than letting the StackOverflowError escape
+        // and fail the job.
+        handleXmlErrorsByParseMode(parser, options.parseMode, options.columnNameOfCorruptRecord, e)
       case NonFatal(e) =>
         handleXmlErrorsByParseMode(parser, options.parseMode, options.columnNameOfCorruptRecord, e)
     } finally {
@@ -290,6 +295,11 @@ class XmlInferSchema(private val options: XmlOptions, private val caseSensitive:
       case e: FileNotFoundException if !options.ignoreMissingFiles =>
         parser.close()
         throw e
+      case e: StackOverflowError =>
+        // See `infer(String, ...)`: a record too deeply nested to infer is handled as a malformed
+        // record rather than crashing with a StackOverflowError.
+        parser.close()
+        handleXmlErrorsByParseMode(parser, options.parseMode, options.columnNameOfCorruptRecord, e)
       case NonFatal(e) =>
         SparkErrorUtils.getRootCause(e) match {
           case _: XMLStreamException | _: MalformedInputException =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -331,6 +331,47 @@ class XmlSuite
     )
   }
 
+  test("SPARK-59322: deeply nested record does not overflow the stack during inference") {
+    // A record nested far more deeply than the JVM stack can accommodate previously escaped
+    // schema inference as a StackOverflowError. It is now handled per the parse mode.
+    val depth = 60000
+    val deepRecord =
+      "<ROWS><ROW>" + ("<a>" * depth) + "x" + ("</a>" * depth) + "</ROW></ROWS>"
+
+    withTempPath { path =>
+      Files.write(path.toPath, deepRecord.getBytes(StandardCharsets.UTF_8))
+
+      // FAILFAST surfaces a clean, framework error instead of a StackOverflowError.
+      checkError(
+        exception = intercept[SparkException] {
+          spark.read
+            .option("rowTag", "ROW")
+            .option("mode", FailFastMode.name)
+            .xml(path.getAbsolutePath)
+        },
+        condition = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
+        parameters = Map(
+          "badRecord" -> "_corrupt_record",
+          "failFastMode" -> "FAILFAST"))
+
+      // PERMISSIVE (the default) captures it as a corrupt record without crashing.
+      val df = spark.read
+        .option("rowTag", "ROW")
+        .xml(path.getAbsolutePath)
+      assert(df.columns.contains("_corrupt_record"))
+    }
+  }
+
+  test("SPARK-59322: a normally nested record still infers its schema") {
+    val record = "<ROWS><ROW><a><b><c>1</c></b></a></ROW></ROWS>"
+    withTempPath { path =>
+      Files.write(path.toPath, record.getBytes(StandardCharsets.UTF_8))
+      val df = spark.read.option("rowTag", "ROW").xml(path.getAbsolutePath)
+      assert(!df.columns.contains("_corrupt_record"))
+      assert(df.count() === 1)
+    }
+  }
+
   test("DSL test for permissive mode for corrupt records") {
     val carsDf = spark.read
       .option("rowTag", "ROW")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

XML schema inference (`XmlInferSchema`) recurses over document elements through the
mutually recursive `inferObject` / `inferField`, so the recursion depth follows the
nesting of the data being read. A record nested more deeply than the JVM stack can
accommodate previously escaped inference as a `StackOverflowError`. Because a
`StackOverflowError` is a `VirtualMachineError`, the existing `NonFatal` handlers in
`XmlInferSchema` did not catch it, so it propagated and failed the job with a raw stack
overflow.

This PR catches `StackOverflowError` at the two per-record inference entry points and
routes it through the existing `handleXmlErrorsByParseMode`, so such a record is handled
exactly like any other malformed record.

This supersedes the earlier revision of this PR, which added an opt-in `maxNestingDepth`
option on the parser. Parser recursion is bounded by the user-supplied read schema rather
than by the document, so that option did not address the data-driven recursion that
happens during schema inference; that change has been reverted here.

### Why are the changes needed?

So that reading a deeply nested XML document produces a clean, actionable outcome
according to the configured parse mode, instead of crashing schema inference with a
`StackOverflowError`.

### Does this PR introduce _any_ user-facing change?

No for any input that infers today. Only a record nested so deeply that it would
previously have overflowed the stack is affected, and it is now handled like a malformed
record: under `FAILFAST` it raises `MALFORMED_RECORD_IN_PARSING`, under `PERMISSIVE`
(the default) it becomes a corrupt record, and under `DROPMALFORMED` it is dropped.

### How was this patch tested?

New tests in `XmlSuite`:
- A deeply nested record is handled per the parse mode -- a clean
  `MALFORMED_RECORD_IN_PARSING` error under `FAILFAST` and a corrupt record under
  `PERMISSIVE` -- instead of overflowing the stack during inference.
- A normally nested record still infers its schema, confirming no change for typical
  input.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
