### PR TITLE
[SPARK-59326][SQL][TESTS] Add ASOF JOIN analyzer, operand-type, and rewrite unit tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.SparkThrowable
-import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, EqualTo, Expression, LessThanOrEqual, Literal, Rand}
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, CreateNamedStruct, EqualTo, Expression, GreaterThan, If, LambdaFunction, LessThanOrEqual, Literal, Rand, Subtract, ZipWith}
 import org.apache.spark.sql.catalyst.plans.{GreaterThanOp, GreaterThanOrEqualOp, Inner, JoinType, LeftOuter, LessThanOp, LessThanOrEqualOp, MatchComparisonOperator}
 import org.apache.spark.sql.catalyst.plans.logical.{AsOfJoin, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.internal.SQLConf
@@ -57,6 +57,26 @@ class ResolveAsOfJoinSuite extends AnalysisTest {
   private val leftKeys: LogicalPlan = LocalRelation(lOp, lKey1, lKey2)
   private val rightKeys: LogicalPlan = LocalRelation(rOp, rKey1, rKey2)
 
+  // String operands: not subtractable, so the distance is a signed -1 / 0 / +1 rank.
+  private val lstr = AttributeReference("s", StringType)()
+  private val rstr = AttributeReference("s", StringType, nullable = false)()
+  private val leftStr: LogicalPlan = LocalRelation(lstr)
+  private val rightStr: LogicalPlan = LocalRelation(rstr)
+
+  // Array operands: the distance is computed element-wise via ZipWith.
+  private val larr = AttributeReference("arr", ArrayType(IntegerType))()
+  private val rarr = AttributeReference("arr", ArrayType(IntegerType))()
+  private val leftArr: LogicalPlan = LocalRelation(larr)
+  private val rightArr: LogicalPlan = LocalRelation(rarr)
+
+  // Positional struct operands (different field names): the distance is flattened per field.
+  private val lstruct = AttributeReference(
+    "st", StructType(StructField("f1", IntegerType) :: StructField("f2", IntegerType) :: Nil))()
+  private val rstruct = AttributeReference(
+    "st", StructType(StructField("g1", IntegerType) :: StructField("g2", IntegerType) :: Nil))()
+  private val leftStruct: LogicalPlan = LocalRelation(lstruct)
+  private val rightStruct: LogicalPlan = LocalRelation(rstruct)
+
   /** Build an [[AsOfJoin]] from a `MATCH_CONDITION` whose operands are already resolved. */
   private def asOf(
       leftExpr: Expression = la,
@@ -93,6 +113,65 @@ class ResolveAsOfJoinSuite extends AnalysisTest {
       assert(r.asOfCondition.dataType == BooleanType, s"operator $op")
       assert(r.resolved, s"operator $op")
     }
+  }
+
+  test("materializes a subtractable leaf operand into a Subtract distance") {
+    val ge = ResolveAsOfJoin.apply(asOf(operator = GreaterThanOrEqualOp)).asInstanceOf[AsOfJoin]
+    assert(ge.matchOperator.isEmpty)
+    assert(ge.orderExpression == Subtract(la, rb))
+    // `<` / `<=` flip the operands so the distance stays non-negative on the matching side.
+    val le = ResolveAsOfJoin.apply(asOf(operator = LessThanOrEqualOp)).asInstanceOf[AsOfJoin]
+    assert(le.orderExpression == Subtract(rb, la))
+  }
+
+  test("materializes a non-subtractable String operand into a signed comparison distance") {
+    val resolved = ResolveAsOfJoin.apply(
+      asOf(leftExpr = lstr, rightExpr = rstr, l = leftStr, r = rightStr)).asInstanceOf[AsOfJoin]
+    assert(resolved.matchOperator.isEmpty)
+    // Strings cannot be subtracted, so the distance is a -1 / 0 / +1 rank.
+    val expected = If(
+      EqualTo(lstr, rstr),
+      Literal(0),
+      If(GreaterThan(lstr, rstr), Literal(1), Literal(-1)))
+    assert(resolved.orderExpression == expected)
+  }
+
+  test("flips the signed comparison distance for a less-than match operator") {
+    val resolved = ResolveAsOfJoin.apply(
+      asOf(leftExpr = lstr, operator = LessThanOrEqualOp, rightExpr = rstr,
+        l = leftStr, r = rightStr)).asInstanceOf[AsOfJoin]
+    val expected = If(
+      EqualTo(lstr, rstr),
+      Literal(0),
+      If(GreaterThan(lstr, rstr), Literal(-1), Literal(1)))
+    assert(resolved.orderExpression == expected)
+  }
+
+  test("materializes an array operand into an element-wise ZipWith distance") {
+    val resolved = ResolveAsOfJoin.apply(
+      asOf(leftExpr = larr, rightExpr = rarr, l = leftArr, r = rightArr)).asInstanceOf[AsOfJoin]
+    assert(resolved.matchOperator.isEmpty)
+    val order = resolved.orderExpression
+    assert(order.isInstanceOf[ZipWith], s"expected ZipWith, got ${order.getClass.getSimpleName}")
+    val zip = order.asInstanceOf[ZipWith]
+    assert(zip.left == larr && zip.right == rarr)
+    // Each element pair reuses the subtractable-leaf distance (Subtract) inside the lambda.
+    val body = zip.function.asInstanceOf[LambdaFunction].function
+    assert(body.isInstanceOf[Subtract], s"expected a Subtract element distance, got $body")
+  }
+
+  test("materializes a positional struct operand into a flattened per-field distance") {
+    val resolved = ResolveAsOfJoin.apply(
+      asOf(leftExpr = lstruct, rightExpr = rstruct, l = leftStruct, r = rightStruct))
+      .asInstanceOf[AsOfJoin]
+    assert(resolved.matchOperator.isEmpty)
+    val order = resolved.orderExpression
+    assert(order.isInstanceOf[CreateNamedStruct],
+      s"expected CreateNamedStruct, got ${order.getClass.getSimpleName}")
+    val fields = order.asInstanceOf[CreateNamedStruct].valExprs
+    // One Subtract distance per struct field, kept together in a composite struct.
+    assert(fields.size == 2)
+    assert(fields.forall(_.isInstanceOf[Subtract]), s"expected per-field Subtracts, got $fields")
   }
 
   test("expands USING into an equi-join predicate wrapped in a Project") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.SparkThrowable
-import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, Expression, LessThanOrEqual, Literal, Rand}
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, EqualTo, Expression, LessThanOrEqual, Literal, Rand}
 import org.apache.spark.sql.catalyst.plans.{GreaterThanOp, GreaterThanOrEqualOp, Inner, JoinType, LeftOuter, LessThanOp, LessThanOrEqualOp, MatchComparisonOperator}
 import org.apache.spark.sql.catalyst.plans.logical.{AsOfJoin, LocalRelation, LogicalPlan, Project}
 import org.apache.spark.sql.internal.SQLConf
