### PR TITLE
[SPARK-59337][ML] Simplify GeneralizedLinearRegressionModel transform implementation

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala
@@ -1051,11 +1051,6 @@ class GeneralizedLinearRegressionModel private[ml] (
   }
 
   override def transform(dataset: Dataset[_]): DataFrame = {
-    transformSchema(dataset.schema)
-    transformImpl(dataset)
-  }
-
-  override protected def transformImpl(dataset: Dataset[_]): DataFrame = {
     val outputSchema = transformSchema(dataset.schema, logging = true)
 
     val offset = if (!hasOffsetCol) lit(0.0) else col($(offsetCol)).cast(DoubleType)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes the redundant `GeneralizedLinearRegressionModel.transformImpl` override and keeps
its implementation directly in `transform`.

### Why are the changes needed?

`GeneralizedLinearRegressionModel` must override `transform` because it can produce
`linkPredictionCol` when `predictionCol` is empty, while the base `Predictor` implementation only
invokes `transformImpl` when `predictionCol` is set. Once GLR owns `transform`, the separate
`transformImpl` override is only called by that method. Previously, `transform` called
`transformSchema` and then delegated to `transformImpl`, which immediately called
`transformSchema` again. As a result, each transform checked the schema twice.

Inlining the implementation removes this redundant indirection and schema validation without
changing the generated columns.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks passed:

```
build/sbt mllib/compile
build/sbt 'mllib/testOnly org.apache.spark.ml.regression.GeneralizedLinearRegressionSuite'
```

`GeneralizedLinearRegressionSuite` ran 29 tests successfully, with one ignored test.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
