### PR TITLE
[SPARK-59336][SQL] Fix syntax error classifier in Postgres connector

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -400,12 +400,13 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     val restrictedPassword = "restricted_password"
     val restrictedJdbcUrl = s"jdbc:postgresql://$dockerIp:$externalPort/postgres"
 
-    Using.resource(getConnection()) { conn =>
-      conn.prepareStatement(s"CREATE USER $restrictedUser PASSWORD '$restrictedPassword'")
-        .executeUpdate()
-    }
-
     Utils.tryWithSafeFinally {
+      Using.resource(getConnection()) { conn =>
+        conn.prepareStatement(s"DROP USER IF EXISTS $restrictedUser").executeUpdate()
+        conn.prepareStatement(s"CREATE USER $restrictedUser PASSWORD '$restrictedPassword'")
+          .executeUpdate()
+      }
+
       val postgresError = intercept[SQLException] {
         spark.read.format("jdbc")
           .option("url", restrictedJdbcUrl)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -402,8 +402,8 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
         .option("password", restrictedPassword)
         .load()
     }
-    assert(postgresError.getSQLState === "42501")
-    assert(postgresError.getMessage === "ERROR: permission denied for table bar")
+    assertResult("42501")(postgresError.getSQLState)
+    assertResult("ERROR: permission denied for table bar")(postgresError.getMessage)
   }
 
   test("write byte as smallint") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
