### PR TITLE
[SPARK-59341][SQL] Assign a tree pattern to UnresolvedStarBase related nodes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -647,6 +647,8 @@ case class UnresolvedStarExceptOrReplace(
     replacements: Option[Seq[NamedExpression]])
   extends LeafExpression with UnresolvedStarBase {
 
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_STAR_EXCEPT_OR_REPLACE)
+
   /**
    * We expand the * EXCEPT by the following three steps:
    * 1. use the original .expandStar() to get top-level column list or struct expansion

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/unresolved.scala
@@ -798,6 +798,8 @@ case class UnresolvedStarWithColumns(
      explicitMetadata: Option[Seq[Metadata]] = None)
   extends UnresolvedStarBase {
 
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_STAR_WITH_COLUMNS)
+
   override def target: Option[Seq[String]] = None
   override def children: Seq[Expression] = exprs
 
@@ -859,6 +861,8 @@ case class UnresolvedStarWithColumnsRenames(
     newNames: Seq[String])
   extends LeafExpression with UnresolvedStarBase {
 
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_STAR_WITH_COLUMNS_RENAMES)
+
   override def target: Option[Seq[String]] = None
 
   override def expandStar(parameters: ExpandStarParameters): Seq[NamedExpression] = {
@@ -895,7 +899,10 @@ case class UnresolvedStarWithColumnsRenames(
  *              is a list of identifiers that is the path of the expansion.
  */
 case class UnresolvedStar(target: Option[Seq[String]])
-  extends LeafExpression with UnresolvedStarBase
+  extends LeafExpression with UnresolvedStarBase {
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_STAR)
+}
 
 /**
  * Represents all of the input attributes to a given relational operator, for example in
@@ -906,6 +913,9 @@ case class UnresolvedStar(target: Option[Seq[String]])
  */
 case class UnresolvedRegex(regexPattern: String, table: Option[String], caseSensitive: Boolean)
   extends LeafExpression with Star with Unevaluable {
+
+  final override val nodePatterns: Seq[TreePattern] = Seq(UNRESOLVED_REGEX)
+
   override def expandStar(parameters: ExpandStarParameters): Seq[NamedExpression] = {
     val pattern = if (caseSensitive) regexPattern else s"(?i)$regexPattern"
     table match {
@@ -966,6 +976,7 @@ case class MultiAlias(child: Expression, names: Seq[String])
  */
 case class ResolvedStar(expressions: Seq[NamedExpression])
   extends LeafExpression with Star with Unevaluable {
+  final override val nodePatterns: Seq[TreePattern] = Seq(RESOLVED_STAR)
   override def newInstance(): NamedExpression = throw new UnresolvedException("newInstance")
   override def expandStar(parameters: ExpandStarParameters): Seq[NamedExpression] = expressions
   override def toString: String = expressions.mkString("ResolvedStar(", ", ", ")")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -94,6 +94,7 @@ object TreePattern extends Enumeration  {
   val PYTHON_UDF: Value = Value
   val REGEXP_EXTRACT_FAMILY: Value = Value
   val REGEXP_REPLACE: Value = Value
+  val RESOLVED_STAR: Value = Value
   val RUNTIME_REPLACEABLE: Value = Value
   val SEMI_STRUCTURED_EXTRACT: Value = Value
   val SCALAR_SUBQUERY: Value = Value
@@ -131,7 +132,11 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_IDENTIFIER: Value = Value
   val UNRESOLVED_ORDINAL: Value = Value
   val UNRESOLVED_PLAN_ID: Value = Value
+  val UNRESOLVED_REGEX: Value = Value
+  val UNRESOLVED_STAR: Value = Value
   val UNRESOLVED_STAR_EXCEPT_OR_REPLACE: Value = Value
+  val UNRESOLVED_STAR_WITH_COLUMNS: Value = Value
+  val UNRESOLVED_STAR_WITH_COLUMNS_RENAMES: Value = Value
   val UNRESOLVED_WINDOW_EXPRESSION: Value = Value
 
   // Execution expression patterns (alphabetically ordered)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreePatterns.scala
@@ -131,6 +131,7 @@ object TreePattern extends Enumeration  {
   val UNRESOLVED_IDENTIFIER: Value = Value
   val UNRESOLVED_ORDINAL: Value = Value
   val UNRESOLVED_PLAN_ID: Value = Value
+  val UNRESOLVED_STAR_EXCEPT_OR_REPLACE: Value = Value
   val UNRESOLVED_WINDOW_EXPRESSION: Value = Value
 
   // Execution expression patterns (alphabetically ordered)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StarTreePatternSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/StarTreePatternSuite.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.trees.TreePattern._
+
+/**
+ * Pins the tree-pattern identity contract for the star-related expression nodes: each node carries
+ * its own identity bit, so rules can prune on it.
+ */
+class StarTreePatternSuite extends SparkFunSuite {
+
+  test("UnresolvedStar declares UNRESOLVED_STAR") {
+    assert(UnresolvedStar(None).containsPattern(UNRESOLVED_STAR))
+  }
+
+  test("UnresolvedStarExceptOrReplace declares UNRESOLVED_STAR_EXCEPT_OR_REPLACE") {
+    val node = UnresolvedStarExceptOrReplace(None, Seq.empty, None)
+    assert(node.containsPattern(UNRESOLVED_STAR_EXCEPT_OR_REPLACE))
+  }
+
+  test("UnresolvedStarWithColumns declares UNRESOLVED_STAR_WITH_COLUMNS") {
+    val node = UnresolvedStarWithColumns(Seq.empty, Seq.empty)
+    assert(node.containsPattern(UNRESOLVED_STAR_WITH_COLUMNS))
+  }
+
+  test("UnresolvedStarWithColumnsRenames declares UNRESOLVED_STAR_WITH_COLUMNS_RENAMES") {
+    val node = UnresolvedStarWithColumnsRenames(Seq.empty, Seq.empty)
+    assert(node.containsPattern(UNRESOLVED_STAR_WITH_COLUMNS_RENAMES))
+  }
+
+  test("UnresolvedRegex declares UNRESOLVED_REGEX") {
+    val node = UnresolvedRegex("col.*", None, caseSensitive = false)
+    assert(node.containsPattern(UNRESOLVED_REGEX))
+  }
+
+  test("ResolvedStar declares RESOLVED_STAR") {
+    assert(ResolvedStar(Seq.empty).containsPattern(RESOLVED_STAR))
+  }
+
+  test("UnresolvedDataFrameStar declares UNRESOLVED_DF_STAR") {
+    assert(UnresolvedDataFrameStar(1L).containsPattern(UNRESOLVED_DF_STAR))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose to add tree pattern for `UnresolvedStarExceptOrReplace` and other unresolved star related nodes so we can use it later for pruning and other similar cases.

### Why are the changes needed?
To improve internal Spark logical plan nodes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests + newly added tests.

### Was this patch authored or co-authored using generative AI tooling?
Yes.