### PR TITLE
[SPARK-57900][BUILD][FOLLOWUP][4.X] Fix the pom of credential-aws-integration-tests

### DIFF
--- a/connector/credential-aws-integration-tests/pom.xml
+++ b/connector/credential-aws-integration-tests/pom.xml
@@ -117,6 +117,7 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
+      <version>${kubernetes-client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>io.vertx</groupId>

--- a/connector/credential-aws-integration-tests/pom.xml
+++ b/connector/credential-aws-integration-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.spark</groupId>
     <artifactId>spark-parent_2.13</artifactId>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>4.4.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the pom of `connector/credential-aws-integration-tests` for branch-4.x:
- set the parent version to `4.4.0-SNAPSHOT`
- add `<version>${kubernetes-client.version}</version>` to the `io.fabric8:kubernetes-client` dependency

### Why are the changes needed?
The branch-4.x backport of SPARK-57900 (81d47f74) kept two master-only conventions:
1. Parent version `5.0.0-SNAPSHOT`, which does not exist on branch-4.x (`4.4.0-SNAPSHOT`); any build activating `-Poidc-e2e` fails to resolve `spark-parent_2.13`.
2. An unversioned `kubernetes-client` dependency, relying on the `kubernetes-client-bom` import that only exists in master's root pom. branch-4.x manages fabric8 artifacts per-dependency (see `resource-managers/kubernetes/core/pom.xml`), so effective-model building fails with `'dependencies.dependency.version' for io.fabric8:kubernetes-client is missing`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Replicated the CI precompile command locally with the full profile set (`Test/package`, assemblies); the build succeeded, including main and test compilation of the new module.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Deepseek V4 Flash
