### PR TITLE
[SPARK-36082][SQL][FOLLOWUP] Restore NAAJ broadcast hash join by default

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.catalyst.expressions.{Alias, And, ArrayDistinct, ArrayExcept, ArrayIntersect, ArraysOverlap, ArrayTransform, ArrayUnion, CaseWhen, Coalesce, CreateArray, CreateMap, CreateNamedStruct, EqualTo, ExpectsInputTypes, Expression, GetStructField, If, IsNull, KnownFloatingPointNormalized, LambdaFunction, Literal, NamedLambdaVariable, TransformValues, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, And, ArrayDistinct, ArrayExcept, ArrayIntersect, ArraysOverlap, ArrayTransform, ArrayUnion, CaseWhen, Coalesce, CreateArray, CreateMap, CreateNamedStruct, EqualTo, ExpectsInputTypes, Expression, GetStructField, If, IsNull, KnownFloatingPointNormalized, LambdaFunction, Literal, NamedLambdaVariable, Or, TransformValues, UnaryExpression}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.planning.ExtractEquiJoinKeys
+import org.apache.spark.sql.catalyst.planning.{ExtractEquiJoinKeys, ExtractSingleColumnNullAwareAntiJoin}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Window}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern._
@@ -93,6 +93,12 @@ object NormalizeFloatingNumbers extends Rule[LogicalPlan] {
             case (l, r) => EqualTo(l, r)
           } ++ condition
           j.copy(condition = Some(newConditions.reduce(And)))
+
+        // The specialized NAAJ is a hash join, but its OR condition is not an equi-join shape.
+        case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
+            if leftKeys.exists(needNormalize) =>
+          val equality = EqualTo(normalize(leftKeys.head), normalize(rightKeys.head))
+          j.copy(condition = Some(Or(equality, IsNull(equality))))
 
         // TODO: ideally Aggregate should also be handled here, but its grouping expressions are
         // mixed in its aggregate expressions. It's unreliable to change the grouping expressions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PushDownLeftSemiAntiJoin.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.planning.ExtractSingleColumnNullAwareAntiJoin
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -61,11 +60,12 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
         }
       }
 
-    // LeftSemi/LeftAnti over Aggregate
+    // LeftSemi/LeftAnti over Aggregate, only push down if join can be planned as broadcast join.
     case join @ Join(agg: Aggregate, rightOp, LeftSemiOrAnti(_), joinCond, _)
         if agg.aggregateExpressions.forall(_.deterministic) && agg.groupingExpressions.nonEmpty &&
           !agg.aggregateExpressions.exists(ScalarSubquery.hasCorrelatedScalarSubquery) &&
