### PR TITLE
[SPARK-59319][SQL][FOLLOWUP] Enforce restricted mode in the single-pass analyzer and avoid eager class loading for rejected calls

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -370,11 +370,16 @@ trait CheckAnalysis extends LookupCatalog with QueryErrorsBase with PlanToString
           "The TRANSFORM ... USING clause")
       case node =>
         node.expressions.foreach(checkExpression)
-        // The body of an analysis-only command (CTAS, `CACHE TABLE ... AS SELECT`,
-        // `CREATE`/`ALTER VIEW`) moves from `children` into `innerChildren` once the command is
-        // analyzed, so `foreach` (which follows `children`) would not otherwise reach it.
+        // `checkExpression` already descends into the node's subquery plans (via
+        // `SubqueryExpression`), which are also part of `innerChildren`. Recurse only into the
+        // inner plans that are not those subqueries -- the analyzed body of an analysis-only
+        // command (CTAS, `CACHE TABLE ... AS SELECT`, `CREATE`/`ALTER VIEW`) that moves from
+        // `children` into `innerChildren` once analyzed, which `foreach` (following `children`)
+        // would not otherwise reach. This keeps each subquery traversed exactly once, so
+        // validation stays linear instead of doubling at every nesting level.
+        val subqueryPlans = node.subqueries
         node.innerChildren.foreach {
-          case inner: LogicalPlan => checkPlan(inner)
+          case inner: LogicalPlan if !subqueryPlans.exists(_ eq inner) => checkPlan(inner)
           case _ =>
         }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HybridAnalyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/HybridAnalyzer.scala
@@ -64,7 +64,14 @@ class HybridAnalyzer(
   private val sampleRateGenerator = new Random()
 
   def apply(plan: LogicalPlan): LogicalPlan = {
+    // Restricted execution mode is enforced by `CheckAnalysis.checkRestrictedMode`, which runs
+    // only in the fixed-point analyzer. When it is enabled, always use the fixed-point analyzer so
+    // the gate cannot be bypassed by enabling the (internal, in-development) single-pass resolver,
+    // which does not run `checkAnalysis`. This routes to the same `resolveInFixedPoint` branch that
+    // runs by default when the single-pass resolver is disabled.
+    val restrictedMode = conf.restrictedModeEnabled
     val dualRun =
+      !restrictedMode &&
       conf.getConf(SQLConf.ANALYZER_DUAL_RUN_LEGACY_AND_SINGLE_PASS_RESOLVER) &&
       !conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED) &&
       !conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY) &&
