### PR TITLE
[SPARK-59286][ML] Revert "Optimize NaiveBayesModel transform closures"

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/NaiveBayes.scala
@@ -435,76 +435,138 @@ class NaiveBayesModel private[ml] (
     this
   }
 
+  /**
+   * Bernoulli scoring requires log(condprob) if 1, log(1-condprob) if 0.
+   * This precomputes log(1.0 - exp(theta)) and its sum which are used for the linear algebra
+   * application of this condition (in predict function).
+   */
+  @transient private lazy val thetaMinusNegTheta = $(modelType) match {
+    case Bernoulli =>
+      theta.map(value => value - math.log1p(-math.exp(value)))
+    case _ =>
+      // This should never happen.
+      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
+        "Variables thetaMinusNegTheta should only be precomputed in Bernoulli NB.")
+  }
+
+  @transient private lazy val piMinusThetaSum = $(modelType) match {
+    case Bernoulli =>
+      val negTheta = theta.map(value => math.log1p(-math.exp(value)))
+      val ones = new DenseVector(Array.fill(theta.numCols)(1.0))
+      val piMinusThetaSum = pi.toDense.copy
+      BLAS.gemv(1.0, negTheta, ones, 1.0, piMinusThetaSum)
+      piMinusThetaSum
+    case _ =>
+      // This should never happen.
+      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
+        "Variables piMinusThetaSum should only be precomputed in Bernoulli NB.")
+  }
+
+  /**
+   * Gaussian scoring requires sum of log(Variance).
+   * This precomputes sum of log(Variance) which are used for the linear algebra
+   * application of this condition (in predict function).
+   */
+  @transient private lazy val logVarSum = $(modelType) match {
+    case Gaussian =>
+      Array.tabulate(numClasses) { i =>
+        Iterator.range(0, numFeatures).map { j =>
+          math.log(sigma(i, j))
+        }.sum
+      }
+    case _ =>
+      // This should never happen.
+      throw new IllegalArgumentException(s"Invalid modelType: ${$(modelType)}. " +
+        "Variables logVarSum should only be precomputed in Gaussian NB.")
+  }
+
   @Since("1.6.0")
   override val numFeatures: Int = theta.numCols
 
   @Since("1.5.0")
   override val numClasses: Int = pi.size
 
