### PR TITLE
[SPARK-59328][SQL] Add an option to reject specified Kafka options in the Kafka data source

### DIFF
--- a/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
+++ b/connector/kafka-0-10-sql/src/main/resources/error/kafka-error-conditions.json
@@ -1,4 +1,9 @@
 {
+  "KAFKA_DISALLOWED_OPTION" : {
+    "message" : [
+      "The Kafka option 'kafka.<option>' is not allowed because it is listed in <config>."
+    ]
+  },
   "MISMATCHED_TOPIC_PARTITIONS_BETWEEN_END_OFFSET_AND_PREFETCHED" : {
     "message" : [
       "Kafka data source in Trigger.AvailableNow should provide the same topic partitions in pre-fetched offset to end offset for each microbatch. The error could be transient - restart your query, and report if you still see the same issue.",

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -263,6 +263,14 @@ object KafkaExceptions {
         "topic" -> topicPartition.topic,
         "partition" -> topicPartition.partition.toString))
   }
+
+  def disallowedOption(option: String, config: String): KafkaIllegalArgumentException = {
+    new KafkaIllegalArgumentException(
+      errorClass = "KAFKA_DISALLOWED_OPTION",
+      messageParameters = Map(
+        "option" -> option,
+        "config" -> config))
+  }
 }
 
 /**

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.connector.read.{Batch, Scan, ScanBuilder}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsTruncate, Write, WriteBuilder}
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStreamingUpdateAsAppend}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
@@ -807,10 +808,19 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   }
 
   private def convertToSpecifiedParams(parameters: Map[String, String]): Map[String, String] = {
-    parameters
+    // Optional operator-configured denylist of Kafka client option names (without the "kafka."
+    // prefix). Empty by default, which allows every option and preserves the previous behavior.
+    val disallowed = SQLConf.get.getConf(SQLConf.KAFKA_DISALLOWED_OPTIONS)
+      .map(_.toLowerCase(Locale.ROOT)).toSet
+    val stripped = parameters
       .keySet
       .filter(_.toLowerCase(Locale.ROOT).startsWith("kafka."))
       .map { k => k.drop(6) -> parameters(k) }
-      .toMap
+    stripped.foreach { case (key, _) =>
+      if (disallowed.contains(key.toLowerCase(Locale.ROOT))) {
+        throw KafkaExceptions.disallowedOption(key, SQLConf.KAFKA_DISALLOWED_OPTIONS.key)
+      }
+    }
+    stripped.toMap
   }
 }

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaSourceProvider.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connector.read.{Batch, Scan, ScanBuilder}
 import org.apache.spark.sql.connector.read.streaming.{ContinuousStream, MicroBatchStream}
 import org.apache.spark.sql.connector.write.{LogicalWriteInfo, SupportsTruncate, Write, WriteBuilder}
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.internal.connector.{SimpleTableProvider, SupportsStreamingUpdateAsAppend}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
@@ -810,7 +810,7 @@ private[kafka010] object KafkaSourceProvider extends Logging {
   private def convertToSpecifiedParams(parameters: Map[String, String]): Map[String, String] = {
     // Optional operator-configured denylist of Kafka client option names (without the "kafka."
     // prefix). Empty by default, which allows every option and preserves the previous behavior.
-    val disallowed = SQLConf.get.getConf(SQLConf.KAFKA_DISALLOWED_OPTIONS)
+    val disallowed = SQLConf.get.getConf(StaticSQLConf.KAFKA_DISALLOWED_OPTIONS)
       .map(_.toLowerCase(Locale.ROOT)).toSet
     val stripped = parameters
       .keySet
@@ -818,7 +818,7 @@ private[kafka010] object KafkaSourceProvider extends Logging {
       .map { k => k.drop(6) -> parameters(k) }
     stripped.foreach { case (key, _) =>
       if (disallowed.contains(key.toLowerCase(Locale.ROOT))) {
-        throw KafkaExceptions.disallowedOption(key, SQLConf.KAFKA_DISALLOWED_OPTIONS.key)
+        throw KafkaExceptions.disallowedOption(key, StaticSQLConf.KAFKA_DISALLOWED_OPTIONS.key)
       }
     }
     stripped.toMap

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -24,7 +24,9 @@ import scala.jdk.CollectionConverters._
 import org.mockito.Mockito.{mock, when}
 
 import org.apache.spark.{SparkConf, SparkEnv, SparkFunSuite}
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.Scan
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class KafkaSourceProviderSuite extends SparkFunSuite {
@@ -152,6 +154,47 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
       intercept[IllegalArgumentException] {
         getKafkaDataSourceScan(options).toMicroBatchStream("dummy")
       }
+    }
+  }
+
+  test("SPARK-59328: disallowed Kafka options are rejected on the source path") {
+    // KafkaBatch reads its default poll timeout from SparkEnv, so provide a mock one.
+    val sparkEnv = mock(classOf[SparkEnv])
+    when(sparkEnv.conf).thenReturn(new SparkConf())
+    SparkEnv.set(sparkEnv)
+
+    val options = buildKafkaSourceCaseInsensitiveStringMap("kafka.max.poll.records" -> "1")
+    // Empty denylist (the default) preserves the previous behavior: the option is accepted.
+    getKafkaDataSourceScan(options).toBatch()
+    // When the option name is denylisted, building the batch scan is rejected.
+    val conf = new SQLConf()
+    conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
+    SQLConf.withExistingConf(conf) {
+      val e = intercept[IllegalArgumentException] {
+        getKafkaDataSourceScan(options).toBatch()
+      }
+      assert(e.getMessage.contains("kafka.max.poll.records"))
+    }
+  }
+
+  test("SPARK-59328: disallowed Kafka options are rejected on the sink path") {
+    val sparkEnv = mock(classOf[SparkEnv])
+    when(sparkEnv.conf).thenReturn(new SparkConf())
+    SparkEnv.set(sparkEnv)
+
+    val params = CaseInsensitiveMap(Map(
+      "kafka.bootstrap.servers" -> "dummy",
+      "kafka.max.poll.records" -> "1"))
+    // Empty denylist (the default) preserves the previous behavior: the option is accepted.
+    KafkaSourceProvider.kafkaParamsForProducer(params)
+    // When the option name is denylisted, building the producer params is rejected.
+    val conf = new SQLConf()
+    conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
+    SQLConf.withExistingConf(conf) {
+      val e = intercept[IllegalArgumentException] {
+        KafkaSourceProvider.kafkaParamsForProducer(params)
+      }
+      assert(e.getMessage.contains("kafka.max.poll.records"))
     }
   }
 }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -170,18 +170,18 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
     val conf = new SQLConf()
     conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
     SQLConf.withExistingConf(conf) {
-      val e = intercept[IllegalArgumentException] {
-        getKafkaDataSourceScan(options).toBatch()
-      }
-      assert(e.getMessage.contains("kafka.max.poll.records"))
+      checkError(
+        exception = intercept[KafkaIllegalArgumentException] {
+          getKafkaDataSourceScan(options).toBatch()
+        },
+        condition = "KAFKA_DISALLOWED_OPTION",
+        parameters = Map(
+          "option" -> "max.poll.records",
+          "config" -> "spark.sql.kafka.disallowedOptions"))
     }
   }
 
   test("SPARK-59328: disallowed Kafka options are rejected on the sink path") {
-    val sparkEnv = mock(classOf[SparkEnv])
-    when(sparkEnv.conf).thenReturn(new SparkConf())
-    SparkEnv.set(sparkEnv)
-
     val params = CaseInsensitiveMap(Map(
       "kafka.bootstrap.servers" -> "dummy",
       "kafka.max.poll.records" -> "1"))
@@ -191,10 +191,14 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
     val conf = new SQLConf()
     conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
     SQLConf.withExistingConf(conf) {
-      val e = intercept[IllegalArgumentException] {
-        KafkaSourceProvider.kafkaParamsForProducer(params)
-      }
-      assert(e.getMessage.contains("kafka.max.poll.records"))
+      checkError(
+        exception = intercept[KafkaIllegalArgumentException] {
+          KafkaSourceProvider.kafkaParamsForProducer(params)
+        },
+        condition = "KAFKA_DISALLOWED_OPTION",
+        parameters = Map(
+          "option" -> "max.poll.records",
+          "config" -> "spark.sql.kafka.disallowedOptions"))
     }
   }
 }

--- a/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
+++ b/connector/kafka-0-10-sql/src/test/scala/org/apache/spark/sql/kafka010/KafkaSourceProviderSuite.scala
@@ -23,10 +23,10 @@ import scala.jdk.CollectionConverters._
 
 import org.mockito.Mockito.{mock, when}
 
-import org.apache.spark.{SparkConf, SparkEnv, SparkFunSuite}
+import org.apache.spark.{SparkConf, SparkEnv, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.connector.read.Scan
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class KafkaSourceProviderSuite extends SparkFunSuite {
@@ -168,7 +168,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
     getKafkaDataSourceScan(options).toBatch()
     // When the option name is denylisted, building the batch scan is rejected.
     val conf = new SQLConf()
-    conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
+    conf.setConf(StaticSQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
     SQLConf.withExistingConf(conf) {
       checkError(
         exception = intercept[KafkaIllegalArgumentException] {
@@ -189,7 +189,7 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
     KafkaSourceProvider.kafkaParamsForProducer(params)
     // When the option name is denylisted, building the producer params is rejected.
     val conf = new SQLConf()
-    conf.setConf(SQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
+    conf.setConf(StaticSQLConf.KAFKA_DISALLOWED_OPTIONS, Seq("max.poll.records"))
     SQLConf.withExistingConf(conf) {
       checkError(
         exception = intercept[KafkaIllegalArgumentException] {
@@ -200,5 +200,23 @@ class KafkaSourceProviderSuite extends SparkFunSuite {
           "option" -> "max.poll.records",
           "config" -> "spark.sql.kafka.disallowedOptions"))
     }
+  }
+
+  test("SPARK-59328: the disallowed-options denylist is an operator boundary") {
+    // Static, so an application cannot SET it away at runtime.
+    assert(!new SQLConf().isModifiable(StaticSQLConf.KAFKA_DISALLOWED_OPTIONS.key))
+    // Entries carrying the "kafka." prefix are rejected, so the denylist cannot silently fail
+    // open (a "kafka." prefixed name would never match the stripped option names it is checked
+    // against). setConfString is the path that runs the value converter and its checkValue.
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        new SQLConf().setConfString(
+          StaticSQLConf.KAFKA_DISALLOWED_OPTIONS.key, "kafka.max.poll.records")
+      },
+      condition = "INVALID_CONF_VALUE.REQUIREMENT",
+      parameters = Map(
+        "confName" -> "spark.sql.kafka.disallowedOptions",
+        "confValue" -> "kafka.max.poll.records",
+        "confRequirement" -> "Kafka option names must be listed without the 'kafka.' prefix."))
   }
 }

--- a/docs/streaming/structured-streaming-kafka-integration.md
+++ b/docs/streaming/structured-streaming-kafka-integration.md
@@ -1049,7 +1049,9 @@ DataFrame operations to explicitly serialize the values into either strings or b
 
 In addition, an operator can reject further Kafka params by listing their names, without the
 `kafka.` prefix, in the `spark.sql.kafka.disallowedOptions` configuration; setting any listed
-param through a Kafka source or sink option will then throw an exception.
+param through a Kafka source or sink option will then throw an exception. This is a static
+configuration. It must be set when the SparkSession is created, for example with
+`--conf spark.sql.kafka.disallowedOptions=...`, and an application cannot change it at runtime.
 
 ## Deploying
 

--- a/docs/streaming/structured-streaming-kafka-integration.md
+++ b/docs/streaming/structured-streaming-kafka-integration.md
@@ -1047,6 +1047,10 @@ DataFrame operations to explicitly serialize the values into either strings or b
 - **interceptor.classes**: Kafka source always read keys and values as byte arrays. It's not safe to
  use ConsumerInterceptor as it may break the query.
 
+In addition, an operator can reject further Kafka params by listing their names, without the
+`kafka.` prefix, in the `spark.sql.kafka.disallowedOptions` configuration; setting any listed
+param through a Kafka source or sink option will then throw an exception.
+
 ## Deploying
 
 As with any Spark applications, `spark-submit` is used to launch your application. `spark-sql-kafka-0-10_{{site.SCALA_BINARY_VERSION}}`

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3914,16 +3914,20 @@ object SQLConf {
       .createWithDefault(false)
 
   val KAFKA_DISALLOWED_OPTIONS =
-    buildConf("spark.sql.kafka.disallowedOptions")
+    buildStaticConf("spark.sql.kafka.disallowedOptions")
       .internal()
       .doc("A comma-separated list of Kafka client option names (without the 'kafka.' prefix) " +
         "that are not allowed to be set through Kafka source/sink options. Empty by default, " +
         "which allows all options and preserves the previous behavior; when non-empty, setting a " +
-        "listed option raises an error.")
+        "listed option raises an error. This is a static configuration fixed when the " +
+        "SparkSession is created and cannot be changed at runtime, so it acts as an operator " +
+        "boundary that a session cannot turn off.")
       .version("4.3.0")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .stringConf
       .toSequence
+      .checkValue(_.forall(!_.toLowerCase(Locale.ROOT).startsWith("kafka.")),
+        "Kafka option names must be listed without the 'kafka.' prefix.")
       .createWithDefault(Nil)
 
   val STATEFUL_OPERATOR_CHECK_CORRECTNESS_ENABLED =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3913,23 +3913,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val KAFKA_DISALLOWED_OPTIONS =
-    buildStaticConf("spark.sql.kafka.disallowedOptions")
-      .internal()
-      .doc("A comma-separated list of Kafka client option names (without the 'kafka.' prefix) " +
-        "that are not allowed to be set through Kafka source/sink options. Empty by default, " +
-        "which allows all options and preserves the previous behavior; when non-empty, setting a " +
-        "listed option raises an error. This is a static configuration fixed when the " +
-        "SparkSession is created and cannot be changed at runtime, so it acts as an operator " +
-        "boundary that a session cannot turn off.")
-      .version("4.3.0")
-      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
-      .stringConf
-      .toSequence
-      .checkValue(_.forall(!_.toLowerCase(Locale.ROOT).startsWith("kafka.")),
-        "Kafka option names must be listed without the 'kafka.' prefix.")
-      .createWithDefault(Nil)
-
   val STATEFUL_OPERATOR_CHECK_CORRECTNESS_ENABLED =
     buildConf("spark.sql.streaming.statefulOperator.checkCorrectness.enabled")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3913,6 +3913,19 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val KAFKA_DISALLOWED_OPTIONS =
+    buildConf("spark.sql.kafka.disallowedOptions")
+      .internal()
+      .doc("A comma-separated list of Kafka client option names (without the 'kafka.' prefix) " +
+        "that are not allowed to be set through Kafka source/sink options. Empty by default, " +
+        "which allows all options and preserves the previous behavior; when non-empty, setting a " +
+        "listed option raises an error.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   val STATEFUL_OPERATOR_CHECK_CORRECTNESS_ENABLED =
     buildConf("spark.sql.streaming.statefulOperator.checkCorrectness.enabled")
       .internal()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -418,4 +418,21 @@ object StaticSQLConf {
       .bytesConf(ByteUnit.BYTE)
       .checkValue(_ >= 0, "The maximum total size must not be negative.")
       .createWithDefault(128 * 1024) // 128 KiB
+
+  val KAFKA_DISALLOWED_OPTIONS =
+    buildStaticConf("spark.sql.kafka.disallowedOptions")
+      .internal()
+      .doc("A comma-separated list of Kafka client option names (without the 'kafka.' prefix) " +
+        "that are not allowed to be set through Kafka source/sink options. Empty by default, " +
+        "which allows all options and preserves the previous behavior; when non-empty, setting a " +
+        "listed option raises an error. This is a static configuration fixed when the " +
+        "SparkSession is created and cannot be changed at runtime, so it acts as an operator " +
+        "boundary that a session cannot turn off.")
+      .version("4.3.0")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
+      .stringConf
+      .toSequence
+      .checkValue(_.forall(!_.toLowerCase(Locale.ROOT).startsWith("kafka.")),
+        "Kafka option names must be listed without the 'kafka.' prefix.")
+      .createWithDefault(Nil)
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add an opt-in, internal `spark.sql.kafka.disallowedOptions` (default empty). When set to a
comma-separated list of Kafka client option names (without the `kafka.` prefix), those options
are rejected if passed as `kafka.<name>` on the Kafka source or sink; an empty list (the default)
allows all options and preserves the previous behavior. The rejection is raised through the Kafka
connector's error-class framework (a new `KAFKA_DISALLOWED_OPTION` condition).

The config is a **static** SQL config (`buildStaticConf`): it is fixed when the `SparkSession` is
created and cannot be changed at runtime, so an application cannot turn the denylist off. It is
declared in `StaticSQLConf`, alongside the other static SQL configs. Entries carrying a `kafka.`
prefix are rejected by a `checkValue`, so the denylist cannot silently fail open.

This is one of three PRs split out of a combined data-source-options change; the Avro schema-URL
and Hive class-loading parts are handled separately.

### Why are the changes needed?

Gives operators an optional control over which Kafka client options an application may set through
the data source. It defaults to empty, so there is no behavior change unless configured.

### Does this PR introduce _any_ user-facing change?

No by default. When `spark.sql.kafka.disallowedOptions` is set, a listed `kafka.<name>` option on a
Kafka read or write is rejected with a clear error. Because the config is static, it must be set
when the `SparkSession` is created (for example with `--conf`) and cannot be set at runtime.

### How was this patch tested?

New `KafkaSourceProviderSuite` cases:
- a listed option is rejected on both the source and the sink path, and the empty default (unset)
  still accepts the option;
- the denylist is an operator boundary: the config is not modifiable at runtime, and a
  `kafka.`-prefixed entry is rejected by `checkValue`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.