### PR TITLE
[SPARK-58963][ML][SQL][FOLLOWUP] Rename the vector posexplode internal expression

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/functions.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/functions.scala
@@ -56,7 +56,7 @@ object functions {
   private[ml] def vector_posexplode(
       v: Column,
       mode: String = "sparse"): Column = {
-    Column.internalFn("vector_posexplode", sf.unwrap_udt(v), sf.lit(mode))
+    Column.internalFn("ml_vector_posexplode", sf.unwrap_udt(v), sf.lit(mode))
   }
 
   private[ml] def array_binary_search(a: Column, v: Column): Column =

--- a/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/FunctionsSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.ml.util.MLTest
 import org.apache.spark.mllib.linalg.{Matrices => OldMatrices, MatrixUDT => OldMatrixUDT,
   Vector => OldVector, Vectors => OldVectors, VectorUDT => OldVectorUDT}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Row}
+import org.apache.spark.sql.catalyst.expressions.ml.VectorPosExplode
 import org.apache.spark.sql.functions.{col, unwrap_udt, wrap_udt}
 import org.apache.spark.sql.types.{StructField, StructType, UserDefinedType}
 
@@ -213,6 +214,10 @@ class FunctionsSuite extends MLTest {
 
     val schema = df.select(vector_posexplode($"vec")).schema
     assert(schema.simpleString === "struct<index:int,value:double>")
+
+    val generators = df.select(vector_posexplode($"vec")).queryExecution.analyzed
+      .flatMap(_.expressions.flatMap(_.collect { case v: VectorPosExplode => v }))
+    assert(generators.map(_.prettyName).distinct === Seq("ml_vector_posexplode"))
   }
 
   test("test get_vector") {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -1221,7 +1221,7 @@ object FunctionRegistry {
     registerInternalExpression[NullIndex]("null_index")
     registerInternalExpression[CastTimestampNTZToLong]("timestamp_ntz_to_long")
     registerInternalExpression[ArrayBinarySearch]("array_binary_search")
-    registerInternalExpression[VectorPosExplode]("vector_posexplode")
+    registerInternalExpression[VectorPosExplode]("ml_vector_posexplode")
   }
 
   registerInternalExpressions()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ml/VectorPosExplode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ml/VectorPosExplode.scala
@@ -37,13 +37,13 @@ import org.apache.spark.unsafe.types.UTF8String
  * Sparse vector examples:
  * {{{
  *   // v = {type: 0, size: 4, indices: [1, 3], values: [2.0, 4.0]}
- *   vector_posexplode(v)
+ *   ml_vector_posexplode(v)
  *   index  value
  *   -5     NaN
  *   1      2.0
  *   3      4.0
  *
- *   vector_posexplode(v, mode = "dense")
+ *   ml_vector_posexplode(v, mode = "dense")
  *   index  value
  *   -5     NaN
  *   0      0.0
@@ -55,13 +55,13 @@ import org.apache.spark.unsafe.types.UTF8String
  * Dense vector examples:
  * {{{
  *   // v = {type: 1, size: null, indices: null, values: [1.0, 0.0, 3.0]}
- *   vector_posexplode(v)
+ *   ml_vector_posexplode(v)
  *   index  value
  *   -4     NaN
  *   0      1.0
  *   2      3.0
  *
- *   vector_posexplode(v, mode = "dense")
+ *   ml_vector_posexplode(v, mode = "dense")
  *   index  value
  *   -4     NaN
  *   0      1.0
@@ -75,6 +75,8 @@ case class VectorPosExplode(child: Expression, mode: Expression)
   def this(child: Expression) = this(child, Literal("sparse"))
 
   override def children: Seq[Expression] = Seq(child, mode)
+
+  override def prettyName: String = "ml_vector_posexplode"
 
   @transient private lazy val vectorMode: VectorPosExplode.VectorMode.Value =
     VectorPosExplode.toMode(mode.eval().asInstanceOf[UTF8String].toString)
@@ -101,13 +103,13 @@ case class VectorPosExplode(child: Expression, mode: Expression)
     }
     val modeValue = mode.eval()
     if (modeValue == null) {
-      return TypeCheckFailure("The second argument of vector_posexplode cannot be null.")
+      return TypeCheckFailure(s"The second argument of $prettyName cannot be null.")
     }
     VectorPosExplode.toModeOption(modeValue.asInstanceOf[UTF8String].toString) match {
       case Some(_) =>
       case None =>
         return TypeCheckFailure(
-          "The second argument of vector_posexplode must be one of: dense, sparse.")
+          s"The second argument of $prettyName must be one of: dense, sparse.")
     }
     TypeCheckResult.TypeCheckSuccess
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This follow-up to #58194:

- renames `VectorGenerators.scala` to `VectorPosExplode.scala`;
- registers the internal expression as `ml_vector_posexplode`;
- defines `ml_vector_posexplode` as the expression's `prettyName`; and
- updates the Spark ML helper and its test to use and verify the new internal name.

### Why are the changes needed?

The ML-specific internal expression should use the `ml_` namespace consistently, and its source
filename should match the expression it contains.

### Does this PR introduce _any_ user-facing change?

No. The renamed function is internal and the original change has not been released.

### How was this patch tested?

- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 build/sbt 'mllib/testOnly *FunctionsSuite -- -z "vector_posexplode"'`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./dev/scalastyle`

The existing `FunctionsSuite` test now also verifies the resolved generator's `prettyName`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
