### PR TITLE
[SPARK-59273][SQL][FOLLOWUP] Skip non-string columns in fill

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameNaFunctions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/DataFrameNaFunctions.scala
@@ -250,6 +250,7 @@ final class DataFrameNaFunctions private[sql](df: DataFrame)
       val typeMatches = (targetType, col.dataType) match {
         case (NumericType, dt) => dt.isInstanceOf[NumericType]
         case (StringType, _: StringType) => true
+        case (StringType, _) => false
         case (BooleanType, dt) => dt == BooleanType
         case _ =>
           throw new IllegalArgumentException(s"$targetType is not matched at fillValue")

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionsSuite.scala
@@ -22,7 +22,14 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.{CharType, StringType, StructField, StructType, VarcharType}
+import org.apache.spark.sql.types.{
+  CharType,
+  IntegerType,
+  StringType,
+  StructField,
+  StructType,
+  VarcharType
+}
 
 class DataFrameNaFunctionsSuite extends SharedSparkSession {
   import testImplicits._
@@ -219,10 +226,12 @@ class DataFrameNaFunctionsSuite extends SharedSparkSession {
     withSQLConf(SQLConf.CHAR_VARCHAR_STANDARD_SEMANTICS.key -> "true") {
       val schema = StructType(Seq(
         StructField("c", CharType(3)),
-        StructField("v", VarcharType(3))))
-      val input = spark.createDataFrame(sparkContext.parallelize(Seq(Row(null, null))), schema)
+        StructField("v", VarcharType(3)),
+        StructField("i", IntegerType)))
+      val input = spark.createDataFrame(
+        sparkContext.parallelize(Seq(Row(null, null, null))), schema)
 
-      checkAnswer(input.na.fill("x"), Row("x  ", "x"))
+      checkAnswer(input.na.fill("x"), Row("x  ", "x", null))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Restore `DataFrameNaFunctions.fillValue` behavior for string replacements: non-string columns are skipped rather than falling through to an exception.

The existing SPARK-59273 CHAR/VARCHAR test now also includes an integer column, ensuring `na.fill("x")` fills the string-family columns while leaving the integer column unchanged.

### Why are the changes needed?

SPARK-59273 changed the string match from exact `StringType` equality to a `StringType` subtype match so CHAR and VARCHAR columns are included. Without a fallback for other column types, a normal mixed string/integer DataFrame throws `StringType is not matched at fillValue`. This regresses `na.fill("x")` in Scala, PySpark, SparkR, and Connect tests.

### Does this PR introduce _any_ user-facing change?

Yes. It restores the existing behavior of `DataFrame.na.fill("...")` on DataFrames that contain both string-family and non-string columns.

### How was this patch tested?

- `./build/sbt -Phadoop-3 -Dsbt.supershell=false 'sql/testOnly org.apache.spark.sql.DataFrameNaFunctionsSuite -- -z "fill"'`\n\n### Was this patch authored or co-authored using generative AI tooling?\n\nGenerated-by: Codex (GPT-5)