-  override protected def predictRawColumn(features: Column): Column = {
-    val localPredictRaw =
-      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
-    udf((features: Vector) => localPredictRaw(features)).apply(features)
+  private def multinomialCalculation(features: Vector) = {
+    requireNonnegativeValues(features)
+    val prob = pi.toDense.copy
+    BLAS.gemv(1.0, theta, features, 1.0, prob)
+    prob
   }
 
-  override protected def raw2probabilityColumn(rawPrediction: Column): Column = {
-    udf((rawPrediction: Vector) =>
-      NaiveBayesModel.raw2probability(rawPrediction)
-    ).apply(rawPrediction)
-  }
-
-  override protected def predictProbabilityColumn(features: Column): Column = {
-    val localPredictRaw =
-      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
-    udf((features: Vector) => {
-      val rawPrediction = localPredictRaw(features)
-      NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
-    }).apply(features)
-  }
-
-  override protected def raw2predictionColumn(rawPrediction: Column): Column = {
-    if (isDefined(thresholds)) {
-      val localThresholds = getThresholds.clone()
-      udf((rawPrediction: Vector) => {
-        val probability = NaiveBayesModel.raw2probability(rawPrediction)
-        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
-      }).apply(rawPrediction)
-    } else {
-      udf((rawPrediction: Vector) => rawPrediction.argmax.toDouble).apply(rawPrediction)
+  private def complementCalculation(features: Vector) = {
+    requireNonnegativeValues(features)
+    val probArray = theta.multiply(features).toArray
+    // the following lines equal to:
+    // val logSumExp = math.log(probArray.map(math.exp).sum)
+    // However, it easily returns Infinity/NaN values.
+    // Here follows 'scipy.special.logsumexp' (which is used in Scikit-Learn's ComplementNB)
+    // to compute the log of the sum of exponentials of elements in a numeric-stable way.
+    val max = probArray.max
+    var sumExp = 0.0
+    var j = 0
+    while (j < probArray.length) {
+      sumExp += math.exp(probArray(j) - max)
+      j += 1
     }
+    val logSumExp = math.log(sumExp) + max
+
+    j = 0
+    while (j < probArray.length) {
+      probArray(j) -= logSumExp
+      j += 1
+    }
+    Vectors.dense(probArray)
   }
 
-  override protected def predictionColumn(features: Column): Column = {
-    val localPredictRaw =
-      NaiveBayesModel.predictRawFunction($(modelType), pi, theta, sigma)
-    if (isDefined(thresholds)) {
-      val localThresholds = getThresholds.clone()
-      udf((features: Vector) => {
-        val rawPrediction = localPredictRaw(features)
-        val probability = NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
-        ProbabilisticClassificationModel.probability2prediction(probability, localThresholds)
-      }).apply(features)
-    } else {
-      udf((features: Vector) => localPredictRaw(features).argmax.toDouble).apply(features)
+  private def bernoulliCalculation(features: Vector) = {
+    requireZeroOneBernoulliValues(features)
+    val prob = piMinusThetaSum.copy
+    BLAS.gemv(1.0, thetaMinusNegTheta, features, 1.0, prob)
+    prob
+  }
+
+  private def gaussianCalculation(features: Vector) = {
+    val prob = Array.ofDim[Double](numClasses)
+    var i = 0
+    while (i < numClasses) {
+      var s = 0.0
+      var j = 0
+      while (j < numFeatures) {
+        val d = features(j) - theta(i, j)
+        s += d * d / sigma(i, j)
+        j += 1
+      }
+      prob(i) = pi(i) - (s + logVarSum(i)) / 2
+      i += 1
+    }
+    Vectors.dense(prob)
+  }
+
+  @transient private lazy val predictRawFunc = {
+    $(modelType) match {
+      case Multinomial =>
+        features: Vector => multinomialCalculation(features)
+      case Complement =>
+        features: Vector => complementCalculation(features)
+      case Bernoulli =>
+        features: Vector => bernoulliCalculation(features)
+      case Gaussian =>
+        features: Vector => gaussianCalculation(features)
     }
   }
 
   @Since("3.0.0")
-  override def predictRaw(features: Vector): Vector = {
-    $(modelType) match {
-      case Multinomial =>
-        NaiveBayesModel.multinomialCalculation(features, pi, theta)
-      case Complement =>
-        NaiveBayesModel.complementCalculation(features, theta)
-      case Bernoulli =>
-        NaiveBayesModel.bernoulliCalculation(features, pi, theta)
-      case Gaussian =>
-        NaiveBayesModel.gaussianCalculation(features, pi, theta, sigma)
-    }
-  }
+  override def predictRaw(features: Vector): Vector = predictRawFunc(features)
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    NaiveBayesModel.raw2probabilityInPlace(rawPrediction)
+    rawPrediction match {
+      case dv: DenseVector =>
+        Utils.softmax(dv.values)
+        dv
+      case sv: SparseVector =>
+        throw new RuntimeException("Unexpected error in NaiveBayesModel:" +
+          " raw2probabilityInPlace encountered SparseVector")
+    }
   }
 
   private[spark] override def estimatedSize: Long = {
@@ -538,182 +600,6 @@ class NaiveBayesModel private[ml] (
 
 @Since("1.6.0")
 object NaiveBayesModel extends MLReadable[NaiveBayesModel] {
-  import NaiveBayes._
-
-  private def predictRawFunction(
-      modelType: String,
-      pi: Vector,
-      theta: Matrix,
-      sigma: Matrix): Vector => Vector = {
-    modelType match {
-      case Multinomial =>
-        features: Vector => multinomialCalculation(features, pi, theta)
-      case Complement =>
-        features: Vector => complementCalculation(features, theta)
-      case Bernoulli =>
-        val (piMinusThetaSum, thetaMinusNegTheta) = bernoulliPredictionState(pi, theta)
-        features: Vector =>
-          bernoulliCalculationWithPrecomputedState(
-            features, piMinusThetaSum, thetaMinusNegTheta)
-      case Gaussian =>
-        val logVarSum = gaussianLogVarSum(sigma)
-        features: Vector =>
-          gaussianCalculationWithPrecomputedState(features, pi, theta, sigma, logVarSum)
-    }
-  }
-
-  private def multinomialCalculation(
-      features: Vector,
-      pi: Vector,
-      theta: Matrix): Vector = {
-    requireNonnegativeValues(features)
-    val prob = pi.toDense.copy
-    BLAS.gemv(1.0, theta, features, 1.0, prob)
-    prob
-  }
-
-  private def complementCalculation(features: Vector, theta: Matrix): Vector = {
-    requireNonnegativeValues(features)
-    val probArray = theta.multiply(features).toArray
-    // the following lines equal to:
-    // val logSumExp = math.log(probArray.map(math.exp).sum)
-    // However, it easily returns Infinity/NaN values.
-    // Here follows 'scipy.special.logsumexp' (which is used in Scikit-Learn's ComplementNB)
-    // to compute the log of the sum of exponentials of elements in a numeric-stable way.
-    val max = probArray.max
-    var sumExp = 0.0
-    var j = 0
-    while (j < probArray.length) {
-      sumExp += math.exp(probArray(j) - max)
-      j += 1
-    }
-    val logSumExp = math.log(sumExp) + max
-
-    j = 0
-    while (j < probArray.length) {
-      probArray(j) -= logSumExp
-      j += 1
-    }
-    Vectors.dense(probArray)
-  }
-
-  private def bernoulliPredictionState(
-      pi: Vector,
-      theta: Matrix): (DenseVector, Matrix) = {
-    val negTheta = theta.map(value => math.log1p(-math.exp(value)))
-    val thetaMinusNegTheta = theta.map(value => value - math.log1p(-math.exp(value)))
-    val ones = new DenseVector(Array.fill(theta.numCols)(1.0))
-    val piMinusThetaSum = pi.toDense.copy
-    BLAS.gemv(1.0, negTheta, ones, 1.0, piMinusThetaSum)
-    (piMinusThetaSum, thetaMinusNegTheta)
-  }
-
-  private def bernoulliCalculationWithPrecomputedState(
-      features: Vector,
-      piMinusThetaSum: DenseVector,
-      thetaMinusNegTheta: Matrix): Vector = {
-    requireZeroOneBernoulliValues(features)
-    val prob = piMinusThetaSum.copy
-    BLAS.gemv(1.0, thetaMinusNegTheta, features, 1.0, prob)
-    prob
-  }
-
-  private def bernoulliCalculation(
-      features: Vector,
-      pi: Vector,
-      theta: Matrix): Vector = {
-    requireZeroOneBernoulliValues(features)
-    val prob = Array.ofDim[Double](pi.size)
-    var i = 0
-    while (i < pi.size) {
-      var score = pi(i)
-      var j = 0
-      while (j < theta.numCols) {
-        val thetaValue = theta(i, j)
-        score += (if (features(j) == 1.0) {
-          thetaValue
-        } else {
-          math.log1p(-math.exp(thetaValue))
-        })
-        j += 1
-      }
-      prob(i) = score
-      i += 1
-    }
-    Vectors.dense(prob)
-  }
-
-  private def gaussianLogVarSum(sigma: Matrix): Array[Double] = {
-    Array.tabulate(sigma.numRows) { i =>
-      var sum = 0.0
-      var j = 0
-      while (j < sigma.numCols) {
-        sum += math.log(sigma(i, j))
-        j += 1
-      }
-      sum
-    }
-  }
-
-  private def gaussianCalculationWithPrecomputedState(
-      features: Vector,
-      pi: Vector,
-      theta: Matrix,
-      sigma: Matrix,
-      logVarSum: Array[Double]): Vector = {
-    val prob = Array.ofDim[Double](pi.size)
-    var i = 0
-    while (i < pi.size) {
-      var s = 0.0
-      var j = 0
-      while (j < theta.numCols) {
-        val d = features(j) - theta(i, j)
-        s += d * d / sigma(i, j)
-        j += 1
-      }
-      prob(i) = pi(i) - (s + logVarSum(i)) / 2
-      i += 1
-    }
-    Vectors.dense(prob)
-  }
-
-  private def gaussianCalculation(
-      features: Vector,
-      pi: Vector,
-      theta: Matrix,
-      sigma: Matrix): Vector = {
-    val prob = Array.ofDim[Double](pi.size)
-    var i = 0
-    while (i < pi.size) {
-      var s = 0.0
-      var j = 0
-      while (j < theta.numCols) {
-        val d = features(j) - theta(i, j)
-        val variance = sigma(i, j)
-        s += d * d / variance + math.log(variance)
-        j += 1
-      }
-      prob(i) = pi(i) - s / 2
-      i += 1
-    }
-    Vectors.dense(prob)
-  }
-
-  private def raw2probability(rawPrediction: Vector): Vector = {
-    raw2probabilityInPlace(rawPrediction.copy)
-  }
-
-  private def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
-    rawPrediction match {
-      case dv: DenseVector =>
-        Utils.softmax(dv.values)
-        dv
-      case _: SparseVector =>
-        throw new RuntimeException("Unexpected error in NaiveBayesModel:" +
-          " raw2probabilityInPlace encountered SparseVector")
-    }
-  }
-
   private[ml] case class Data(pi: Vector, theta: Matrix, sigma: Matrix)
 
   private[ml] def serializeData(data: Data, dos: DataOutputStream): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Revert #58557, which optimized the `NaiveBayesModel` transform closures.

### Why are the changes needed?

The optimization introduced by #58557 needs to be rolled back, restoring the previous
implementation.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not run. This patch is an exact Git revert of commit
`dbe046229ceaebc37fe1d98cf03b757148b5c2b2`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
