### PR TITLE
[SPARK-59348][SQL] Rewrite match-all LIKE '%' to IsNotNull in predicates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicate.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.internal.LogKeys.{SQL_TEXT, UNSUPPORTED_EXPR}
-import org.apache.spark.sql.catalyst.expressions.{And, ArrayExists, ArrayFilter, CaseWhen, EqualNullSafe, Expression, If, In, InSet, LambdaFunction, Literal, MapFilter, Not, Or}
+import org.apache.spark.sql.catalyst.expressions.{And, ArrayExists, ArrayFilter, CaseWhen, EqualNullSafe, Expression, If, In, InSet, IsNotNull, LambdaFunction, Like, Literal, MapFilter, Not, Or}
 import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLiteral}
 import org.apache.spark.sql.catalyst.plans.logical.{DeleteAction, DeleteFromTable, Filter, InsertAction, InsertStarAction, Join, LogicalPlan, MergeAction, MergeIntoTable, ReplaceData, UpdateAction, UpdateStarAction, UpdateTable, WriteDelta}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreePattern.{INSET, NULL_LITERAL, TRUE_OR_FALSE_LITERAL}
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.catalyst.trees.TreePattern.{INSET, LIKE_FAMLIY, NULL_LITERAL, TRUE_OR_FALSE_LITERAL}
+import org.apache.spark.sql.types.{BooleanType, StringType}
 import org.apache.spark.util.Utils
 
 