@@ -46,6 +46,16 @@ class ResolveAsOfJoinSuite extends AnalysisTest {
   private val rmap = AttributeReference("m", MapType(StringType, IntegerType))()
   private val leftMap: LogicalPlan = LocalRelation(lmap)
   private val rightMap: LogicalPlan = LocalRelation(rmap)
+
+  // Two shared key columns on each side (plus a distinct match operand) for multi-column USING.
+  private val lOp = AttributeReference("lop", IntegerType)()
+  private val lKey1 = AttributeReference("k1", IntegerType)()
+  private val lKey2 = AttributeReference("k2", IntegerType)()
+  private val rOp = AttributeReference("rop", IntegerType, nullable = false)()
+  private val rKey1 = AttributeReference("k1", IntegerType, nullable = false)()
+  private val rKey2 = AttributeReference("k2", IntegerType, nullable = false)()
+  private val leftKeys: LogicalPlan = LocalRelation(lOp, lKey1, lKey2)
+  private val rightKeys: LogicalPlan = LocalRelation(rOp, rKey1, rKey2)
 
   /** Build an [[AsOfJoin]] from a `MATCH_CONDITION` whose operands are already resolved. */
   private def asOf(
@@ -94,6 +104,19 @@ class ResolveAsOfJoinSuite extends AnalysisTest {
     assert(join.matchOperator.isEmpty, "the match condition should still be materialized")
     assert(project.getTagValue(Project.hiddenOutputTag).isDefined,
       "USING columns should be tagged as hidden output")
+  }
+
+  test("expands multi-column USING into ANDed equi-join predicates") {
+    val result = ResolveAsOfJoin.apply(
+      asOf(leftExpr = lOp, rightExpr = rOp, usingColumns = Some(Seq("k1", "k2")),
+        l = leftKeys, r = rightKeys))
+    val project = result.asInstanceOf[Project]
+    val join = project.child.asInstanceOf[AsOfJoin]
+    assert(join.usingColumns.isEmpty)
+    // USING (k1, k2) expands to k1 = k1 AND k2 = k2: two equi-predicates.
+    assert(join.condition.get.collect { case e: EqualTo => e }.size == 2,
+      s"expected two equi-predicates, got ${join.condition}")
+    assert(project.getTagValue(Project.hiddenOutputTag).isDefined)
   }
 
   test("keeps an explicit ON condition and does not add a USING projection") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.SparkThrowable
+import org.apache.spark.sql.catalyst.expressions.{Add, AttributeReference, Expression, LessThanOrEqual, Literal, Rand}
+import org.apache.spark.sql.catalyst.plans.{GreaterThanOp, GreaterThanOrEqualOp, Inner, JoinType, LeftOuter, LessThanOp, LessThanOrEqualOp, MatchComparisonOperator}
+import org.apache.spark.sql.catalyst.plans.logical.{AsOfJoin, LocalRelation, LogicalPlan, Project}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
+
+/**
+ * Unit tests for the fixed-point analyzer rule [[ResolveAsOfJoin]], which materializes a SQL
+ * `MATCH_CONDITION` clause into an [[AsOfJoin]]'s executable fields and expands `USING` column
+ * lists into equi-join predicates. Operand resolution itself is done by the generic
+ * `ResolveReferences` rule, so these tests feed already-resolved operands and exercise
+ * `ResolveAsOfJoin` directly, mirroring `ResolveBinBySuite`.
+ */
+class ResolveAsOfJoinSuite extends AnalysisTest {
+
+  // Left is nullable, right is non-nullable, so LEFT OUTER's nullability change is observable.
+  private val lk = AttributeReference("k", IntegerType)()
+  private val la = AttributeReference("a", IntegerType)()
+  private val rk = AttributeReference("k", IntegerType, nullable = false)()
+  private val rb = AttributeReference("b", IntegerType, nullable = false)()
+  private val left: LogicalPlan = LocalRelation(lk, la)
+  private val right: LogicalPlan = LocalRelation(rk, rb)
+
+  // Non-orderable (MAP) operands for the invalid-type case.
+  private val lmap = AttributeReference("m", MapType(StringType, IntegerType))()
+  private val rmap = AttributeReference("m", MapType(StringType, IntegerType))()
+  private val leftMap: LogicalPlan = LocalRelation(lmap)
+  private val rightMap: LogicalPlan = LocalRelation(rmap)
+
+  /** Build an [[AsOfJoin]] from a `MATCH_CONDITION` whose operands are already resolved. */
+  private def asOf(
+      leftExpr: Expression = la,
+      operator: MatchComparisonOperator = GreaterThanOrEqualOp,
+      rightExpr: Expression = rb,
+      condition: Option[Expression] = None,
+      joinType: JoinType = Inner,
+      usingColumns: Option[Seq[String]] = None,
+      l: LogicalPlan = left,
+      r: LogicalPlan = right): AsOfJoin =
+    AsOfJoin.fromMatchCondition(l, r, leftExpr, operator, rightExpr, condition, joinType,
+      usingColumns)
+
+  private def expectError(plan: LogicalPlan, condition: String): Unit = {
+    val ex = intercept[SparkThrowable](ResolveAsOfJoin.apply(plan))
+    assert(ex.getCondition == condition,
+      s"expected condition '$condition' but got '${ex.getCondition}'")
+  }
+
+  test("materializes MATCH_CONDITION into asOfCondition and clears the match fields") {
+    val resolved = ResolveAsOfJoin.apply(asOf()).asInstanceOf[AsOfJoin]
+    assert(resolved.matchLeftOperand.isEmpty)
+    assert(resolved.matchOperator.isEmpty)
+    assert(resolved.matchRightOperand.isEmpty)
+    assert(resolved.asOfCondition.dataType == BooleanType)
+    assert(resolved.asOfCondition.resolved)
+    assert(resolved.resolved)
+  }
+
+  test("materializes each MATCH_CONDITION comparison operator") {
+    Seq(GreaterThanOrEqualOp, GreaterThanOp, LessThanOrEqualOp, LessThanOp).foreach { op =>
+      val r = ResolveAsOfJoin.apply(asOf(operator = op)).asInstanceOf[AsOfJoin]
+      assert(r.matchOperator.isEmpty, s"operator $op should be materialized")
+      assert(r.asOfCondition.dataType == BooleanType, s"operator $op")
+      assert(r.resolved, s"operator $op")
+    }
+  }
+
+  test("expands USING into an equi-join predicate wrapped in a Project") {
+    val result = ResolveAsOfJoin.apply(asOf(usingColumns = Some(Seq("k"))))
+    val project = result.asInstanceOf[Project]
+    val join = project.child.asInstanceOf[AsOfJoin]
+    assert(join.usingColumns.isEmpty, "USING should be consumed")
+    assert(join.condition.isDefined, "USING should expand into an equi-join condition")
+    assert(join.matchOperator.isEmpty, "the match condition should still be materialized")
+    assert(project.getTagValue(Project.hiddenOutputTag).isDefined,
+      "USING columns should be tagged as hidden output")
+  }
+
+  test("keeps an explicit ON condition and does not add a USING projection") {
+    val onCond = LessThanOrEqual(la, rb)
+    val join = ResolveAsOfJoin.apply(asOf(condition = Some(onCond))).asInstanceOf[AsOfJoin]
+    assert(join.condition.contains(onCond))
+    assert(join.usingColumns.isEmpty)
+    assert(join.matchOperator.isEmpty)
+  }
+
+  test("Inner preserves right-side nullability; LEFT OUTER makes the right side nullable") {
+    val inner = ResolveAsOfJoin.apply(asOf(joinType = Inner)).asInstanceOf[AsOfJoin]
+    assert(inner.output.map(_.nullable) == Seq(true, true, false, false))
+    val leftOuter = ResolveAsOfJoin.apply(asOf(joinType = LeftOuter)).asInstanceOf[AsOfJoin]
+    assert(leftOuter.output.map(_.nullable) == Seq(true, true, true, true))
+  }
+
+  test("rejects a MATCH_CONDITION operand referencing both join sides") {
+    expectError(asOf(leftExpr = Add(la, rb)), "ASOF_JOIN_MATCH_CONDITION_TABLE_REFERENCE")
+  }
+
+  test("rejects a non-deterministic MATCH_CONDITION operand") {
+    expectError(asOf(leftExpr = Rand(Literal(1L))),
+      "ASOF_JOIN_MATCH_CONDITION_INVALID_EXPRESSION")
+  }
+
+  test("rejects non-orderable MATCH_CONDITION operand types") {
+    expectError(
+      asOf(leftExpr = lmap, rightExpr = rmap, l = leftMap, r = rightMap),
+      "ASOF_JOIN_MATCH_CONDITION_INVALID_TYPE")
+  }
+
+  test("AsOfJoin survives the full Analyzer and CheckAnalysis") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
+      // Unresolved operands here: the generic ResolveReferences resolves them, then
+      // ResolveAsOfJoin materializes the match condition.
+      val plan = AsOfJoin.fromMatchCondition(
+        left, right, UnresolvedAttribute("a"), GreaterThanOrEqualOp,
+        UnresolvedAttribute("b"), None, Inner)
+      assertAnalysisSuccess(plan)
+    }
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAsOfJoinSuite.scala
@@ -25,11 +25,10 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 /**
- * Unit tests for the fixed-point analyzer rule [[ResolveAsOfJoin]], which materializes a SQL
- * `MATCH_CONDITION` clause into an [[AsOfJoin]]'s executable fields and expands `USING` column
- * lists into equi-join predicates. Operand resolution itself is done by the generic
- * `ResolveReferences` rule, so these tests feed already-resolved operands and exercise
- * `ResolveAsOfJoin` directly, mirroring `ResolveBinBySuite`.
+ * Unit tests for the analyzer rule [[ResolveAsOfJoin]], which materializes a SQL
+ * `MATCH_CONDITION` into an [[AsOfJoin]]'s executable fields and expands `USING` into equi-join
+ * predicates. Operands are resolved by the generic `ResolveReferences`, so these tests feed
+ * already-resolved operands, mirroring `ResolveBinBySuite`.
  */
 class ResolveAsOfJoinSuite extends AnalysisTest {
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
@@ -19,24 +19,31 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
-import org.apache.spark.sql.catalyst.expressions.{CreateStruct, GetStructField, If, OuterReference, ScalarSubquery}
+import org.apache.spark.sql.catalyst.expressions.{CreateStruct, Expression, GetStructField, If, Literal, OuterReference, ScalarSubquery}
 import org.apache.spark.sql.catalyst.expressions.aggregate.MinBy
-import org.apache.spark.sql.catalyst.plans.{AsOfJoinDirection, Inner, LeftOuter, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{AsOfJoin, LocalRelation}
+import org.apache.spark.sql.catalyst.plans.{AsOfJoinDirection, Inner, JoinType, LeftOuter, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{AsOfJoin, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.internal.SQLConf
 
 class RewriteAsOfJoinSuite extends PlanTest {
 
-  test("simple") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
-      tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
+  private val left = LocalRelation($"a".int, $"b".int, $"c".int)
+  private val right = LocalRelation($"a".int, $"b".int, $"d".int)
 
-    val rewritten = RewriteAsOfJoin(query.analyze)
-
-    val filter = OuterReference(left.output(0)) >= right.output(0)
+  // Builds the plan RewriteAsOfJoin is expected to produce. For each left row it runs a
+  // correlated scalar subquery that picks the nearest matching right row via
+  // MIN_BY(struct(right.*), orderExpression) over the right rows satisfying `filter`, then
+  // projects the right columns back out. INNER drops left rows with no match through
+  // `__right__ IS NOT NULL`; LEFT OUTER keeps them, so it omits that Filter.
+  //
+  // `filter` and `orderExpression` are the only parts that vary with
+  // (direction, tolerance, allowExactMatches): they mirror AsOfJoin.makeAsOfCond and
+  // makeOrderingExpr, so each test spells just those out and shares the rest of the shape here.
+  private def expectedRewrite(
+      filter: Expression,
+      orderExpression: Expression,
+      joinType: JoinType): LogicalPlan = {
     val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
     val nearestRight = MinBy(rightStruct, orderExpression)
       .toAggregateExpression().as("__nearest_right__")
 
@@ -44,363 +51,289 @@ class RewriteAsOfJoinSuite extends PlanTest {
       left.output :+ ScalarSubquery(
         right.where(filter).groupBy()(nearestRight),
         left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val withNullFilter = joinType match {
+      case LeftOuter => scalarSubquery
+      case _ => scalarSubquery.where(scalarSubquery.output.last.isNotNull)
+    }
+    withNullFilter.select(left.output ++ right.output.zipWithIndex.map {
+      case (attr, idx) => GetStructField(scalarSubquery.output.last, idx).as(attr.name)
+    }: _*)
+  }
+
+  test("simple") {
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) >= right.output(0),
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("condition") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0),
       Some(left.output(1) === right.output(1)), Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(1)) === right.output(1) &&
-      OuterReference(left.output(0)) >= right.output(0)
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    // The join condition is AND-ed in front of the as-of condition.
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(1)) === right.output(1) &&
+        OuterReference(left.output(0)) >= right.output(0),
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("left outer") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
-    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, LeftOuter,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) >= right.output(0)
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    // LEFT OUTER keeps left rows with no match, so the rewrite omits the `IS NOT NULL` filter
+    // that INNER applies. The condition and ordering are the same as the `simple` case.
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) >= right.output(0),
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = LeftOuter)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) >= right.output(0) &&
-      right.output(0) >= OuterReference(left.output(0)) - 1
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) >= right.output(0) &&
+        right.output(0) >= OuterReference(left.output(0)) - 1,
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("allowExactMatches = false") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, LeftOuter,
       tolerance = None, allowExactMatches = false, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) > right.output(0)
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) > right.output(0),
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = LeftOuter)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance & allowExactMatches = false") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("backward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) > right.output(0) &&
-      right.output(0) > OuterReference(left.output(0)) - 1
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = OuterReference(left.output(0)) - right.output(0)
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) > right.output(0) &&
+        right.output(0) > OuterReference(left.output(0)) - 1,
+      orderExpression = OuterReference(left.output(0)) - right.output(0),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("direction = forward") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("forward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) <= right.output(0)
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = right.output(0) - OuterReference(left.output(0))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    // Forward flips the comparison (`<=`) and the ordering distance (right - left).
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) <= right.output(0),
+      orderExpression = right.output(0) - OuterReference(left.output(0)),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("direction = forward & allowExactMatches = false") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = None, allowExactMatches = false, direction = AsOfJoinDirection("forward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) < right.output(0)
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = right.output(0) - OuterReference(left.output(0))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) < right.output(0),
+      orderExpression = right.output(0) - OuterReference(left.output(0)),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance & direction = forward") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("forward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) <= right.output(0) &&
-      right.output(0) <= OuterReference(left.output(0)) + 1
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = right.output(0) - OuterReference(left.output(0))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) <= right.output(0) &&
+        right.output(0) <= OuterReference(left.output(0)) + 1,
+      orderExpression = right.output(0) - OuterReference(left.output(0)),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance & allowExactMatches = false & direction = forward") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("forward"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = OuterReference(left.output(0)) < right.output(0) &&
-      right.output(0) < OuterReference(left.output(0)) + 1
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = right.output(0) - OuterReference(left.output(0))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = OuterReference(left.output(0)) < right.output(0) &&
+        right.output(0) < OuterReference(left.output(0)) + 1,
+      orderExpression = right.output(0) - OuterReference(left.output(0)),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("direction = nearest") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("nearest"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = true
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
-      OuterReference(left.output(0)) - right.output(0),
-      right.output(0) - OuterReference(left.output(0)))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
+    // nearest + allowExactMatches with no tolerance places no constraint on the match, so the
+    // as-of condition collapses to the literal true. The ordering picks the smallest absolute
+    // distance in either direction.
+    val correctAnswer = expectedRewrite(
+      filter = Literal.TrueLiteral,
+      orderExpression = If(OuterReference(left.output(0)) > right.output(0),
+        OuterReference(left.output(0)) - right.output(0),
+        right.output(0) - OuterReference(left.output(0))),
+      joinType = Inner)
 
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
+  test("allowExactMatches = false & direction = nearest") {
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = None, allowExactMatches = false, direction = AsOfJoinDirection("nearest"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    // nearest without tolerance and without exact matches: the only constraint is that the
+    // right key differs from the left key (AsOfJoin.makeAsOfCond `case (false, Nearest)`).
+    val correctAnswer = expectedRewrite(
+      filter = !(OuterReference(left.output(0)) === right.output(0)),
+      orderExpression = If(OuterReference(left.output(0)) > right.output(0),
+        OuterReference(left.output(0)) - right.output(0),
+        right.output(0) - OuterReference(left.output(0))),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance & allowExactMatches = false & direction = nearest") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("nearest"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = (!(OuterReference(left.output(0)) === right.output(0))) &&
-      ((right.output(0) > OuterReference(left.output(0)) - 1) &&
-        (right.output(0) < OuterReference(left.output(0)) + 1))
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
-      OuterReference(left.output(0)) - right.output(0),
-      right.output(0) - OuterReference(left.output(0)))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    val correctAnswer = expectedRewrite(
+      filter = (!(OuterReference(left.output(0)) === right.output(0))) &&
+        ((right.output(0) > OuterReference(left.output(0)) - 1) &&
+          (right.output(0) < OuterReference(left.output(0)) + 1)),
+      orderExpression = If(OuterReference(left.output(0)) > right.output(0),
+        OuterReference(left.output(0)) - right.output(0),
+        right.output(0) - OuterReference(left.output(0))),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
   test("tolerance & direction = nearest") {
-    val left = LocalRelation($"a".int, $"b".int, $"c".int)
-    val right = LocalRelation($"a".int, $"b".int, $"d".int)
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("nearest"))
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    val filter = right.output(0) >= OuterReference(left.output(0)) - 1 &&
-      right.output(0) <= OuterReference(left.output(0)) + 1
-    val rightStruct = CreateStruct(right.output)
-    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
-      OuterReference(left.output(0)) - right.output(0),
-      right.output(0) - OuterReference(left.output(0)))
-    val nearestRight = MinBy(rightStruct, orderExpression)
-      .toAggregateExpression().as("__nearest_right__")
-
-    val scalarSubquery = left.select(
-      left.output :+ ScalarSubquery(
-        right.where(filter).groupBy()(nearestRight),
-        left.output).as("__right__"): _*)
-    val correctAnswer = scalarSubquery
-      .where(scalarSubquery.output.last.isNotNull)
-      .select(left.output :+
-        GetStructField(scalarSubquery.output.last, 0).as("a") :+
-        GetStructField(scalarSubquery.output.last, 1).as("b") :+
-        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+    // nearest + allowExactMatches + tolerance intentionally drops the `true` base condition and
+    // keeps only the two-sided tolerance band (AsOfJoin.makeAsOfCond `case (true, Nearest)`).
+    val correctAnswer = expectedRewrite(
+      filter = right.output(0) >= OuterReference(left.output(0)) - 1 &&
+        right.output(0) <= OuterReference(left.output(0)) + 1,
+      orderExpression = If(OuterReference(left.output(0)) > right.output(0),
+        OuterReference(left.output(0)) - right.output(0),
+        right.output(0) - OuterReference(left.output(0))),
+      joinType = Inner)
 
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
+  test("no rewrite when the node requires the sort-merge as-of join operator") {
+    // The rule only fires when `!conf.useSortMergeAsOfJoinOperator(requiresSortMergeAsOfJoin)`.
+    // A node flagged `requiresSortMergeAsOfJoin = true` (e.g. from a SQL `MATCH_CONDITION`
+    // clause) must be left untouched so the sort-merge physical operator handles it instead.
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
+      .copy(requiresSortMergeAsOfJoin = true)
+    val analyzed = query.analyze
+
+    // Precondition: the flag survives analysis, so it is the guard -- not a dropped flag --
+    // that makes this a no-op.
+    assert(analyzed.collectFirst { case a: AsOfJoin => a }.exists(_.requiresSortMergeAsOfJoin),
+      "expected the analyzed plan to still carry requiresSortMergeAsOfJoin = true")
+
+    val rewritten = RewriteAsOfJoin(analyzed)
+
+    comparePlans(rewritten, analyzed)
+  }
+
+  test("no rewrite when the sort-merge as-of join operator is enabled by config") {
+    // The guard is `sortMergeAsOfJoinEnabled || requiresSortMergeAsOfJoin`. This is the other
+    // trigger: with the config on, the sort-merge operator is enabled globally, so even a plain
+    // node (flag off) is left intact for that operator rather than rewritten to a subquery.
+    withSQLConf(SQLConf.SORT_MERGE_AS_OF_JOIN_ENABLED.key -> "true") {
+      val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+        tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
+      val analyzed = query.analyze
+
+      comparePlans(RewriteAsOfJoin(analyzed), analyzed)
+    }
+  }
+
+  test("references above the join are remapped to the rewritten output") {
+    // Every other test roots the query at AsOfJoin, so the attribute remapping that
+    // `transformUpWithNewOutput` returns (the `project -> attrMapping` pair) never has an
+    // ancestor to fix up. Put a Project above the join that selects a right-side column: the
+    // rewrite gives that column a fresh exprId (a GetStructField alias), so the parent
+    // reference must be remapped onto it, otherwise the plan is left with a dangling reference.
+    val join = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
+    val originalRightExprId = join.output.last.exprId
+    val query = join.select(join.output.last).analyze
+
+    val rewritten = RewriteAsOfJoin(query)
+
+    rewritten.foreach { node =>
+      assert(node.missingInput.isEmpty,
+        s"${node.nodeName} has dangling references: ${node.missingInput}")
+    }
+    assert(!rewritten.references.exists(_.exprId == originalRightExprId),
+      "expected the parent projection to be remapped off the original AsOfJoin output")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
@@ -30,15 +30,10 @@ class RewriteAsOfJoinSuite extends PlanTest {
   private val left = LocalRelation($"a".int, $"b".int, $"c".int)
   private val right = LocalRelation($"a".int, $"b".int, $"d".int)
 
-  // Builds the plan RewriteAsOfJoin is expected to produce. For each left row it runs a
-  // correlated scalar subquery that picks the nearest matching right row via
-  // MIN_BY(struct(right.*), orderExpression) over the right rows satisfying `filter`, then
-  // projects the right columns back out. INNER drops left rows with no match through
-  // `__right__ IS NOT NULL`; LEFT OUTER keeps them, so it omits that Filter.
-  //
-  // `filter` and `orderExpression` are the only parts that vary with
-  // (direction, tolerance, allowExactMatches): they mirror AsOfJoin.makeAsOfCond and
-  // makeOrderingExpr, so each test spells just those out and shares the rest of the shape here.
+  // Builds the plan RewriteAsOfJoin should produce: per left row, a correlated scalar subquery
+  // picks the nearest matching right row via MIN_BY(struct(right.*), orderExpression), then
+  // projects the right columns back out. INNER drops non-matches via `__right__ IS NOT NULL`;
+  // LEFT OUTER keeps them. Only `filter` and `orderExpression` vary per test.
   private def expectedRewrite(
       filter: Expression,
       orderExpression: Expression,
@@ -97,8 +92,7 @@ class RewriteAsOfJoinSuite extends PlanTest {
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    // LEFT OUTER keeps left rows with no match, so the rewrite omits the `IS NOT NULL` filter
-    // that INNER applies. The condition and ordering are the same as the `simple` case.
+    // LEFT OUTER keeps non-matching left rows, so the `IS NOT NULL` filter is omitted.
     val correctAnswer = expectedRewrite(
       filter = OuterReference(left.output(0)) >= right.output(0),
       orderExpression = OuterReference(left.output(0)) - right.output(0),
@@ -216,9 +210,8 @@ class RewriteAsOfJoinSuite extends PlanTest {
 
     val rewritten = RewriteAsOfJoin(query.analyze)
 
-    // nearest + allowExactMatches with no tolerance places no constraint on the match, so the
-    // as-of condition collapses to the literal true. The ordering picks the smallest absolute
-    // distance in either direction.
+    // nearest + allowExactMatches + no tolerance: no match constraint, so the condition is
+    // `true`. The ordering picks the smallest absolute distance in either direction.
     val correctAnswer = expectedRewrite(
       filter = Literal.TrueLiteral,
       orderExpression = If(OuterReference(left.output(0)) > right.output(0),
@@ -285,16 +278,14 @@ class RewriteAsOfJoinSuite extends PlanTest {
   }
 
   test("no rewrite when the node requires the sort-merge as-of join operator") {
-    // The rule only fires when `!conf.useSortMergeAsOfJoinOperator(requiresSortMergeAsOfJoin)`.
-    // A node flagged `requiresSortMergeAsOfJoin = true` (e.g. from a SQL `MATCH_CONDITION`
-    // clause) must be left untouched so the sort-merge physical operator handles it instead.
+    // A node flagged `requiresSortMergeAsOfJoin = true` (e.g. from a SQL MATCH_CONDITION) is
+    // left untouched so the sort-merge physical operator handles it instead.
     val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
       .copy(requiresSortMergeAsOfJoin = true)
     val analyzed = query.analyze
 
-    // Precondition: the flag survives analysis, so it is the guard -- not a dropped flag --
-    // that makes this a no-op.
+    // The flag must survive analysis, so it, not a dropped flag, is what makes this a no-op.
     assert(analyzed.collectFirst { case a: AsOfJoin => a }.exists(_.requiresSortMergeAsOfJoin),
       "expected the analyzed plan to still carry requiresSortMergeAsOfJoin = true")
 
@@ -304,9 +295,8 @@ class RewriteAsOfJoinSuite extends PlanTest {
   }
 
   test("no rewrite when the sort-merge as-of join operator is enabled by config") {
-    // The guard is `sortMergeAsOfJoinEnabled || requiresSortMergeAsOfJoin`. This is the other
-    // trigger: with the config on, the sort-merge operator is enabled globally, so even a plain
-    // node (flag off) is left intact for that operator rather than rewritten to a subquery.
+    // With the config on, the sort-merge operator is enabled globally, so even a plain node
+    // (flag off) is left intact rather than rewritten to a subquery.
     withSQLConf(SQLConf.SORT_MERGE_AS_OF_JOIN_ENABLED.key -> "true") {
       val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
         tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
@@ -317,11 +307,9 @@ class RewriteAsOfJoinSuite extends PlanTest {
   }
 
   test("references above the join are remapped to the rewritten output") {
-    // Every other test roots the query at AsOfJoin, so the attribute remapping that
-    // `transformUpWithNewOutput` returns (the `project -> attrMapping` pair) never has an
-    // ancestor to fix up. Put a Project above the join that selects a right-side column: the
-    // rewrite gives that column a fresh exprId (a GetStructField alias), so the parent
-    // reference must be remapped onto it, otherwise the plan is left with a dangling reference.
+    // A Project above the join selects a right-side column, which the rewrite gives a fresh
+    // exprId (a GetStructField alias). The parent reference must be remapped onto it, or the
+    // plan is left with a dangling reference. Other tests root at AsOfJoin and never hit this.
     val join = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
       tolerance = None, allowExactMatches = true, direction = AsOfJoinDirection("backward"))
     val originalRightExprId = join.output.last.exprId

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteAsOfJoinSuite.scala
@@ -225,6 +225,92 @@ class RewriteAsOfJoinSuite extends PlanTest {
     comparePlans(rewritten, correctAnswer, checkAnalysis = false)
   }
 
+  test("direction = forward & allowExactMatches = false") {
+    val left = LocalRelation($"a".int, $"b".int, $"c".int)
+    val right = LocalRelation($"a".int, $"b".int, $"d".int)
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = None, allowExactMatches = false, direction = AsOfJoinDirection("forward"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    val filter = OuterReference(left.output(0)) < right.output(0)
+    val rightStruct = CreateStruct(right.output)
+    val orderExpression = right.output(0) - OuterReference(left.output(0))
+    val nearestRight = MinBy(rightStruct, orderExpression)
+      .toAggregateExpression().as("__nearest_right__")
+
+    val scalarSubquery = left.select(
+      left.output :+ ScalarSubquery(
+        right.where(filter).groupBy()(nearestRight),
+        left.output).as("__right__"): _*)
+    val correctAnswer = scalarSubquery
+      .where(scalarSubquery.output.last.isNotNull)
+      .select(left.output :+
+        GetStructField(scalarSubquery.output.last, 0).as("a") :+
+        GetStructField(scalarSubquery.output.last, 1).as("b") :+
+        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+
+    comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
+  test("tolerance & direction = forward") {
+    val left = LocalRelation($"a".int, $"b".int, $"c".int)
+    val right = LocalRelation($"a".int, $"b".int, $"d".int)
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("forward"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    val filter = OuterReference(left.output(0)) <= right.output(0) &&
+      right.output(0) <= OuterReference(left.output(0)) + 1
+    val rightStruct = CreateStruct(right.output)
+    val orderExpression = right.output(0) - OuterReference(left.output(0))
+    val nearestRight = MinBy(rightStruct, orderExpression)
+      .toAggregateExpression().as("__nearest_right__")
+
+    val scalarSubquery = left.select(
+      left.output :+ ScalarSubquery(
+        right.where(filter).groupBy()(nearestRight),
+        left.output).as("__right__"): _*)
+    val correctAnswer = scalarSubquery
+      .where(scalarSubquery.output.last.isNotNull)
+      .select(left.output :+
+        GetStructField(scalarSubquery.output.last, 0).as("a") :+
+        GetStructField(scalarSubquery.output.last, 1).as("b") :+
+        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+
+    comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
+  test("tolerance & allowExactMatches = false & direction = forward") {
+    val left = LocalRelation($"a".int, $"b".int, $"c".int)
+    val right = LocalRelation($"a".int, $"b".int, $"d".int)
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = Some(1), allowExactMatches = false, direction = AsOfJoinDirection("forward"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    val filter = OuterReference(left.output(0)) < right.output(0) &&
+      right.output(0) < OuterReference(left.output(0)) + 1
+    val rightStruct = CreateStruct(right.output)
+    val orderExpression = right.output(0) - OuterReference(left.output(0))
+    val nearestRight = MinBy(rightStruct, orderExpression)
+      .toAggregateExpression().as("__nearest_right__")
+
+    val scalarSubquery = left.select(
+      left.output :+ ScalarSubquery(
+        right.where(filter).groupBy()(nearestRight),
+        left.output).as("__right__"): _*)
+    val correctAnswer = scalarSubquery
+      .where(scalarSubquery.output.last.isNotNull)
+      .select(left.output :+
+        GetStructField(scalarSubquery.output.last, 0).as("a") :+
+        GetStructField(scalarSubquery.output.last, 1).as("b") :+
+        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+
+    comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
   test("direction = nearest") {
     val left = LocalRelation($"a".int, $"b".int, $"c".int)
     val right = LocalRelation($"a".int, $"b".int, $"d".int)
@@ -266,6 +352,37 @@ class RewriteAsOfJoinSuite extends PlanTest {
     val filter = (!(OuterReference(left.output(0)) === right.output(0))) &&
       ((right.output(0) > OuterReference(left.output(0)) - 1) &&
         (right.output(0) < OuterReference(left.output(0)) + 1))
+    val rightStruct = CreateStruct(right.output)
+    val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
+      OuterReference(left.output(0)) - right.output(0),
+      right.output(0) - OuterReference(left.output(0)))
+    val nearestRight = MinBy(rightStruct, orderExpression)
+      .toAggregateExpression().as("__nearest_right__")
+
+    val scalarSubquery = left.select(
+      left.output :+ ScalarSubquery(
+        right.where(filter).groupBy()(nearestRight),
+        left.output).as("__right__"): _*)
+    val correctAnswer = scalarSubquery
+      .where(scalarSubquery.output.last.isNotNull)
+      .select(left.output :+
+        GetStructField(scalarSubquery.output.last, 0).as("a") :+
+        GetStructField(scalarSubquery.output.last, 1).as("b") :+
+        GetStructField(scalarSubquery.output.last, 2).as("d"): _*)
+
+    comparePlans(rewritten, correctAnswer, checkAnalysis = false)
+  }
+
+  test("tolerance & direction = nearest") {
+    val left = LocalRelation($"a".int, $"b".int, $"c".int)
+    val right = LocalRelation($"a".int, $"b".int, $"d".int)
+    val query = AsOfJoin(left, right, left.output(0), right.output(0), None, Inner,
+      tolerance = Some(1), allowExactMatches = true, direction = AsOfJoinDirection("nearest"))
+
+    val rewritten = RewriteAsOfJoin(query.analyze)
+
+    val filter = right.output(0) >= OuterReference(left.output(0)) - 1 &&
+      right.output(0) <= OuterReference(left.output(0)) + 1
     val rightStruct = CreateStruct(right.output)
     val orderExpression = If(OuterReference(left.output(0)) > right.output(0),
       OuterReference(left.output(0)) - right.output(0),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
@@ -166,11 +166,10 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
   }
 
   test("array operands with empty struct elements are invalid") {
-    // An array whose element type contains an empty struct is not a valid operand, even though
-    // the array itself is orderable (exercises the ArrayType arm of containsEmptyStructType).
+    // An array whose element contains an empty struct is invalid even though the array itself
+    // is orderable (the ArrayType arm of containsEmptyStructType).
     val arrayOfEmptyStruct = ArrayType(StructType(Nil))
-    // Pin that the array itself is orderable, so the rejection is attributable to the empty
-    // struct rather than to non-orderability.
+    // Pin orderability so the rejection is due to the empty struct, not non-orderability.
     assert(RowOrdering.isOrderable(arrayOfEmptyStruct))
     assert(!MatchConditionTypes.isValidOperandType(arrayOfEmptyStruct))
     assert(!MatchConditionTypes.areOperandsCompatible(arrayOfEmptyStruct, arrayOfEmptyStruct))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
@@ -35,6 +35,15 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
     assert(!MatchConditionTypes.areOperandsCompatible(DateType, StringType))
   }
 
+  test("orderable scalars with no common type are incompatible") {
+    // Both are individually valid, orderable operands ...
+    assert(MatchConditionTypes.isValidOperandType(TimestampType))
+    assert(MatchConditionTypes.isValidOperandType(BooleanType))
+    // ... but TIMESTAMP and BOOLEAN have no common wider type and are not a
+    // string/temporal pair, so they are not comparable.
+    assert(!MatchConditionTypes.areOperandsCompatible(TimestampType, BooleanType))
+  }
+
   test("positional struct operands with different field names are compatible") {
     val leftStruct = StructType(
       StructField("a", IntegerType) ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
@@ -117,4 +117,41 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
     assert(!MatchConditionTypes.usesStructDecomposition(leftStruct, rightStruct))
     assert(!MatchConditionTypes.areOperandsCompatible(leftStruct, rightStruct))
   }
+
+  test("map operands are invalid (not orderable)") {
+    val mapType = MapType(StringType, IntegerType)
+    assert(!MatchConditionTypes.isValidOperandType(mapType))
+    assert(!MatchConditionTypes.areOperandsCompatible(mapType, mapType))
+  }
+
+  test("array operands with non-orderable elements are invalid") {
+    val arrayOfMap = ArrayType(MapType(StringType, IntegerType))
+    assert(!MatchConditionTypes.isValidOperandType(arrayOfMap))
+    assert(!MatchConditionTypes.areOperandsCompatible(arrayOfMap, arrayOfMap))
+    assert(!MatchConditionTypes.usesArrayOrderExpression(arrayOfMap, arrayOfMap))
+  }
+
+  test("struct operands with a non-orderable field are invalid") {
+    val structWithMap = StructType(
+      StructField("a", IntegerType) ::
+        StructField("m", MapType(StringType, IntegerType)) ::
+        Nil)
+    assert(!MatchConditionTypes.isValidOperandType(structWithMap))
+    assert(!MatchConditionTypes.areOperandsCompatible(structWithMap, structWithMap))
+  }
+
+  test("positional struct operands with incompatible field types are rejected") {
+    val leftStruct = StructType(
+      StructField("a", IntegerType) ::
+        StructField("b", TimestampType) ::
+        Nil)
+    val rightStruct = StructType(
+      StructField("x", IntegerType) ::
+        StructField("y", BooleanType) ::
+        Nil)
+    // Same field count, so the operands are structurally decomposable ...
+    assert(MatchConditionTypes.usesStructDecomposition(leftStruct, rightStruct))
+    // ... but the second field pair (TIMESTAMP vs BOOLEAN) is not comparable.
+    assert(!MatchConditionTypes.areOperandsCompatible(leftStruct, rightStruct))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
@@ -154,4 +154,31 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
     // ... but the second field pair (TIMESTAMP vs BOOLEAN) is not comparable.
     assert(!MatchConditionTypes.areOperandsCompatible(leftStruct, rightStruct))
   }
+
+  test("array operands with empty struct elements are invalid") {
+    // An array whose element type contains an empty struct is not a valid operand, even though
+    // the array itself is orderable (exercises the ArrayType arm of containsEmptyStructType).
+    val arrayOfEmptyStruct = ArrayType(StructType(Nil))
+    assert(!MatchConditionTypes.isValidOperandType(arrayOfEmptyStruct))
+    assert(!MatchConditionTypes.areOperandsCompatible(arrayOfEmptyStruct, arrayOfEmptyStruct))
+  }
+
+  test("array operands with structurally incompatible struct elements are rejected") {
+    val leftArray = ArrayType(
+      StructType(
+        StructField("a", IntegerType) ::
+          StructField("b", TimestampType) ::
+          Nil))
+    val rightArray = ArrayType(
+      StructType(
+        StructField("x", IntegerType) ::
+          StructField("y", BooleanType) ::
+          Nil))
+    // Each operand is individually a valid, orderable type ...
+    assert(MatchConditionTypes.isValidOperandType(leftArray))
+    assert(MatchConditionTypes.isValidOperandType(rightArray))
+    // ... but the element structs' second field pair (TIMESTAMP vs BOOLEAN) is not comparable.
+    assert(!MatchConditionTypes.areOperandsCompatible(leftArray, rightArray))
+    assert(!MatchConditionTypes.usesArrayOrderExpression(leftArray, rightArray))
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/plans/logical/AsOfJoinMatchConditionTypesSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.expressions.RowOrdering
 import org.apache.spark.sql.catalyst.plans.logical.AsOfJoin.MatchConditionTypes
 import org.apache.spark.sql.types._
 
@@ -159,11 +160,14 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
     // An array whose element type contains an empty struct is not a valid operand, even though
     // the array itself is orderable (exercises the ArrayType arm of containsEmptyStructType).
     val arrayOfEmptyStruct = ArrayType(StructType(Nil))
+    // Pin that the array itself is orderable, so the rejection is attributable to the empty
+    // struct rather than to non-orderability.
+    assert(RowOrdering.isOrderable(arrayOfEmptyStruct))
     assert(!MatchConditionTypes.isValidOperandType(arrayOfEmptyStruct))
     assert(!MatchConditionTypes.areOperandsCompatible(arrayOfEmptyStruct, arrayOfEmptyStruct))
   }
 
-  test("array operands with structurally incompatible struct elements are rejected") {
+  test("array operands with incompatible struct element field types are rejected") {
     val leftArray = ArrayType(
       StructType(
         StructField("a", IntegerType) ::
@@ -179,6 +183,5 @@ class AsOfJoinMatchConditionTypesSuite extends SparkFunSuite {
     assert(MatchConditionTypes.isValidOperandType(rightArray))
     // ... but the element structs' second field pair (TIMESTAMP vs BOOLEAN) is not comparable.
     assert(!MatchConditionTypes.areOperandsCompatible(leftArray, rightArray))
-    assert(!MatchConditionTypes.usesArrayOrderExpression(leftArray, rightArray))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Test-only change; no production code is modified. Adds unit tests for SQL ASOF JOIN in three suites:
- ResolveAsOfJoinSuite (new) — direct tests for the analyzer rule ResolveAsOfJoin, which had no suite of its own. Covers materializing a MATCH_CONDITION into the AsOfJoin fields for all four operators; the distance (orderExpression) shape per operand type; USING expansion (single and multi-column); ON preservation; output nullability; the three match-condition error classes; and surviving the full analyzer.
- AsOfJoinMatchConditionTypesSuite — adds operand-type cases for MatchConditionTypes: non-orderable types, empty structs, incompatible field-type pairs, and scalars with no common wider type.
- RewriteAsOfJoinSuite — adds forward/nearest combined with tolerance and allowExactMatches (previously only backward), the two sort-merge "no rewrite" gating cases, and parent-reference remapping. A shared expectedRewrite(...) helper removes duplicated expected-plan construction.

This folds in the RewriteAsOfJoinSuite work originally proposed as SPARK-59409 (#58701).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These behaviors were only covered indirectly (SQL/golden/DataFrame suites) or not at all.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Ran the three suites via Maven; all pass — ResolveAsOfJoinSuite (18), AsOfJoinMatchConditionTypesSuite (18), RewriteAsOfJoinSuite (18).

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.8)