### PR TITLE
[SPARK-59356][SQL] Estimate selectivity of StartsWith/EndsWith/Contains in FilterEstimation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/FilterEstimation.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal.{FalseLiteral, TrueLite
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.plans.logical.statsEstimation.EstimationUtils._
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 case class FilterEstimation(plan: Filter) extends Logging {
 
@@ -214,10 +215,20 @@ case class FilterEstimation(plan: Filter) extends Logging {
       case op @ GreaterThanOrEqual(attrLeft: Attribute, attrRight: Attribute) =>
         evaluateBinaryForTwoColumns(op, attrLeft, attrRight, update)
 
+      // StartsWith/EndsWith/Contains are null-intolerant, so only non-null rows can match; and a
+      // value must be at least as long as the operand. We can bound their selectivity from
+      // `nullCount` and `maxLen` even without distribution statistics. `Like` still falls through
+      // (its common prefix/suffix/infix forms are already rewritten to the operators below).
+      case StartsWith(ar: Attribute, l @ Literal(v, StringType)) if v != null =>
+        evaluateStringPredicate(ar, l, update)
+      case EndsWith(ar: Attribute, l @ Literal(v, StringType)) if v != null =>
+        evaluateStringPredicate(ar, l, update)
+      case Contains(ar: Attribute, l @ Literal(v, StringType)) if v != null =>
+        evaluateStringPredicate(ar, l, update)
+
       case _ =>
         // TODO: it's difficult to support string operators without advanced statistics.
-        // Hence, these string operators Like(_, _) | Contains(_, _) | StartsWith(_, _)
-        // | EndsWith(_, _) are not supported yet
+        // Hence, the string operator Like(_, _) is not supported yet.
         logDebug("[CBO] Unsupported filter condition: " + condition)
         None
     }
@@ -264,6 +275,59 @@ case class FilterEstimation(plan: Filter) extends Logging {
       nullPercent
     } else {
       1.0 - nullPercent
+    }
+
+    Some(percent)
+  }
+
+  /**
+   * Returns a percentage of rows meeting a null-intolerant string predicate
+   * (StartsWith / EndsWith / Contains) with a string literal operand.
+   *
+   * These predicates never match a null input, so at most the non-null rows can match, giving an
+   * upper bound of `1 - nullPercent`. In addition, a value must have at least as many characters
+   * as the operand, so if the operand is longer than the column's `maxLen` no row can match. Both
+   * bounds reuse statistics already collected (`nullCount`, `maxLen`) and hold under any collation
+   * (`maxLen` is a code-point count). This is a conservative estimate -- it never under-estimates
+   * -- and improves on the default of 1.0 (all rows) used for unsupported predicates.
+   *
+   * @param attr an Attribute (or a column)
+   * @param literal the non-null string literal operand
+   * @param update a boolean flag to specify if we need to update ColumnStat of a given column
+   *               for subsequent conditions
+   * @return an optional double value to show the percentage of rows meeting a given condition.
+   *         It returns None if no statistics are collected for a given column.
+   */
+  def evaluateStringPredicate(
+      attr: Attribute,
+      literal: Literal,
+      update: Boolean): Option[Double] = {
+    if (!colStatsMap.contains(attr) || colStatsMap(attr).nullCount.isEmpty) {
+      logDebug("[CBO] No statistics for " + attr)
+      return None
+    }
+    val colStat = colStatsMap(attr)
+    val rowCountValue = childStats.rowCount.get
+    val nullPercent: Double = if (rowCountValue == 0) {
+      0
+    } else if (colStat.nullCount.get > rowCountValue) {
+      1
+    } else {
+      (BigDecimal(colStat.nullCount.get) / BigDecimal(rowCountValue)).toDouble
+    }
+
+    // A value must have at least as many characters as the operand to start with / end with /
+    // contain it. `maxLen` is the maximum code-point length, so this holds under any collation.
+    val operandLength = literal.value.asInstanceOf[UTF8String].numChars()
+    val percent = if (colStat.maxLen.exists(_ < operandLength)) {
+      0.0
+    } else {
+      1.0 - nullPercent
+    }
+
+    if (update && percent > 0) {
+      // Surviving rows are non-null (the predicate is null-intolerant).
+      colStatsMap.update(attr, colStat.copy(nullCount = Some(0)))
     }
 
     Some(percent)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/FilterEstimationSuite.scala
@@ -579,6 +579,54 @@ class FilterEstimationSuite extends StatsEstimationTestBase {
       expectedRowCount = 10)
   }
 
+  test("cstring startsWith 'A' - bounded by the non-null fraction") {
+    // Only non-null rows can match, so selectivity <= 1 - nullPercent = 0.5.
+    val colStatNullableString = colStatString.copy(nullCount = Some(5))
+    validateEstimatedStats(
+      Filter(StartsWith(attrString, Literal("A")),
+        childStatsTestPlan(Seq(attrString), tableRowCount = 10L,
+          attributeMap = AttributeMap(Seq(attrString -> colStatNullableString)))),
+      Seq(attrString -> colStatString.copy(distinctCount = Some(5))),
+      expectedRowCount = 5)
+  }
+
+  test("cstring endsWith / contains 'A' - bounded by the non-null fraction") {
+    val colStatNullableString = colStatString.copy(nullCount = Some(5))
+    Seq(EndsWith(attrString, Literal("A")), Contains(attrString, Literal("A"))).foreach { cond =>
+      validateEstimatedStats(
+        Filter(cond,
+          childStatsTestPlan(Seq(attrString), tableRowCount = 10L,
+            attributeMap = AttributeMap(Seq(attrString -> colStatNullableString)))),
+        Seq(attrString -> colStatString.copy(distinctCount = Some(5))),
+        expectedRowCount = 5)
+    }
+  }
+
+  test("cstring startsWith operand longer than maxLen matches nothing") {
+    // colStatString.maxLen is 2, so a 3-character prefix cannot match any value.
+    validateEstimatedStats(
+      Filter(StartsWith(attrString, Literal("abc")), childStatsTestPlan(Seq(attrString), 10L)),
+      Seq(attrString -> colStatString),
+      expectedRowCount = 0)
+  }
+
+  test("cstring startsWith on an all-null column matches nothing") {
+    val colStatAllNull = colStatString.copy(nullCount = Some(10))
+    validateEstimatedStats(
+      Filter(StartsWith(attrString, Literal("A")),
+        childStatsTestPlan(Seq(attrString), tableRowCount = 10L,
+          attributeMap = AttributeMap(Seq(attrString -> colStatAllNull)))),
+      Seq(attrString -> colStatAllNull),
+      expectedRowCount = 0)
+  }
+
+  test("cstring startsWith on a non-null column is unchanged (selectivity 1.0)") {
+    validateEstimatedStats(
+      Filter(StartsWith(attrString, Literal("A")), childStatsTestPlan(Seq(attrString), 10L)),
+      Seq(attrString -> colStatString),
+      expectedRowCount = 10)
+  }
+
   test("SPARK-59273: CHAR/VARCHAR equality, IN, and range fall back like STRING") {
     Seq(attrChar -> colStatChar, attrVarchar -> colStatVarchar).foreach {
       case (attr, colStat) =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

The cost-based optimizer's `FilterEstimation` lists `StartsWith` / `EndsWith` / `Contains` (and
`Like`) as "not supported yet", so they fall through to a conservative default selectivity of
**1.0** (all rows pass). This estimates `StartsWith` / `EndsWith` / `Contains` with a string
literal operand from statistics Spark already collects:

- **`nullCount`** — these predicates are null-intolerant, so a null input never matches; only
  non-null rows can match, bounding selectivity by `1 - nullPercent` (reusing the computation in
  `evaluateNullCheck`). An all-null column ⇒ 0.
- **`maxLen`** — a value must have at least as many characters as the operand, so when the operand
  is longer than the column's `maxLen`, no row can match ⇒ 0. `maxLen` is a code-point count
  (`Max(Length(col))`), so this holds under any collation.

General `Like` selectivity remains out of scope (its common prefix/suffix/infix forms are already
rewritten to these operators before estimation runs), and `EqualTo` is already estimated via NDV.

### Why are the changes needed?

`WHERE s LIKE 'abc%'` is rewritten to `StartsWith(s, 'abc')`; estimating it as passing every row
distorts join planning (order, build/probe side, broadcast eligibility). These are exactly the
predicates the LIKE simplifications produce, so today those rewrites help pushdown/pruning but not
the CBO's cardinality estimates. Both bounds are conservative — the estimate is at most 1.0, so it
never under-estimates (the safe direction for join planning) and only tightens the current
default. It introduces no new statistics and is gated by the existing CBO/column-stats
preconditions.

### Does this PR introduce _any_ user-facing change?

No. Query results are unchanged; this only refines cost-based cardinality estimates, and only
under `spark.sql.cbo.enabled` with column statistics present.

The only TPC-DS query using `LIKE` is q91 (`hd_buy_potential LIKE 'Unknown%'`), whose injected
stats have `nullCount = 0` and `maxLen = 10 (>= len("Unknown"))`, so the estimate equals the prior
default of 1.0 and the plan is unchanged — no plan-stability golden changes.

### How was this patch tested?

New tests in `FilterEstimationSuite`: `StartsWith` on a nullable column (bounded by the non-null
fraction), `EndsWith`/`Contains` parity, operand longer than `maxLen` (0 rows), all-null column
(0 rows), and a non-null column (selectivity 1.0, unchanged).
`build/sbt 'catalyst/testOnly *FilterEstimationSuite'` passes (91/91); scalastyle clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