@@ -53,7 +53,7 @@ import org.apache.spark.util.Utils
 object ReplaceNullWithFalseInPredicate extends Rule[LogicalPlan] {
 
   def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
-    _.containsAnyPattern(NULL_LITERAL, TRUE_OR_FALSE_LITERAL, INSET), ruleId) {
+    _.containsAnyPattern(NULL_LITERAL, TRUE_OR_FALSE_LITERAL, INSET, LIKE_FAMLIY), ruleId) {
     case f @ Filter(cond, _) => f.copy(condition = replaceNullWithFalse(cond))
     case j @ Join(_, _, _, Some(cond), _) => j.copy(condition = Some(replaceNullWithFalse(cond)))
     case rd @ ReplaceData(_, cond, _, _, _, groupFilterCond, _) =>
@@ -99,8 +99,9 @@ object ReplaceNullWithFalseInPredicate extends Rule[LogicalPlan] {
   }
 
   /**
-   * Recursively traverse the Boolean-type expression to replace
-   * `Literal(null, BooleanType)` with `FalseLiteral`, if possible.
+   * Recursively traverse the Boolean-type expression to replace, where possible,
+   * `Literal(null, BooleanType)` with `FalseLiteral` -- and, in the same null-as-false spirit
+   * within a predicate, a match-all `x LIKE '%'` with `IsNotNull(x)`.
    *
    * Note that `transformExpressionsDown` can not be used here as we must stop as soon as we hit
    * an expression that is not [[CaseWhen]], [[If]], [[And]], [[Or]] or
@@ -119,6 +120,14 @@ object ReplaceNullWithFalseInPredicate extends Rule[LogicalPlan] {
       FalseLiteral
     case Not(InSet(value, list)) if isNullLiteral(value) || list.contains(null) =>
       FalseLiteral
+
+    // `x LIKE '%'` (a pattern of only unescaped `%`) is true for any non-null value and null for
+    // null. In a predicate, null is treated as false, so it is equivalent to `IsNotNull(x)`,
+    // which is cheaper and can be pushed down. This case is reached only through null-preserving
+    // operators, so it never fires under `Not`, where the rewrite would be unsafe.
+    case Like(child, Literal(pattern, _: StringType), escapeChar)
+        if pattern != null && isMatchAllLikePattern(pattern.toString, escapeChar) =>
+      IsNotNull(child)
 
     case And(left, right) =>
       And(replaceNullWithFalse(left), replaceNullWithFalse(right))
@@ -166,4 +175,9 @@ object ReplaceNullWithFalseInPredicate extends Rule[LogicalPlan] {
     case Literal(null, _) => true
     case _ => false
   }
+
+  // A `LIKE` pattern that matches any non-null value: one or more `%` wildcards and nothing else.
+  // `%` must be an actual wildcard, so the escape character must not be `%`.
+  private def isMatchAllLikePattern(pattern: String, escapeChar: Char): Boolean =
+    escapeChar != '%' && pattern.nonEmpty && pattern.forall(_ == '%')
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -452,6 +452,49 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
     }
   }
 
+  test("rewrite match-all LIKE pattern to IsNotNull in predicate positions") {
+    val rel = LocalRelation($"s".string, $"i".int)
+    val right = LocalRelation($"d".int)
+
+    // A pattern of only `%` matches every non-null value, so in a predicate it is IsNotNull.
+    Seq("%", "%%", "%%%").foreach { p =>
+      comparePlans(
+        Optimize.execute(rel.where($"s".like(p)).analyze),
+        rel.where($"s".isNotNull).analyze)
+    }
+
+    // Through null-preserving operators (And/Or) and in a join condition.
+    comparePlans(
+      Optimize.execute(rel.where(($"i" > 1) && $"s".like("%")).analyze),
+      rel.where(($"i" > 1) && $"s".isNotNull).analyze)
+    comparePlans(
+      Optimize.execute(rel.where(($"i" > 1) || $"s".like("%")).analyze),
+      rel.where(($"i" > 1) || $"s".isNotNull).analyze)
+    comparePlans(
+      Optimize.execute(rel.join(right, Inner, Some($"s".like("%"))).analyze),
+      rel.join(right, Inner, Some($"s".isNotNull)).analyze)
+  }
+
+  test("do not rewrite LIKE when not a match-all pattern or not a predicate position") {
+    val rel = LocalRelation($"s".string, $"i".int)
+
+    // Not match-all: a prefix, the empty pattern, and `%` escaped to a literal.
+    Seq(rel.where($"s".like("a%")),
+        rel.where($"s".like("")),
+        rel.where($"s".like("%%", '%'))).foreach { p =>
+      val analyzed = p.analyze
+      comparePlans(Optimize.execute(analyzed), analyzed)
+    }
+
+    // `Not` flips null semantics, so the match-all LIKE under it must be left intact.
+    val notPlan = rel.where(Not($"s".like("%"))).analyze
+    comparePlans(Optimize.execute(notPlan), notPlan)
+
+    // A projection is not a null-rejecting position: null vs false would be observable.
+    val projPlan = rel.select($"s".like("%").as("f")).analyze
+    comparePlans(Optimize.execute(projPlan), projPlan)
+  }
+
   private def testFilter(originalCond: Expression, expectedCond: Expression): Unit = {
     test((rel, exp) => rel.where(exp), originalCond, expectedCond)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`col LIKE '%'` (a pattern of only unescaped `%`) matches every non-null value, so a filter
`WHERE col LIKE '%'` keeps exactly the non-null rows. Today Spark evaluates it as a per-row
regex (`.*`) and pushes nothing to the data source.

This PR rewrites such patterns, **in null-rejecting predicate positions**, to `IsNotNull(col)`:

```
Aggregate [count(1)]                    Aggregate [count(1)]
+- Filter (col LIKE '%')       ==>      +- Filter (isnotnull(col))
   +- Relation t                           +- Relation t
```

The rewrite is implemented in `ReplaceNullWithFalseInPredicate`, which already performs this
class of null-as-false simplification (cf. its existing `Not(In(...))`/`Not(InSet(...))`
handling). It fires only for a literal pattern of one or more `%` with the escape character not
being `%`; `LIKE ''`, prefixes, and `_` patterns are excluded. `LikeAll`/`LikeAny` are out of
scope.

### Why are the changes needed?

- `IsNotNull` is far cheaper than compiling and running a regex per row.
- `IsNotNull` pushes down: Parquet/ORC skip row groups via null-count statistics; the raw `LIKE`
  regex does not.
- If `col` is non-nullable, `IsNotNull(col)` then folds to `true` and downstream
  `PruneFilters`/`NullPropagation` drop the filter entirely.

The pattern shows up in practice from dynamically-generated SQL (e.g. an empty search box
becoming `LIKE '%'`).

**Correctness.** `col LIKE '%'` returns `true` for a non-null value and `null` for `null`,
whereas `IsNotNull(col)` returns `false` for `null`. They are equivalent only in null-rejecting
predicate positions, where `null` is treated as `false`. `ReplaceNullWithFalseInPredicate`
targets exactly those plan nodes (`Filter`, `Join` condition, `MergeIntoTable`,
`DeleteFromTable`, `UpdateTable`, `ReplaceData`, `WriteDelta`) and recurses only through
null-preserving operators (`And`, `Or`, `If`, `CaseWhen`), **not** into `Not` — so
`NOT (col LIKE '%')` and `col LIKE '%'` in a projection are left untouched, where `null` vs
`false` would be observable. No collation gate is needed: `'%'` matches every non-null value
under any collation.

### Does this PR introduce _any_ user-facing change?

No. Query results are identical; this is a performance improvement.

### How was this patch tested?

New tests in `ReplaceNullWithFalseInPredicateSuite`:
- Rewritten: `'%'`, `'%%'`, `'%%%'` -> `IsNotNull`; through `AND`/`OR`; in a join condition.
- Not rewritten: prefix `'a%'`, empty `''`, `%` escaped (`ESCAPE '%'`), under `NOT`, and in a
  projection (the null-vs-false safety boundary).

`build/sbt 'catalyst/testOnly *ReplaceNullWithFalseInPredicateSuite'` passes (36/36); scalastyle
clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