-          canPushThroughCondition(agg.children, joinCond, rightOp) =>
+          canPushThroughCondition(agg.children, joinCond, rightOp) &&
+          canPlanAsBroadcastHashJoin(join, conf) =>
       val aliasMap = getAliasMap(agg)
       val canPushDownPredicate = (predicate: Expression) => {
         val replaced = replaceAlias(predicate, aliasMap)
@@ -75,20 +75,7 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
       val makeJoinCondition = (predicates: Seq[Expression]) => {
         replaceAlias(predicates.reduce(And), aliasMap)
       }
-      val canPushDownJoin = if (ExtractSingleColumnNullAwareAntiJoin.extract(join).isDefined) {
-        val originalIsBroadcastHash =
-          NullAwareAntiJoinPlanning.decide(join, conf) == NullAwareAntiJoinPlanning.BroadcastHash
-        (pushedJoin: Join) => originalIsBroadcastHash &&
-          NullAwareAntiJoinPlanning.decide(pushedJoin, conf) ==
-            NullAwareAntiJoinPlanning.BroadcastHash
-      } else {
-        (_: Join) => canPlanAsBroadcastHashJoin(join, conf)
-      }
-      pushDownJoin(
-        join,
-        canPushDownPredicate,
-        makeJoinCondition,
-        canPushDownJoin)
+      pushDownJoin(join, canPushDownPredicate, makeJoinCondition)
 
     // LeftSemi/LeftAnti over Window
     case join @ Join(w: Window, rightOp, LeftSemiOrAnti(_), _, _)
@@ -146,17 +133,11 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
   private def pushDownJoin(
       join: Join,
       canPushDownPredicate: Expression => Boolean,
-      makeJoinCondition: Seq[Expression] => Expression,
-      canPushDownJoin: Join => Boolean = _ => true): LogicalPlan = {
+      makeJoinCondition: Seq[Expression] => Expression): LogicalPlan = {
     assert(join.left.children.length == 1)
 
     if (join.condition.isEmpty) {
-      val pushedJoin = join.copy(left = join.left.children.head)
-      if (canPushDownJoin(pushedJoin)) {
-        join.left.withNewChildren(Seq(pushedJoin))
-      } else {
-        join
-      }
+      join.left.withNewChildren(Seq(join.copy(left = join.left.children.head)))
     } else {
       val (pushDown, stayUp) = splitConjunctivePredicates(join.condition.get)
         .partition(canPushDownPredicate)
@@ -170,25 +151,19 @@ object PushDownLeftSemiAntiJoin extends Rule[LogicalPlan]
       if (pushDown.isEmpty || referRightSideCols)  {
         join
       } else {
-        val pushedJoin = join.copy(
-          left = join.left.children.head, condition = Some(makeJoinCondition(pushDown)))
-        if (!canPushDownJoin(pushedJoin)) {
-          join
+        val newPlan = join.left.withNewChildren(Seq(join.copy(
+          left = join.left.children.head, condition = Some(makeJoinCondition(pushDown)))))
+        // If there is no more filter to stay up, return the new plan that has join pushed down.
+        if (stayUp.isEmpty) {
+          newPlan
         } else {
-          val newPlan = join.left.withNewChildren(Seq(pushedJoin))
-          // If no predicates remain above the join, return the plan with the join pushed down.
-          if (stayUp.isEmpty) {
-            newPlan
-          } else {
-            join.joinType match {
-              // For a left semi join, the non-pushable part of the condition is kept as a Filter
-              // above the join.
-              case LeftSemi => Filter(stayUp.reduce(And), newPlan)
-              // In the case of a left anti join, the join is pushed down only when the entire join
-              // condition is eligible to be pushed down to preserve the semantics of the left anti
-              // join.
-              case _ => join
-            }
+          join.joinType match {
+            // In case of Left semi join, the part of the join condition which does not refer to
+            // to attributes of the grandchild are kept as a Filter above.
+            case LeftSemi => Filter(stayUp.reduce(And), newPlan)
+            // In case of left-anti join, the join is pushed down only when the entire join
+            // condition is eligible to be pushed down to preserve the semantics of left-anti join.
+            case _ => join
           }
         }
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -438,12 +438,15 @@ trait JoinSelectionHelper extends Logging {
       getBroadcastBuildSide(join, hintOnly = true, conf).orElse {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
-    // `JoinSelection` always builds from the right for this shape. Its dedicated threshold
-    // defaults to Long.MaxValue to preserve the original NAAJ planning behavior.
-    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
-        if j.right.stats.sizeInBytes >= 0 &&
-          j.right.stats.sizeInBytes <= conf.nullAwareAntiJoinBroadcastThreshold =>
-      Some(BuildRight)
+    // `JoinSelection` always builds from the right for this shape. A negative threshold preserves
+    // the original unbounded NAAJ behavior, while zero disables the broadcast hash optimization.
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _) =>
+      val threshold = conf.nullAwareAntiJoinBroadcastThreshold
+      if (threshold < 0 || (threshold > 0 && j.right.stats.sizeInBytes <= threshold)) {
+        Some(BuildRight)
+      } else {
+        None
+      }
     case _ => None
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -353,66 +353,6 @@ trait JoinSelectionHelper extends Logging {
     }
   }
 
-  def getBroadcastNestedLoopJoinDesiredBuildSide(join: Join): BuildSide = {
-    if (join.joinType.isInstanceOf[InnerLike] || join.joinType == FullOuter) {
-      getSmallerSide(join.left, join.right)
-    } else {
-      // For perf reasons, BroadcastNestedLoopJoinExec prefers to broadcast the left side for a
-      // right join and the right side for a left join. If one side is much smaller, revisiting
-      // that preference may be worthwhile.
-      if (canBuildBroadcastLeft(join.joinType)) BuildLeft else BuildRight
-    }
-  }
-
-  def getBroadcastNestedLoopJoinBuildSide(
-      join: Join,
-      hintOnly: Boolean,
-      conf: SQLConf): Option[BuildSide] = {
-    lazy val buildLeft = if (hintOnly) {
-      hintToBroadcastLeft(join.hint)
-    } else {
-      canBroadcastBySize(join.left, conf) &&
-        !hintToNotBroadcastAndReplicateLeft(join.hint)
-    }
-    lazy val buildRight = if (hintOnly) {
-      hintToBroadcastRight(join.hint)
-    } else {
-      canBroadcastBySize(join.right, conf) &&
-        !hintToNotBroadcastAndReplicateRight(join.hint)
-    }
-
-    if (join.joinType.isInstanceOf[InnerLike] || join.joinType == FullOuter) {
-      if (buildLeft && buildRight) {
-        Some(getBroadcastNestedLoopJoinDesiredBuildSide(join))
-      } else if (buildLeft) {
-        Some(BuildLeft)
-      } else if (buildRight) {
-        Some(BuildRight)
-      } else {
-        None
-      }
-    } else {
-      getBroadcastNestedLoopJoinDesiredBuildSide(join) match {
-        case BuildLeft =>
-          if (buildLeft) Some(BuildLeft) else if (buildRight) Some(BuildRight) else None
-        case BuildRight =>
-          if (buildRight) Some(BuildRight) else if (buildLeft) Some(BuildLeft) else None
-      }
-    }
-  }
-
-  def getBroadcastNestedLoopJoinBuildSide(join: Join, conf: SQLConf): BuildSide = {
-    val hintedBuildSide = if (join.hint.isEmpty) {
-      None
-    } else {
-      getBroadcastNestedLoopJoinBuildSide(join, hintOnly = true, conf)
-    }
-    hintedBuildSide
-      .orElse(getBroadcastNestedLoopJoinBuildSide(join, hintOnly = false, conf))
-      .orElse(getBroadcastNestedLoopJoinBuildSide(join.hint, join.joinType))
-      .getOrElse(getBroadcastNestedLoopJoinDesiredBuildSide(join))
-  }
-
   def getSmallerSide(left: LogicalPlan, right: LogicalPlan): BuildSide = {
     if (right.stats.sizeInBytes <= left.stats.sizeInBytes) BuildRight else BuildLeft
   }
@@ -498,13 +438,12 @@ trait JoinSelectionHelper extends Logging {
       getBroadcastBuildSide(join, hintOnly = true, conf).orElse {
         if (noShufflePlannedBefore) getBroadcastBuildSide(join, hintOnly = false, conf) else None
       }
-    case j if ExtractSingleColumnNullAwareAntiJoin.extract(j).isDefined =>
-      if (NullAwareAntiJoinPlanning.decide(j, conf) ==
-          NullAwareAntiJoinPlanning.BroadcastHash) {
-        Some(BuildRight)
-      } else {
-        None
-      }
+    // `JoinSelection` always builds from the right for this shape. Its dedicated threshold
+    // defaults to Long.MaxValue to preserve the original NAAJ planning behavior.
+    case j @ ExtractSingleColumnNullAwareAntiJoin(_, _)
+        if j.right.stats.sizeInBytes >= 0 &&
+          j.right.stats.sizeInBytes <= conf.nullAwareAntiJoinBroadcastThreshold =>
+      Some(BuildRight)
     case _ => None
   }
 
@@ -626,21 +565,5 @@ trait JoinSelectionHelper extends Logging {
   private def forceApplyShuffledHashJoin(conf: SQLConf): Boolean = {
     Utils.isTesting &&
       conf.getConfString("spark.sql.join.forceApplyShuffledHashJoin", "false") == "true"
-  }
-}
-
-private[sql] object NullAwareAntiJoinPlanning extends JoinSelectionHelper {
-  sealed trait Decision
-  case object BroadcastHash extends Decision
-  case object BroadcastNestedLoop extends Decision
-
-  def decide(join: Join, conf: SQLConf): Decision = {
-    if (conf.optimizeNullAwareAntiJoin &&
-        canBroadcastBySize(join.right, conf) &&
-        getBroadcastNestedLoopJoinBuildSide(join, conf) == BuildRight) {
-      BroadcastHash
-    } else {
-      BroadcastNestedLoop
-    }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/planning/patterns.scala
@@ -404,11 +404,12 @@ object ExtractSingleColumnNullAwareAntiJoin extends JoinSelectionHelper with Pre
    * But if it's a single column case O(M*N) calculation could be optimized into O(M)
    * using hash lookup instead of loop lookup.
    */
-  private[sql] def extract(join: Join): Option[ReturnType] = join match {
+  def unapply(join: Join): Option[ReturnType] = join match {
     case Join(left, right, LeftAnti,
       Some(Or(e @ EqualTo(leftAttr: Expression, rightAttr: Expression),
         IsNull(e2 @ EqualTo(_, _)))), _)
-        if e.semanticEquals(e2) =>
+        if SQLConf.get.optimizeNullAwareAntiJoin &&
+          e.semanticEquals(e2) =>
       if (canEvaluate(leftAttr, left) && canEvaluate(rightAttr, right)) {
         Some(Seq(leftAttr), Seq(rightAttr))
       } else if (canEvaluate(leftAttr, right) && canEvaluate(rightAttr, left)) {
@@ -417,10 +418,6 @@ object ExtractSingleColumnNullAwareAntiJoin extends JoinSelectionHelper with Pre
         None
       }
     case _ => None
-  }
-
-  def unapply(join: Join): Option[ReturnType] = {
-    if (SQLConf.get.optimizeNullAwareAntiJoin) extract(join) else None
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7383,7 +7383,7 @@ object SQLConf {
         "optimization. If the estimated size exceeds this value, Spark falls back to regular " +
         "join planning. The fallback may still use a broadcast nested loop join. By setting " +
         "this value to -1, the broadcast hash join optimization can be disabled.")
-      .version("5.0.0")
+      .version("4.2.1")
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(Long.MaxValue)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7366,11 +7366,12 @@ object SQLConf {
   val OPTIMIZE_NULL_AWARE_ANTI_JOIN =
     buildConf("spark.sql.optimizeNullAwareAntiJoin")
       .internal()
-      .doc("When true, NULL-aware anti join execution will be planed into " +
+      .doc("When true, NULL-aware anti join execution can be planned as " +
         "BroadcastHashJoinExec with flag isNullAwareAntiJoin enabled, " +
         "optimized from O(M*N) calculation into O(M) calculation " +
         "using Hash lookup instead of Looping lookup. " +
-        "Only support for singleColumn NAAJ for now.")
+        "Only support for singleColumn NAAJ for now. The optimization is also controlled by " +
+        "spark.sql.nullAwareAntiJoinBroadcastThreshold.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
@@ -7380,13 +7381,18 @@ object SQLConf {
       .internal()
       .doc("Configures the maximum estimated size in bytes of the right side of a " +
         "single-column null-aware anti join for which Spark uses the broadcast hash join " +
-        "optimization. If the estimated size exceeds this value, Spark falls back to regular " +
-        "join planning. The fallback may still use a broadcast nested loop join. By setting " +
-        "this value to -1, the broadcast hash join optimization can be disabled.")
+        "optimization. This configuration takes effect only when " +
+        "spark.sql.optimizeNullAwareAntiJoin is enabled. A negative value allows the " +
+        "optimization regardless of the estimated size, while zero disables it. If the " +
+        "estimated size exceeds a positive value, Spark falls back to regular join planning. " +
+        "The fallback may still broadcast the right side with a nested-loop representation " +
+        "that uses more memory and runs in O(M * N) time. Join hints do not override this " +
+        "configuration when the broadcast hash optimization is selected. This configuration " +
+        "also controls whether a null-aware anti join can be pushed below an aggregate.")
       .version("4.2.1")
       .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .bytesConf(ByteUnit.BYTE)
-      .createWithDefault(Long.MaxValue)
+      .createWithDefault(-1)
 
   val LEGACY_DUPLICATE_BETWEEN_INPUT =
     buildConf("spark.sql.legacy.duplicateBetweenInput")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7375,6 +7375,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD =
+    buildConf("spark.sql.nullAwareAntiJoinBroadcastThreshold")
+      .internal()
+      .doc("Configures the maximum estimated size in bytes of the right side of a " +
+        "single-column null-aware anti join for which Spark uses the broadcast hash join " +
+        "optimization. If the estimated size exceeds this value, Spark falls back to regular " +
+        "join planning. The fallback may still use a broadcast nested loop join. By setting " +
+        "this value to -1, the broadcast hash join optimization can be disabled.")
+      .version("5.0.0")
+      .bytesConf(ByteUnit.BYTE)
+      .createWithDefault(Long.MaxValue)
+
   val LEGACY_DUPLICATE_BETWEEN_INPUT =
     buildConf("spark.sql.legacy.duplicateBetweenInput")
       .internal()
@@ -9742,6 +9754,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def optimizeNullAwareAntiJoin: Boolean =
     getConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN)
+
+  def nullAwareAntiJoinBroadcastThreshold: Long =
+    getConf(SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD)
 
   def legacyDuplicateBetweenInput: Boolean =
     getConf(SQLConf.LEGACY_DUPLICATE_BETWEEN_INPUT)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7384,6 +7384,7 @@ object SQLConf {
         "join planning. The fallback may still use a broadcast nested loop join. By setting " +
         "this value to -1, the broadcast hash join optimization can be disabled.")
       .version("4.2.1")
+      .withBindingPolicy(ConfigBindingPolicy.NOT_APPLICABLE)
       .bytesConf(ByteUnit.BYTE)
       .createWithDefault(Long.MaxValue)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -7371,13 +7371,13 @@ object SQLConf {
         "optimized from O(M*N) calculation into O(M) calculation " +
         "using Hash lookup instead of Looping lookup. " +
         "Only support for singleColumn NAAJ for now. The optimization is also controlled by " +
-        "spark.sql.nullAwareAntiJoinBroadcastThreshold.")
+        "spark.sql.optimizeNullAwareAntiJoin.broadcastThreshold.")
       .version("3.1.0")
       .booleanConf
       .createWithDefault(true)
 
   val NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD =
-    buildConf("spark.sql.nullAwareAntiJoinBroadcastThreshold")
+    buildConf("spark.sql.optimizeNullAwareAntiJoin.broadcastThreshold")
       .internal()
       .doc("Configures the maximum estimated size in bytes of the right side of a " +
         "single-column null-aware anti join for which Spark uses the broadcast hash join " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -17,25 +17,14 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, EqualTo, IsNull, Or}
-import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest, RightOuter}
-import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, LeafNode, NO_BROADCAST_HASH, SHUFFLE_HASH, Statistics}
+import org.apache.spark.sql.catalyst.expressions.{AttributeMap, EqualTo, IsNull, Or}
+import org.apache.spark.sql.catalyst.plans.{Inner, LeftAnti, PlanTest}
+import org.apache.spark.sql.catalyst.plans.logical.{BROADCAST, HintInfo, Join, JoinHint, NO_BROADCAST_HASH, SHUFFLE_HASH}
 import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
 
 class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
-
-  private case class TrackingStatsTestPlan(
-      override val output: Seq[Attribute],
-      statsAccessed: AtomicBoolean) extends LeafNode {
-    override def computeStats(): Statistics = {
-      statsAccessed.set(true)
-      Statistics(sizeInBytes = 20000000)
-    }
-  }
 
   private val left = StatsTestPlan(
     outputList = Seq($"a".int, $"b".int, $"c".int),
@@ -160,71 +149,10 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     assert(getSmallerSide(left, right) === BuildRight)
   }
 
-  test("getBroadcastNestedLoopJoinBuildSide checks the fixed desired side first") {
-    val leftStatsAccessed = new AtomicBoolean(false)
-    val uncachedLeft = TrackingStatsTestPlan(Seq($"uncachedLeft".int), leftStatsAccessed)
-    val leftAntiJoin = Join(uncachedLeft, right, LeftAnti, None, JoinHint.NONE)
-    val rightStatsAccessed = new AtomicBoolean(false)
-    val uncachedRight = TrackingStatsTestPlan(Seq($"uncachedRight".int), rightStatsAccessed)
-    val rightOuterJoin = Join(right, uncachedRight, RightOuter, None, JoinHint.NONE)
-
-    withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(getBroadcastNestedLoopJoinBuildSide(leftAntiJoin, SQLConf.get) === BuildRight)
-      assert(!leftStatsAccessed.get())
-      assert(getBroadcastNestedLoopJoinBuildSide(rightOuterJoin, SQLConf.get) === BuildLeft)
-      assert(!rightStatsAccessed.get())
-    }
-  }
-
   test("canBroadcastBySize should return true if the plan size is less than 10MB") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(canBroadcastBySize(left, SQLConf.get) === false)
       assert(canBroadcastBySize(right, SQLConf.get) === true)
-    }
-  }
-
-  test("canPlanAsBroadcastHashJoin should respect NAAJ size and nested-loop build side") {
-    val leftKey = left.output.head
-    val rightKey = right.output.head
-    val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
-    val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
-    val smallLeft = left.copy(rowCount = 1000, size = Some(1000))
-    val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
-
-    withSQLConf(
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
-      assert(!canPlanAsBroadcastHashJoin(
-        nullAwareAntiJoin.copy(right = largeRight.copy(rowCount = 1)), SQLConf.get))
-      assert(!canPlanAsBroadcastHashJoin(
-        nullAwareAntiJoin.copy(left = smallLeft, right = largeRight), SQLConf.get))
-      assert(!canPlanAsBroadcastHashJoin(
-        nullAwareAntiJoin.copy(hint = JoinHint(hintBroadcast, None)), SQLConf.get))
-    }
-
-    withSQLConf(
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(!canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
-    }
-  }
-
-  test("canPlanAsBroadcastHashJoin checks the NAAJ right-size short circuit") {
-    val leftStatsAccessed = new AtomicBoolean(false)
-    val uncachedLeft = TrackingStatsTestPlan(Seq($"uncachedLeft".int), leftStatsAccessed)
-    val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
-    val leftKey = uncachedLeft.output.head
-    val rightKey = largeRight.output.head
-    val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
-    val nullAwareAntiJoin = Join(
-      uncachedLeft, largeRight, LeftAnti, Some(condition), JoinHint.NONE)
-
-    withSQLConf(
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
-      assert(!canPlanAsBroadcastHashJoin(nullAwareAntiJoin, SQLConf.get))
-      assert(!leftStatsAccessed.get())
     }
   }
 
@@ -267,17 +195,25 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     }
   }
 
-  test("getBroadcastHashJoinBuildSide builds from the right for a null-aware anti join") {
+  test("getBroadcastHashJoinBuildSide uses the null-aware anti join broadcast threshold") {
     val leftKey = left.output.head
     val rightKey = right.output.head
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
     val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
+    val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
 
     withSQLConf(
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
       SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "10MB") {
       assert(getBroadcastHashJoinBuildSide(nullAwareAntiJoin, SQLConf.get) === Some(BuildRight))
+      assert(getBroadcastHashJoinBuildSide(
+        nullAwareAntiJoin.copy(right = largeRight), SQLConf.get) === Some(BuildRight))
+    }
+
+    withSQLConf(SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "10MB") {
+      assert(getBroadcastHashJoinBuildSide(nullAwareAntiJoin, SQLConf.get) === Some(BuildRight))
+      assert(getBroadcastHashJoinBuildSide(
+        nullAwareAntiJoin.copy(right = largeRight), SQLConf.get).isEmpty)
     }
   }
-
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/JoinSelectionHelperSuite.scala
@@ -201,6 +201,9 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
     val condition = Or(EqualTo(leftKey, rightKey), IsNull(EqualTo(leftKey, rightKey)))
     val nullAwareAntiJoin = Join(left, right, LeftAnti, Some(condition), JoinHint.NONE)
     val largeRight = right.copy(rowCount = 20000000, size = Some(20000000))
+    val overLongMaxRight = right.copy(
+      rowCount = BigInt(Long.MaxValue) + 1,
+      size = Some(BigInt(Long.MaxValue) + 1))
 
     withSQLConf(
       SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
@@ -208,6 +211,23 @@ class JoinSelectionHelperSuite extends PlanTest with JoinSelectionHelper {
       assert(getBroadcastHashJoinBuildSide(nullAwareAntiJoin, SQLConf.get) === Some(BuildRight))
       assert(getBroadcastHashJoinBuildSide(
         nullAwareAntiJoin.copy(right = largeRight), SQLConf.get) === Some(BuildRight))
+      assert(getBroadcastHashJoinBuildSide(
+        nullAwareAntiJoin.copy(right = overLongMaxRight), SQLConf.get) === Some(BuildRight))
+    }
+
+    withSQLConf(SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "-2") {
+      assert(getBroadcastHashJoinBuildSide(
+        nullAwareAntiJoin.copy(right = overLongMaxRight), SQLConf.get) === Some(BuildRight))
+    }
+
+    withSQLConf(SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "0") {
+      assert(getBroadcastHashJoinBuildSide(nullAwareAntiJoin, SQLConf.get).isEmpty)
+    }
+
+    withSQLConf(
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
+      SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "-1") {
+      assert(getBroadcastHashJoinBuildSide(nullAwareAntiJoin, SQLConf.get).isEmpty)
     }
 
     withSQLConf(SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "10MB") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LeftSemiAntiJoinPushDownSuite.scala
@@ -24,7 +24,6 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
-import org.apache.spark.sql.catalyst.statsEstimation.StatsTestPlan
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.IntegerType
 
@@ -108,66 +107,6 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
       .analyze
 
     comparePlans(optimized, correctAnswer)
-  }
-
-  test("Aggregate: NAAJ pushdown when original and rewritten joins can build right") {
-    val condition = Or($"b" === $"d", IsNull($"b" === $"d"))
-    val originalQuery = testRelation
-      .groupBy($"b")($"b", sum($"c"))
-      .join(testRelation1, joinType = LeftAnti, condition = Some(condition))
-    val correctAnswer = testRelation
-      .join(testRelation1, joinType = LeftAnti, condition = Some(condition))
-      .groupBy($"b")($"b", sum($"c"))
-
-    withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true") {
-      val analyzedOriginal = originalQuery.analyze
-      val analyzedCorrectAnswer = correctAnswer.analyze
-      val originalJoin = analyzedOriginal.asInstanceOf[Join]
-      val pushedJoin = analyzedCorrectAnswer.asInstanceOf[Aggregate].child.asInstanceOf[Join]
-      assert(PushDownLeftSemiAntiJoin.canPlanAsBroadcastHashJoin(originalJoin, SQLConf.get))
-      assert(PushDownLeftSemiAntiJoin.canPlanAsBroadcastHashJoin(pushedJoin, SQLConf.get))
-      comparePlans(Optimize.execute(analyzedOriginal), analyzedCorrectAnswer)
-    }
-  }
-
-  test("Aggregate: NAAJ no pushdown when the original join would build left") {
-    val leftKey = $"leftKey".int
-    val leftKeyStats = ColumnStat(
-      distinctCount = Some(1),
-      min = Some(0),
-      max = Some(0),
-      nullCount = Some(0),
-      avgLen = Some(4),
-      maxLen = Some(4))
-    val child = StatsTestPlan(
-      Seq(leftKey), 1000, AttributeMap(Seq(leftKey -> leftKeyStats)), Some(1000))
-    val aggregate = Aggregate(Seq(leftKey), Seq(leftKey), child)
-    val right = StatsTestPlan(
-      Seq($"rightKey".int), 1000, AttributeMap(Seq()), Some(1000))
-    val condition = Or(
-      EqualTo(aggregate.output.head, right.output.head),
-      IsNull(EqualTo(aggregate.output.head, right.output.head)))
-    val originalQuery = Join(
-      aggregate, right, LeftAnti, Some(condition), JoinHint.NONE)
-
-    withSQLConf(
-      SQLConf.CBO_ENABLED.key -> "true",
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "100") {
-      assert(aggregate.stats.sizeInBytes <= SQLConf.get.autoBroadcastJoinThreshold)
-      assert(child.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
-      assert(right.stats.sizeInBytes > SQLConf.get.autoBroadcastJoinThreshold)
-      comparePlans(Optimize.execute(originalQuery), originalQuery)
-    }
-  }
-
-  test("Aggregate: ordinary LeftSemi join no pushdown - empty join condition") {
-    val originalQuery = testRelation
-      .groupBy($"b")($"b", sum($"c"))
-      .join(testRelation1, joinType = LeftSemi, condition = None)
-    val correctAnswer = originalQuery.analyze
-
-    comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer)
   }
 
   test("Aggregate: LeftSemi join no pushdown - non-deterministic aggr expressions") {
@@ -521,7 +460,7 @@ class LeftSemiAntiJoinPushDownSuite extends PlanTest {
   }
 
   Seq(LeftSemi, LeftAnti).foreach { jt =>
-    test(s"SPARK-34081: ordinary $jt only pushes down when broadcast-eligible") {
+    test(s"SPARK-34081: $jt only push down if join can be planned as broadcast join") {
       Seq(-1, 100000).foreach { threshold =>
         withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
           val originalQuery = testRelation

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingPointNumbersSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{ArrayDistinct, ArrayExcept, ArrayIntersect, ArraysOverlap, ArrayTransform, ArrayUnion, CaseWhen, Expression, If, IsNull, KnownFloatingPointNormalized, LambdaFunction, NamedLambdaVariable}
-import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.{LeftAnti, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 import org.apache.spark.sql.types.DoubleType
@@ -88,6 +88,23 @@ class NormalizeFloatingPointNumbersSuite extends PlanTest {
     val joinCond = Some(KnownFloatingPointNormalized(NormalizeNaNAndZero(a))
       === KnownFloatingPointNormalized(NormalizeNaNAndZero(b)))
     val correctAnswer = testRelation1.join(testRelation2, condition = joinCond)
+
+    comparePlans(doubleOptimized, correctAnswer)
+  }
+
+  test("normalize floating points in null-aware anti join keys") {
+    val equality = a === b
+    val query = testRelation1.join(
+      testRelation2, joinType = LeftAnti, condition = Some(equality || IsNull(equality)))
+
+    val optimized = Optimize.execute(query)
+    val doubleOptimized = Optimize.execute(optimized)
+    val normalizedEquality = KnownFloatingPointNormalized(NormalizeNaNAndZero(a)) ===
+      KnownFloatingPointNormalized(NormalizeNaNAndZero(b))
+    val correctAnswer = testRelation1.join(
+      testRelation2,
+      joinType = LeftAnti,
+      condition = Some(normalizedEquality || IsNull(normalizedEquality)))
 
     comparePlans(doubleOptimized, correctAnswer)
   }
@@ -249,4 +266,3 @@ class NormalizeFloatingPointNumbersSuite extends PlanTest {
     comparePlans(doubleOptimized, correctAnswer)
   }
 }
-

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{EliminateSubqueryAliases, NamedRelation}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions._
-import org.apache.spark.sql.catalyst.optimizer.{BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers, NullAwareAntiJoinPlanning}
+import org.apache.spark.sql.catalyst.optimizer.{BuildLeft, BuildRight, BuildSide, JoinSelectionHelper, NormalizeFloatingNumbers}
 import org.apache.spark.sql.catalyst.planning._
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -340,18 +340,10 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             .getOrElse(createJoinWithoutHint())
         }
 
-      case j: logical.Join if ExtractSingleColumnNullAwareAntiJoin.extract(j).isDefined =>
-        val (leftKeys, rightKeys) = ExtractSingleColumnNullAwareAntiJoin.extract(j).get
-        NullAwareAntiJoinPlanning.decide(j, conf) match {
-          case NullAwareAntiJoinPlanning.BroadcastHash =>
-            Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
-              None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
-          case NullAwareAntiJoinPlanning.BroadcastNestedLoop =>
-            checkHintNonEquiJoin(j.hint)
-            val buildSide = getBroadcastNestedLoopJoinBuildSide(j, conf)
-            Seq(joins.BroadcastNestedLoopJoinExec(
-              planLater(j.left), planLater(j.right), buildSide, LeftAnti, j.condition))
-        }
+      case j @ ExtractSingleColumnNullAwareAntiJoin(leftKeys, rightKeys)
+          if canPlanAsBroadcastHashJoin(j, conf) =>
+        Seq(joins.BroadcastHashJoinExec(leftKeys, rightKeys, LeftAnti, BuildRight,
+          None, planLater(j.left), planLater(j.right), isNullAwareAntiJoin = true))
 
       // If it is not an equi-join, we first look at the join hints w.r.t. the following order:
       //   1. broadcast hint: pick broadcast nested loop join. If both sides have the broadcast
@@ -369,12 +361,42 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
       //   3. Pick broadcast nested loop join as the final solution. It may OOM but we don't have
       //      other choice. It broadcasts the smaller side for inner and full joins, broadcasts the
       //      left side for right join, and broadcasts right side for left join.
-      case j @ logical.Join(left, right, joinType, condition, hint) =>
+      case logical.Join(left, right, joinType, condition, hint) =>
         checkHintNonEquiJoin(hint)
-        val desiredBuildSide = getBroadcastNestedLoopJoinDesiredBuildSide(j)
+        val desiredBuildSide = if (joinType.isInstanceOf[InnerLike] || joinType == FullOuter) {
+          getSmallerSide(left, right)
+        } else {
+          // For perf reasons, `BroadcastNestedLoopJoinExec` prefers to broadcast left side if
+          // it's a right join, and broadcast right side if it's a left join.
+          // TODO: revisit it. If left side is much smaller than the right side, it may be better
+          // to broadcast the left side even if it's a left join.
+          if (canBuildBroadcastLeft(joinType)) BuildLeft else BuildRight
+        }
 
         def createBroadcastNLJoin(onlyLookingAtHint: Boolean) = {
-          getBroadcastNestedLoopJoinBuildSide(j, onlyLookingAtHint, conf).map { buildSide =>
+          val buildLeft = if (onlyLookingAtHint) {
+            hintToBroadcastLeft(hint)
+          } else {
+            canBroadcastBySize(left, conf) && !hintToNotBroadcastAndReplicateLeft(hint)
+          }
+
+          val buildRight = if (onlyLookingAtHint) {
+            hintToBroadcastRight(hint)
+          } else {
+            canBroadcastBySize(right, conf) && !hintToNotBroadcastAndReplicateRight(hint)
+          }
+
+          val maybeBuildSide = if (buildLeft && buildRight) {
+            Some(desiredBuildSide)
+          } else if (buildLeft) {
+            Some(BuildLeft)
+          } else if (buildRight) {
+            Some(BuildRight)
+          } else {
+            None
+          }
+
+          maybeBuildSide.map { buildSide =>
             Seq(joins.BroadcastNestedLoopJoinExec(
               planLater(left), planLater(right), buildSide, joinType, condition))
           }

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1308,6 +1308,90 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
+  test("SPARK-36082: left-broadcast NAAJ fallback uses nested-loop join") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString,
+      SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "0") {
+      withTempView("naajHintedLeft", "naajHintedRight") {
+        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
+          .createOrReplaceTempView("naajHintedLeft")
+        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
+          .createOrReplaceTempView("naajHintedRight")
+
+        val result = sql(
+          "select /*+ BROADCAST(naajHintedLeft) */ naajHintedLeft.* " +
+            "from naajHintedLeft left anti join naajHintedRight on " +
+            "naajHintedLeft.key = naajHintedRight.key or " +
+            "isnull(naajHintedLeft.key = naajHintedRight.key)")
+        val plan = result.queryExecution.sparkPlan
+        val nestedLoopJoins = plan.collect {
+          case join: BroadcastNestedLoopJoinExec => join
+        }
+        val nullAwareHashJoins = plan.collect {
+          case join: BroadcastHashJoinExec if join.isNullAwareAntiJoin => join
+        }
+        assert(nestedLoopJoins.size === 1)
+        assert(nestedLoopJoins.head.buildSide === BuildLeft)
+        assert(nullAwareHashJoins.isEmpty)
+        checkAnswer(result, Row(2.0d))
+      }
+    }
+  }
+
+  test("SPARK-36082: threshold-disabled NAAJ preserves floating-point equality") {
+    withSQLConf(
+      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0",
+      SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> "0") {
+      withTempView("naajFloatingLeft", "naajFloatingRight") {
+        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
+          .createOrReplaceTempView("naajFloatingLeft")
+        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
+          .createOrReplaceTempView("naajFloatingRight")
+
+        val result = sql(
+          "select * from naajFloatingLeft " +
+            "where key not in (select key from naajFloatingRight)")
+        val joinExec = result.queryExecution.sparkPlan.collect {
+          case join: BroadcastNestedLoopJoinExec => join
+        }
+        assert(joinExec.size === 1)
+        assert(joinExec.head.buildSide === BuildRight)
+        checkAnswer(result, Row(2.0d))
+      }
+    }
+  }
+
+  test("SPARK-36082: NAAJ hash join preserves floating-point equality") {
+    Seq(false, true).foreach { adaptiveEnabled =>
+      Seq(false, true).foreach { codegenEnabled =>
+        withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> adaptiveEnabled.toString,
+          SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> codegenEnabled.toString,
+          SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+          SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
+          withTempView("naajHashLeft", "naajHashRight") {
+            Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
+              .createOrReplaceTempView("naajHashLeft")
+            Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
+              .createOrReplaceTempView("naajHashRight")
+
+            val result = sql(
+              "select * from naajHashLeft where key not in (select key from naajHashRight)")
+            val joinExec = result.queryExecution.sparkPlan.collect {
+              case join: BroadcastHashJoinExec if join.isNullAwareAntiJoin => join
+            }
+            assert(joinExec.size === 1)
+            checkAnswer(result, Row(2.0d))
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-54972: Improve not in subqueries with non-nullable columns") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // testData.key nullable false

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1282,6 +1282,32 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
     }
   }
 
+  test("SPARK-36082: NAAJ broadcast threshold enables a build-left fallback") {
+    val smallLeft = spark.range(1).selectExpr("id AS key")
+    val largeRight = spark.range(100)
+      .selectExpr("IF(id = 0, CAST(NULL AS BIGINT), id) AS key")
+    val threshold = statisticSizeInByte(smallLeft)
+    assert(threshold < statisticSizeInByte(largeRight))
+
+    withTempView("naajSmallLeft", "naajLargeRight") {
+      smallLeft.createOrReplaceTempView("naajSmallLeft")
+      largeRight.createOrReplaceTempView("naajLargeRight")
+      withSQLConf(
+        SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
+        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString,
+        SQLConf.NULL_AWARE_ANTI_JOIN_BROADCAST_THRESHOLD.key -> threshold.toString) {
+        val result = sql(
+          "SELECT * FROM naajSmallLeft WHERE key NOT IN (SELECT key FROM naajLargeRight)")
+        val joinExec = result.queryExecution.sparkPlan.collect {
+          case join: BroadcastNestedLoopJoinExec => join
+        }
+        assert(joinExec.size === 1)
+        assert(joinExec.head.buildSide === BuildLeft)
+        checkAnswer(result, Seq.empty)
+      }
+    }
+  }
+
   test("SPARK-54972: Improve not in subqueries with non-nullable columns") {
     withSQLConf(SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
       // testData.key nullable false
@@ -1296,117 +1322,6 @@ class JoinSuite extends SharedSparkSession with AdaptiveSparkPlanHelper
         "select * from testData where (key, key + 1) not in (select * from testData2)",
         classOf[BroadcastHashJoinExec]))
       assert(!joinExec2.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-    }
-  }
-
-  test("SPARK-36082: keep in-threshold NAAJ hash join when the fallback builds right") {
-    withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
-      val joinExec = assertJoin((
-        "select * from testData where key not in (select b from testData3)",
-        classOf[BroadcastHashJoinExec]))
-      assert(joinExec.asInstanceOf[BroadcastHashJoinExec].isNullAwareAntiJoin)
-    }
-  }
-
-  test("SPARK-36082: disabled NAAJ hash optimization uses nested-loop fallback") {
-    withSQLConf(
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "false",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
-      val joinExec = assertJoin((
-        "select * from testData where key not in (select b from testData3)",
-        classOf[BroadcastNestedLoopJoinExec]))
-      assert(joinExec.asInstanceOf[BroadcastNestedLoopJoinExec].buildSide === BuildRight)
-    }
-  }
-
-  test("SPARK-36082: keep over-threshold NAAJ nested-loop join when fallback builds right") {
-    withSQLConf(SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      val joinExec = assertJoin((
-        "select * from testData where key not in (select b from testData3)",
-        classOf[BroadcastNestedLoopJoinExec]))
-      assert(joinExec.asInstanceOf[BroadcastNestedLoopJoinExec].buildSide === BuildRight)
-    }
-  }
-
-  test("SPARK-36082: keep NAAJ nested-loop join when the fallback builds left") {
-    val smallLeft = spark.range(1).selectExpr("id AS key")
-    val largeRight = spark.range(100)
-      .selectExpr("IF(id = 0, CAST(NULL AS BIGINT), id) AS b")
-    val threshold = statisticSizeInByte(smallLeft)
-    assert(threshold < statisticSizeInByte(largeRight))
-
-    withTempView("naajSmallLeft", "naajLargeRight") {
-      smallLeft.createOrReplaceTempView("naajSmallLeft")
-      largeRight.createOrReplaceTempView("naajLargeRight")
-      withSQLConf(
-        SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-        SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> threshold.toString) {
-        val result = sql(
-          "select * from naajSmallLeft where key not in (select b from naajLargeRight)")
-        val joinExec = result.queryExecution.sparkPlan.collect {
-          case j: BroadcastNestedLoopJoinExec => j
-        }
-        assert(joinExec.size === 1)
-        assert(joinExec.head.buildSide === BuildLeft)
-        checkAnswer(result, Seq.empty)
-      }
-    }
-  }
-
-  test("SPARK-36082: left-broadcast NAAJ fallback uses nested-loop join") {
-    withSQLConf(
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> Long.MaxValue.toString) {
-      withTempView("naajHintedLeft", "naajHintedRight") {
-        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
-          .createOrReplaceTempView("naajHintedLeft")
-        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
-          .createOrReplaceTempView("naajHintedRight")
-
-        val result = sql(
-          "select /*+ BROADCAST(naajHintedLeft) */ naajHintedLeft.* " +
-            "from naajHintedLeft left anti join naajHintedRight on " +
-            "naajHintedLeft.key = naajHintedRight.key or " +
-            "isnull(naajHintedLeft.key = naajHintedRight.key)")
-        val plan = result.queryExecution.sparkPlan
-        val nestedLoopJoins = plan.collect {
-          case join: BroadcastNestedLoopJoinExec => join
-        }
-        val nullAwareHashJoins = plan.collect {
-          case join: BroadcastHashJoinExec if join.isNullAwareAntiJoin => join
-        }
-        assert(nestedLoopJoins.size === 1)
-        assert(nestedLoopJoins.head.buildSide === BuildLeft)
-        assert(nullAwareHashJoins.isEmpty)
-        checkAnswer(result, Row(2.0d))
-      }
-    }
-  }
-
-  test("SPARK-36082: threshold-disabled NAAJ preserves floating-point equality") {
-    withSQLConf(
-      SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
-      SQLConf.OPTIMIZE_NULL_AWARE_ANTI_JOIN.key -> "true",
-      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "0") {
-      withTempView("naajFloatingLeft", "naajFloatingRight") {
-        Seq[java.lang.Double](-0.0d, 2.0d, null).toDF("key")
-          .createOrReplaceTempView("naajFloatingLeft")
-        Seq[java.lang.Double](0.0d, 1.0d).toDF("key")
-          .createOrReplaceTempView("naajFloatingRight")
-
-        val result = sql(
-          "select * from naajFloatingLeft " +
-            "where key not in (select key from naajFloatingRight)")
-        val joinExec = result.queryExecution.sparkPlan.collect {
-          case join: BroadcastNestedLoopJoinExec => join
-        }
-        assert(joinExec.size === 1)
-        assert(joinExec.head.buildSide === BuildRight)
-        checkAnswer(result, Row(2.0d))
-      }
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follows [#55678](https://github.com/apache/spark/pull/55678) and
[#58404](https://github.com/apache/spark/pull/58404).

It restores the original default planning behavior for optimized single-column null-aware anti
joins (NAAJs): Spark selects the specialized null-aware `BroadcastHashJoinExec`, builds the right
side, and does not consult `spark.sql.autoBroadcastJoinThreshold` or join hints.

It adds the internal `spark.sql.optimizeNullAwareAntiJoin.broadcastThreshold` configuration as an
explicit tuning option. The configuration takes effect only when
`spark.sql.optimizeNullAwareAntiJoin` is enabled and has these semantics:

- A negative value, including the default `-1`, allows the specialized hash optimization
  regardless of the estimated right-side size.
- Zero disables the specialized hash optimization.
- A positive value is the maximum estimated right-side size in bytes for the optimization.

When the hash optimization is skipped, Spark falls through to regular join planning. The threshold
also controls whether a NAAJ can be pushed below an aggregate. Join hints do not override the
threshold when the specialized hash optimization is selected; this matches the behavior before
#55678.

The PR also normalizes floating-point NAAJ keys. This fixes a pre-existing hash-key issue in which
SQL-equal values such as `-0.0` and `0.0` could produce different hash representations and an
incorrect NAAJ result.

The AQE broadcast-mode validation introduced in #55678 is retained. The PR removes the additional
NAAJ fallback decision and optimizer plumbing introduced in #58404.

### Why are the changes needed?

#55678 made the NAAJ hash optimization conditional on the general automatic broadcast threshold,
and #58404 added planning logic to preserve the exact nested-loop fallback and its build side.
However, the automatic broadcast threshold and plan statistics are cost-planning heuristics; they
do not prove that either input can be materialized and broadcast safely.

Spark does not have a shuffle-capable NAAJ implementation. When regular join planning chooses the
right side for the fallback, `BroadcastNestedLoopJoinExec` still broadcasts that same input as an
`Array[InternalRow]`, rather than as a compact `HashedRelation`, while changing hash lookup from
`O(M + N)` to nested-loop evaluation at `O(M * N)`. The fallback can therefore use more memory and
run much longer without eliminating the OOM risk.

When the right side exceeds a positive threshold, regular join planning may choose a build-left
nested-loop join if the left side is estimated to be broadcastable. This is only best-effort: the
estimate may be inaccurate, and the fallback may still OOM or run in `O(M * N)` time. A generally
scalable solution for large NAAJs still requires a non-broadcast implementation.

Using a negative unlimited sentinel also covers `BigInt` statistics greater than `Long.MaxValue`,
which no finite byte threshold can represent.

### Does this PR introduce _any_ user-facing change?

Yes. Compared with the current behavior, optimized single-column NAAJs use the null-aware broadcast
hash join by default even when the estimated right side exceeds
`spark.sql.autoBroadcastJoinThreshold`. This restores the behavior from before #55678.

Users who need the size-based fallback can set the internal
`spark.sql.optimizeNullAwareAntiJoin.broadcastThreshold` configuration to a positive byte size, or
set it to zero to disable the specialized hash optimization. The default is `-1`, meaning
unlimited.

The PR also fixes NAAJ equality for floating-point hash keys, including `-0.0` and `0.0`.

### How was this patch tested?

The following focused suites were run locally:

```
build/sbt \
  "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.JoinSelectionHelperSuite" \
  "catalyst/testOnly org.apache.spark.sql.catalyst.optimizer.NormalizeFloatingPointNumbersSuite" \
  "sql/testOnly org.apache.spark.sql.JoinSuite -- -z SPARK-36082"
```

All 41 tests passed: 18 in `JoinSelectionHelperSuite`, 19 in
`NormalizeFloatingPointNumbersSuite`, and 4 matching SPARK-36082 in `JoinSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
