### PR TITLE
[SPARK-59318][SQL] Add opt-in restrictions for data source client options, schema URLs, and class loading

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.connector.read.{Batch, Scan, ScanBuilder}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsTruncate, Write, WriteBuilder}
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStreamingUpdateAsAppend}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
@@ -807,10 +808,22 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   }
 
   private def convertToSpecifiedParams(parameters: Map[String, String]): Map[String, String] = {
+    // Optional operator-configured denylist of Kafka client option names (without the "kafka."
+    // prefix). Empty by default, which allows every option and preserves the previous behavior.
+    val disallowed = SQLConf.get.getConf(SQLConf.KAFKA_DISALLOWED_OPTIONS)
+      .map(_.toLowerCase(Locale.ROOT)).toSet
     parameters
       .keySet
       .filter(_.toLowerCase(Locale.ROOT).startsWith("kafka."))
       .map { k => k.drop(6) -> parameters(k) }
+      .map { case (key, value) =>
+        if (disallowed.nonEmpty && disallowed.contains(key.toLowerCase(Locale.ROOT))) {
+          throw new IllegalArgumentException(
+            s"Kafka option 'kafka.$key' is not allowed because it is listed in " +
+              s"${SQLConf.KAFKA_DISALLOWED_OPTIONS.key}.")
+        }
+        key -> value
+      }
       .toMap
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7016,6 +7016,32 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val AVRO_SCHEMA_URL_ALLOWED_SCHEMES =
+    buildConf("spark.sql.avro.schemaUrlAllowedSchemes")
+      .internal()
+      .doc("A comma-separated allowlist of URI schemes permitted for the 'avroSchemaUrl' Avro " +
+        "option. Empty by default, which permits any scheme and preserves the previous behavior; " +
+        "when non-empty, an avroSchemaUrl whose scheme is not listed is rejected before it is " +
+        "opened.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
+  val KAFKA_DISALLOWED_OPTIONS =
+    buildConf("spark.sql.kafka.disallowedOptions")
+      .internal()
+      .doc("A comma-separated list of Kafka client option names (without the 'kafka.' prefix) " +
+        "that are not allowed to be set through Kafka source/sink options. Empty by default, " +
+        "which allows all options and preserves the previous behavior; when non-empty, setting a " +
+        "listed option raises an error.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   val JSON_ENABLE_PARTIAL_RESULTS =
     buildConf("spark.sql.json.enablePartialResults")
       .internal()

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/AvroOptions.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.avro
 
 import java.net.URI
-import java.util.HashMap
+import java.util.{HashMap, Locale}
 
 import org.apache.avro.Schema
 import org.apache.hadoop.conf.Configuration
@@ -76,6 +76,18 @@ private[sql] class AvroOptions(
     parameters.get(AVRO_SCHEMA).map(AvroUtils.parseAvroSchema).orElse({
       val avroUrlSchema = parameters.get(AVRO_SCHEMA_URL).map(url => {
         log.debug("loading avro schema from url: " + url)
+        // Optional operator-configured allowlist of URI schemes for avroSchemaUrl. Empty by
+        // default, which permits any scheme and preserves the previous behavior.
+        val allowedSchemes = SQLConf.get.getConf(SQLConf.AVRO_SCHEMA_URL_ALLOWED_SCHEMES)
+          .map(_.toLowerCase(Locale.ROOT))
+        if (allowedSchemes.nonEmpty) {
+          val scheme = Option(new URI(url).getScheme).map(_.toLowerCase(Locale.ROOT)).getOrElse("")
+          if (!allowedSchemes.contains(scheme)) {
+            throw new IllegalArgumentException(
+              s"The scheme '$scheme' of avroSchemaUrl '$url' is not in the allowlist " +
+                s"${SQLConf.AVRO_SCHEMA_URL_ALLOWED_SCHEMES.key}.")
+          }
+        }
         val fs = FileSystem.get(new URI(url), conf)
         val in = fs.open(new Path(url))
         try {

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -1163,11 +1163,14 @@ private[hive] object HiveClientImpl extends Logging {
     Option(hc.getComment).map(field.withComment).getOrElse(field)
   }
 
+  // Resolve the class without running its static initializer here; initialization happens when
+  // the format is actually instantiated for a scan, which is the only point it is needed.
   private def toInputFormat(name: String) =
-    Utils.classForName[org.apache.hadoop.mapred.InputFormat[_, _]](name)
+    Utils.classForName[org.apache.hadoop.mapred.InputFormat[_, _]](name, initialize = false)
 
   private def toOutputFormat(name: String) =
-    Utils.classForName[org.apache.hadoop.hive.ql.io.HiveOutputFormat[_, _]](name)
+    Utils.classForName[org.apache.hadoop.hive.ql.io.HiveOutputFormat[_, _]](
+      name, initialize = false)
 
   def toHiveTableType(catalogTableType: CatalogTableType): HiveTableType = {
     catalogTableType match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add opt-in controls, all defaulting to the current behavior:
- `spark.sql.kafka.disallowedOptions` (default empty): reject the listed Kafka client option names
  when passed via SQL options.
- `spark.sql.avro.schemaUrlAllowedSchemes` (default empty = unrestricted): restrict the URI schemes
  accepted for `avroSchemaUrl`.
- Hive metastore serde/InputFormat class names are resolved with `initialize = false` (static
  initialization is deferred to instantiation at scan time).

### Why are the changes needed?

Gives operators optional controls over which data-source client options and schema-URL schemes are
accepted and defers metastore class initialization. The option-based controls default to empty
(disabled), so there is no behavior change unless configured.

### Does this PR introduce _any_ user-facing change?

No by default. When the new options are set, the corresponding Kafka options / `avroSchemaUrl`
schemes are rejected.

### How was this patch tested?

`hive/compile` and `sql-kafka-0-10/compile`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

This pull request and its description were written by Isaac.

Co-authored-by: Isaac <no-reply@databricks.com>
