### PR TITLE
[SPARK-59299][SQL][TESTS][FOLLOWUP] Split ASOF JOIN parser test cases into separate tests

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1056,7 +1056,11 @@ class PlanParserSuite extends AnalysisTest {
           $"u.a",
           None,
           Inner).select(star()))
+    }
+  }
 
+  test("asof join - left asof with on condition") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t left asof join u match_condition (t.a >= u.a) on t.b = u.b",
         AsOfJoin.fromMatchCondition(
@@ -1067,7 +1071,11 @@ class PlanParserSuite extends AnalysisTest {
           $"u.a",
           Some($"t.b" === $"u.b"),
           LeftOuter).select(star()))
+    }
+  }
 
+  test("asof join - using single join column") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a) using (b)",
         AsOfJoin.fromMatchCondition(
@@ -1079,7 +1087,11 @@ class PlanParserSuite extends AnalysisTest {
           None,
           Inner,
           usingColumns = Some(Seq("b"))).select(star()))
+    }
+  }
 
+  test("asof join - using multiple join columns") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a) using (a, b)",
         AsOfJoin.fromMatchCondition(
@@ -1091,7 +1103,11 @@ class PlanParserSuite extends AnalysisTest {
           None,
           Inner,
           usingColumns = Some(Seq("a", "b"))).select(star()))
+    }
+  }
 
+  test("asof join - less than or equal match operator") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (u.a <= t.a)",
         AsOfJoin.fromMatchCondition(
@@ -1102,7 +1118,11 @@ class PlanParserSuite extends AnalysisTest {
           $"t.a",
           None,
           Inner).select(star()))
+    }
+  }
 
+  test("asof join - greater than match operator") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a > u.a)",
         AsOfJoin.fromMatchCondition(
@@ -1113,7 +1133,11 @@ class PlanParserSuite extends AnalysisTest {
           $"u.a",
           None,
           Inner).select(star()))
+    }
+  }
 
+  test("asof join - less than match operator") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a < u.a)",
         AsOfJoin.fromMatchCondition(
@@ -1124,7 +1148,11 @@ class PlanParserSuite extends AnalysisTest {
           $"u.a",
           None,
           Inner).select(star()))
+    }
+  }
 
+  test("asof join - explicit inner join type") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t inner asof join u match_condition (t.a >= u.a)",
         AsOfJoin.fromMatchCondition(
@@ -1135,7 +1163,11 @@ class PlanParserSuite extends AnalysisTest {
           $"u.a",
           None,
           Inner).select(star()))
+    }
+  }
 
+  test("asof join - explicit left outer join type") {
+    withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t left outer asof join u match_condition (t.a >= u.a)",
         AsOfJoin.fromMatchCondition(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1059,7 +1059,7 @@ class PlanParserSuite extends AnalysisTest {
     }
   }
 
-  test("asof join - left asof with on condition") {
+  test("asof join - explicit left join type with on condition") {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t left asof join u match_condition (t.a >= u.a) on t.b = u.b",
@@ -1074,7 +1074,7 @@ class PlanParserSuite extends AnalysisTest {
     }
   }
 
-  test("asof join - using single join column") {
+  test("asof join - using with a single join column") {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a) using (b)",
@@ -1090,7 +1090,7 @@ class PlanParserSuite extends AnalysisTest {
     }
   }
 
-  test("asof join - using multiple join columns") {
+  test("asof join - using with multiple join columns") {
     withSQLConf(SQLConf.SQL_ASOF_JOIN_ENABLED.key -> "true") {
       assertEqual(
         "select * from t asof join u match_condition (t.a >= u.a) using (a, b)",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow-up to SPARK-59299 (#58578) addressing a review comment. `PlanParserSuite`'s
`test("asof join")` bundled nine positive `ASOF JOIN` parsing cases under one test name. This
splits them so each scenario is its own named test:

- `asof join` - basic `MATCH_CONDITION` (`t.a >= u.a`), retained as the canonical case;
- `asof join - left asof with on condition`;
- `asof join - using single join column` / `... multiple join columns`;
- `asof join - less than or equal / greater than / less than match operator`;
- `asof join - explicit inner / left outer join type`.

No assertions were changed - the existing cases are only redistributed into separate tests
(the diff is purely additive).

### Why are the changes needed?
With all cases in one `test(...)` block, a failure is reported only as `asof join` without
indicating which case broke, and the first failing assertion aborts the block so the remaining
cases never run. One scenario per test makes failures self-identifying and independent,
matching the surrounding `asof join - ...` tests in the same suite.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Test-only change: the existing `test("asof join")` assertions are only redistributed into
separately-named tests, with no assertion modified (the diff is purely additive). Coverage is
verified by this PR's GitHub Actions CI, which compiles `sql/catalyst` and runs
`PlanParserSuite`.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)