+import org.apache.spark.util.Utils
 
 /**
  * To run this test suite for a specific version (e.g., postgres:18.2-alpine):
@@ -394,16 +395,22 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
         .executeUpdate()
     }
 
-    val postgresError = intercept[SQLException] {
-      spark.read.format("jdbc")
-        .option("url", restrictedJdbcUrl)
-        .option("dbtable", "bar")
-        .option("user", restrictedUser)
-        .option("password", restrictedPassword)
-        .load()
+    Utils.tryWithSafeFinally {
+      val postgresError = intercept[SQLException] {
+        spark.read.format("jdbc")
+          .option("url", restrictedJdbcUrl)
+          .option("dbtable", "bar")
+          .option("user", restrictedUser)
+          .option("password", restrictedPassword)
+          .load()
+      }
+      assertResult("42501")(postgresError.getSQLState)
+      assertResult("ERROR: permission denied for table bar")(postgresError.getMessage)
+    } {
+      Using.resource(getConnection()) { conn =>
+        conn.prepareStatement(s"DROP USER $restrictedUser").executeUpdate()
+      }
     }
-    assertResult("42501")(postgresError.getSQLState)
-    assertResult("ERROR: permission denied for table bar")(postgresError.getMessage)
   }
 
   test("write byte as smallint") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -23,6 +23,8 @@ import java.text.SimpleDateFormat
 import java.time.LocalDateTime
 import java.util.Properties
 
+import scala.util.Using
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
@@ -42,12 +44,6 @@ import org.apache.spark.tags.DockerTest
 @DockerTest
 class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
   override val db = new PostgresDatabaseOnDocker
-
-  private val restrictedUser = "restricted_user"
-  private val restrictedPassword = "restricted_password"
-
-  private def restrictedJdbcUrl: String =
-    s"jdbc:postgresql://$dockerIp:$externalPort/postgres"
 
   override def dataPreparation(conn: Connection): Unit = {
     conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
@@ -172,9 +168,6 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
 
     conn.prepareStatement(
       "CREATE FUNCTION test_null() RETURNS VOID AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql")
-      .executeUpdate()
-
-    conn.prepareStatement(s"CREATE USER $restrictedUser PASSWORD '$restrictedPassword'")
       .executeUpdate()
 
     conn.prepareStatement("CREATE TABLE test_bit_array (c1 bit(1)[], c2 bit(5)[])").executeUpdate()
@@ -392,12 +385,22 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
   }
 
   test("SPARK-57780: do not classify insufficient privilege as a syntax error") {
-    val properties = new Properties()
-    properties.setProperty("user", restrictedUser)
-    properties.setProperty("password", restrictedPassword)
+    val restrictedUser = "restricted_user"
+    val restrictedPassword = "restricted_password"
+    val restrictedJdbcUrl = s"jdbc:postgresql://$dockerIp:$externalPort/postgres"
+
+    Using.resource(getConnection()) { conn =>
+      conn.prepareStatement(s"CREATE USER $restrictedUser PASSWORD '$restrictedPassword'")
+        .executeUpdate()
+    }
 
     val postgresError = intercept[SQLException] {
-      spark.read.jdbc(restrictedJdbcUrl, "bar", properties)
+      spark.read.format("jdbc")
+        .option("url", restrictedJdbcUrl)
+        .option("dbtable", "bar")
+        .option("user", restrictedUser)
+        .option("password", restrictedPassword)
+        .load()
     }
     assert(postgresError.getSQLState === "42501")
     assert(postgresError.getMessage === "ERROR: permission denied for table bar")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -385,7 +385,7 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     assert(sql("select c1, c3 from queryOption").collect().toSet == expectedResult)
   }
 
-  test("SPARK-57780: do not classify insufficient privilege as a syntax error") {
+  test("SPARK-59336: do not classify insufficient privilege as a syntax error") {
     val restrictedUser = "restricted_user"
     val restrictedPassword = "restricted_password"
     val restrictedJdbcUrl = s"jdbc:postgresql://$dockerIp:$externalPort/postgres"

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -43,6 +43,12 @@ import org.apache.spark.tags.DockerTest
 class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
   override val db = new PostgresDatabaseOnDocker
 
+  private val restrictedUser = "restricted_user"
+  private val restrictedPassword = "restricted_password"
+
+  private def restrictedJdbcUrl: String =
+    s"jdbc:postgresql://$dockerIp:$externalPort/postgres"
+
   override def dataPreparation(conn: Connection): Unit = {
     conn.prepareStatement("CREATE DATABASE foo").executeUpdate()
     conn.setCatalog("foo")
@@ -166,6 +172,9 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
 
     conn.prepareStatement(
       "CREATE FUNCTION test_null() RETURNS VOID AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql")
+      .executeUpdate()
+
+    conn.prepareStatement(s"CREATE USER $restrictedUser PASSWORD '$restrictedPassword'")
       .executeUpdate()
 
     conn.prepareStatement("CREATE TABLE test_bit_array (c1 bit(1)[], c2 bit(5)[])").executeUpdate()
@@ -380,6 +389,18 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
          |OPTIONS (url '$jdbcUrl', query '$query')
        """.stripMargin.replaceAll("\n", " "))
     assert(sql("select c1, c3 from queryOption").collect().toSet == expectedResult)
+  }
+
+  test("SPARK-57780: do not classify insufficient privilege as a syntax error") {
+    val properties = new Properties()
+    properties.setProperty("user", restrictedUser)
+    properties.setProperty("password", restrictedPassword)
+
+    val postgresError = intercept[SQLException] {
+      spark.read.jdbc(restrictedJdbcUrl, "bar", properties)
+    }
+    assert(postgresError.getSQLState === "42501")
+    assert(postgresError.getMessage === "ERROR: permission denied for table bar")
   }
 
   test("write byte as smallint") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -385,6 +385,16 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
     assert(sql("select c1, c3 from queryOption").collect().toSet == expectedResult)
   }
 
+  test("SPARK-59336: do not classify missing table as a syntax error") {
+    val postgresError = intercept[SQLException] {
+      spark.read.format("jdbc")
+        .option("url", jdbcUrl)
+        .option("query", "SELECT * FROM table_that_does_not_exist")
+        .load()
+    }
+    assertResult("42P01")(postgresError.getSQLState)
+  }
+
   test("SPARK-59336: do not classify insufficient privilege as a syntax error") {
     val restrictedUser = "restricted_user"
     val restrictedPassword = "restricted_password"
@@ -405,10 +415,12 @@ class PostgresIntegrationSuite extends SharedJDBCIntegrationSuite {
           .load()
       }
       assertResult("42501")(postgresError.getSQLState)
-      assertResult("ERROR: permission denied for table bar")(postgresError.getMessage)
+      assert(
+        postgresError.getMessage.contains("permission denied"),
+        s"Unexpected PostgreSQL error message: ${postgresError.getMessage}")
     } {
       Using.resource(getConnection()) { conn =>
-        conn.prepareStatement(s"DROP USER $restrictedUser").executeUpdate()
+        conn.prepareStatement(s"DROP USER IF EXISTS $restrictedUser").executeUpdate()
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -260,10 +260,9 @@ private case class PostgresDialect()
 
   // See https://www.postgresql.org/docs/current/errcodes-appendix.html
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
-    exception.getSQLState match {
-      case "42000" | "42601" => true
-      case _ => false
-    }
+    // SQLSTATE 42000 covers both syntax errors and access-rule violations, so preserve the
+    // original exception for that ambiguous state.
+    exception.getSQLState == "42601"
   }
 
   // SHOW INDEX syntax

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -258,12 +258,12 @@ private case class PostgresDialect()
       s" $indexType (${columnList.mkString(", ")}) $indexProperties"
   }
 
-  // PostgreSQL class 42 contains both syntax errors and access rule violations. SQLSTATE 42501
-  // is insufficient_privilege, which is an access error rather than a syntax error.
   // See https://www.postgresql.org/docs/current/errcodes-appendix.html
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
-    val sqlState = exception.getSQLState
-    Option(sqlState).exists(_.startsWith("42")) && sqlState != "42501"
+    exception.getSQLState match {
+      case "42000" | "42601" => true
+      case _ => false
+    }
   }
 
   // SHOW INDEX syntax

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -258,9 +258,12 @@ private case class PostgresDialect()
       s" $indexType (${columnList.mkString(", ")}) $indexProperties"
   }
 
+  // PostgreSQL class 42 contains both syntax errors and access rule violations. SQLSTATE 42501
+  // is insufficient_privilege, which is an access error rather than a syntax error.
   // See https://www.postgresql.org/docs/current/errcodes-appendix.html
   override def isSyntaxErrorBestEffort(exception: SQLException): Boolean = {
-    Option(exception.getSQLState).exists(_.startsWith("42"))
+    val sqlState = exception.getSQLState
+    Option(sqlState).exists(_.startsWith("42")) && sqlState != "42501"
   }
 
   // SHOW INDEX syntax

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -82,7 +82,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn).setAutoCommit(false)
   }
 
-  test("SPARK-57780: classify only syntax error SQLSTATEs as syntax errors") {
+  test("SPARK-59336: classify only syntax error SQLSTATEs as syntax errors") {
     assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42000")))
     assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42601")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("permission denied", "42501")))

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -18,7 +18,7 @@
 
 package org.apache.spark.sql.jdbc
 
-import java.sql.{Connection, ResultSet, ResultSetMetaData, Statement, Types}
+import java.sql.{Connection, ResultSet, ResultSetMetaData, SQLException, Statement, Types}
 
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.anyString
@@ -80,6 +80,11 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     // No explicit fetchsize - should use Postgres default (1000) and set autoCommit=false
     dialect.beforeFetch(conn, createJDBCOptions(Map.empty))
     verify(conn).setAutoCommit(false)
+  }
+
+  test("SPARK-57780: insufficient privilege is not classified as a syntax error") {
+    assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42601")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("permission denied", "42501")))
   }
 
   test("updateExtraColumnMeta escapes a single quote in the table and column name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -82,9 +82,11 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn).setAutoCommit(false)
   }
 
-  test("SPARK-57780: insufficient privilege is not classified as a syntax error") {
+  test("SPARK-57780: classify only syntax error SQLSTATEs as syntax errors") {
+    assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42000")))
     assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42601")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("permission denied", "42501")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("undefined table", "42P01")))
   }
 
   test("updateExtraColumnMeta escapes a single quote in the table and column name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -87,6 +87,7 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42601")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("permission denied", "42501")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("undefined table", "42P01")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("error without SQLSTATE")))
   }
 
   test("updateExtraColumnMeta escapes a single quote in the table and column name") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/PostgresDialectSuite.scala
@@ -82,11 +82,13 @@ class PostgresDialectSuite extends SparkFunSuite with MockitoSugar {
     verify(conn).setAutoCommit(false)
   }
 
-  test("SPARK-59336: classify only syntax error SQLSTATEs as syntax errors") {
-    assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42000")))
+  test("SPARK-59336: classify only SQLSTATE 42601 as a syntax error") {
     assert(dialect.isSyntaxErrorBestEffort(new SQLException("syntax error", "42601")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("access rule violation", "42000")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("permission denied", "42501")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("undefined table", "42P01")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("undefined column", "42703")))
+    assert(!dialect.isSyntaxErrorBestEffort(new SQLException("undefined function", "42883")))
     assert(!dialect.isSyntaxErrorBestEffort(new SQLException("error without SQLSTATE")))
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

- Don't classify Postgres 42501 error as syntax error, since that error is permission issue.

https://www.postgresql.org/docs/17/errcodes-appendix.html
<img width="1268" height="2640" alt="image" src="https://github.com/user-attachments/assets/74e029c5-7edc-44c7-8956-c7a71011cef8" />


### Why are the changes needed?
- To properly classify syntax errors in Postgres connector.


### Does this PR introduce _any_ user-facing change?
- Yes. For PostgreSQL JDBC queries, Spark now wraps only SQLSTATE `42601` as a syntax error. Other class-42 errors, including `42000` (syntax error or access rule violation), `42501` (insufficient privilege), and `42P01` (undefined table), are propagated as their original PostgreSQL JDBC errors.

### How was this patch tested?
- New integration test where we assert no permission error is not classified as SyntaxError (that is behavioural change)
- New unit tests
- Existing positive test for syntax error classification here: https://github.com/urosstan-db/spark/blob/6697d711944e4c6cbcf038ce80df8d2272def3a3/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/SharedJDBCIntegrationSuite.scala#L57-L74

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Codex CLI