@@ -72,9 +79,10 @@ class HybridAnalyzer(
       checkDualRunSampleRate()
 
     withTrackedAnalyzerBridgeState(dualRun) {
-      if (conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED)) {
+      if (!restrictedMode && conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED)) {
         resolveInSinglePass(plan)
-      } else if (conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY)) {
+      } else if (!restrictedMode &&
+          conf.getConf(SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY)) {
         resolveInSinglePassTentatively(plan)
       } else if (dualRun) {
         resolveInDualRun(plan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -88,6 +88,12 @@ case class CallMethodViaReflection(
       throw QueryCompilationErrors.wrongNumArgsError(
         toSQLId(prettyName), Seq("> 1"), children.length
       )
+    } else if (SQLConf.get.restrictedModeEnabled) {
+      // In restricted execution mode this call is rejected during analysis by
+      // `CheckAnalysis.checkRestrictedMode`. Skip resolving the referenced class here so a call
+      // that is going to be rejected never loads the class and runs its static initializer (which
+      // `classExists`/`findMethod` would otherwise trigger via `Utils.classForName`).
+      TypeCheckSuccess
     } else {
       val unexpectedParameter = children.zipWithIndex.collectFirst {
         case (e, 0) if !(e.dataType.isInstanceOf[StringType] && e.foldable) =>

--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RestrictedModeInitFixture.java
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/RestrictedModeInitFixture.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions;
+
+/**
+ * A test fixture for a {@code reflect} target whose class initializer has an observable side
+ * effect: it sets the {@link #INIT_PROPERTY} system property. A test can read that property to
+ * check whether this class was ever initialized without initializing it itself -- {@code classOf}
+ * and reading the compile-time constant {@link #INIT_PROPERTY} do not trigger initialization.
+ */
+public final class RestrictedModeInitFixture {
+
+  public static final String INIT_PROPERTY =
+      "spark.test.restrictedModeInitFixture.initialized";
+
+  static {
+    System.setProperty(INIT_PROPERTY, "true");
+  }
+
+  public static String touch() {
+    return "touched";
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/RestrictedModeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/RestrictedModeSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal, RestrictedModeInitFixture}
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, ScriptInputOutputSchema, ScriptTransformation}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.StringType
@@ -95,6 +95,30 @@ class RestrictedModeSuite extends AnalysisTest {
       // Analysis succeeds (no restricted-mode error) when the profile is off.
       analyzer.checkAnalysis(analyzer.execute(transformPlan))
     }
+  }
+
+  test("restricted mode rejects reflect without initializing the referenced class") {
+    // Resolving a reflect call type-checks it, which loads the referenced class (running its
+    // static initializer -- arbitrary code) via `Utils.classForName`. When the call is going to
+    // be rejected by restricted mode, that must not happen. `RestrictedModeInitFixture`'s static
+    // initializer sets a system property; `classOf` and reading the compile-time constant below
+    // do not initialize the class, so the property stays unset unless the class is initialized.
+    val fixtureClass = classOf[RestrictedModeInitFixture].getName
+    System.clearProperty(RestrictedModeInitFixture.INIT_PROPERTY)
+    withRestrictedMode(true) {
+      val analyzer = getAnalyzer
+      val plan = Project(
+        Seq(UnresolvedAlias(
+          UnresolvedFunction(
+            "reflect",
+            Seq(Literal(fixtureClass), Literal("touch")),
+            isDistinct = false))),
+        TestRelations.testRelation)
+      val e = intercept[AnalysisException](analyzer.checkAnalysis(analyzer.execute(plan)))
+      checkRestrictedError(e, "The `reflect` function")
+    }
+    assert(System.getProperty(RestrictedModeInitFixture.INIT_PROPERTY) == null,
+      "the reflect target class must not be initialized when the call is rejected")
   }
 
   test("restricted mode is enforced for an analyzed sub-plan under a fresh parent") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/RestrictedModeCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/RestrictedModeCommandSuite.scala
@@ -18,8 +18,8 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.SparkConf
-import org.apache.spark.sql.{AnalysisException, QueryTest}
-import org.apache.spark.sql.internal.StaticSQLConf
+import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 
 /**
@@ -64,5 +64,36 @@ class RestrictedModeCommandSuite extends QueryTest with SharedSparkSession {
   test("the restricted mode config cannot be turned off at runtime") {
     val e = intercept[AnalysisException](sql(s"SET $restricted=false"))
     assert(e.getCondition == "CANNOT_MODIFY_STATIC_CONFIG")
+  }
+
+  test("restricted mode is enforced with the single-pass resolver enabled") {
+    // The restricted-mode gate runs in `CheckAnalysis`, which only the fixed-point analyzer
+    // invokes. The single-pass resolver would otherwise resolve `reflect` and mark the plan
+    // analyzed without the gate; a restricted-mode session must fall back to the fixed-point
+    // analyzer in every single-pass mode (fully enabled, which skips the ResolverGuard, and
+    // tentative, which consults it) so the gate cannot be bypassed.
+    Seq(
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED.key,
+      SQLConf.ANALYZER_SINGLE_PASS_RESOLVER_ENABLED_TENTATIVELY.key).foreach { key =>
+      withSQLConf(key -> "true") {
+        checkRestricted("SELECT reflect('java.lang.Math', 'abs', -1)", "The `reflect` function")
+      }
+    }
+  }
+
+  test("restricted mode reaches a feature nested inside a scalar subquery") {
+    checkRestricted(
+      "SELECT (SELECT reflect('java.lang.Math', 'abs', -1)) AS c",
+      "The `reflect` function")
+  }
+
+  test("restricted mode allows deeply nested subqueries with no restricted feature") {
+    // `checkRestrictedMode` descends into subquery plans, which are also part of `innerChildren`.
+    // Visiting them through both paths doubles the traversal at every nesting level, so a modest
+    // chain of nested scalar subqueries would take exponential time. Analyzing this query must
+    // stay feasible (it is linear once each subquery is traversed only once).
+    val depth = 40
+    val nested = (1 to depth).foldLeft("SELECT 1 AS c") { (inner, _) => s"SELECT ($inner) AS c" }
+    checkAnswer(sql(nested), Row(1))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #58604, which added the opt-in restricted SQL execution mode (`spark.sql.restrictedMode.enabled`). It addresses three issues found in post-merge review, all scoped to when restricted mode is enabled (no change to default behavior):

1. **Enforce the mode across both analyzer paths.** `CheckAnalysis.checkRestrictedMode` runs only in the fixed-point analyzer. The single-pass resolver resolves `reflect`/`java_method`/`try_reflect` and marks the plan analyzed without calling `checkAnalysis`, so the mode was not enforced when the single-pass resolver was enabled. `HybridAnalyzer.apply` now routes a restricted-mode session to the fixed-point analyzer (the same branch used by default when the single-pass resolver is off) in every single-pass mode.

2. **Do not load the referenced class before rejecting a reflect call.** Type-checking a `reflect`/`java_method`/`try_reflect` call resolves the referenced class via `Utils.classForName`, which runs its static initializer. That happened during analysis, before `checkRestrictedMode` rejected the call. `CallMethodViaReflection.checkInputDataTypes` now short-circuits in restricted mode so a call that is going to be rejected never loads the class.

3. **Traverse each subquery only once.** `checkRestrictedMode` descended into subquery plans both through `SubqueryExpression` and through `innerChildren` (which already contains them), doubling the work at every nesting level and making validation exponential in subquery-nesting depth. It now recurses through `innerChildren` only for the non-subquery inner plans (analysis-only command bodies), keeping validation linear.

### Why are the changes needed?

Restricted mode is a gate that blocks `reflect`/`java_method`/`try_reflect` and `TRANSFORM ... USING`. Without (1) the gate could be bypassed by enabling the single-pass resolver; without (2) a rejected call could still run a class's static initializer; (3) made the gate's cost blow up on deeply nested subqueries.

### Does this PR introduce _any_ user-facing change?

No. All changes only affect sessions that have opted into restricted mode; the default behavior is unchanged.

### How was this patch tested?

New unit tests in `RestrictedModeSuite` (rejection without initializing the referenced class) and `RestrictedModeCommandSuite` (enforcement with the single-pass resolver enabled; a feature nested inside a scalar subquery is still reached; deeply nested subqueries with no restricted feature analyze in linear time). Existing `CallMethodViaReflectionSuite` still passes.

### Was this patch authored or co-authored using generative AI tooling?

Yes, generated by Claude.