### PR TITLE
[SPARK-59363][DOCS] Fix ungrammatical 'allows to' in the Avro data source doc

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -299,7 +299,7 @@ Data source options of Avro can be set via:
   <tr>
     <td><code>compression</code></td>
     <td>snappy</td>
-    <td>The <code>compression</code> option allows to specify a compression codec used in write.<br>
+    <td>The <code>compression</code> option allows you to specify a compression codec used in write.<br>
   Currently supported codecs are <code>uncompressed</code>, <code>snappy</code>, <code>deflate</code>, <code>bzip2</code>, <code>xz</code> and <code>zstandard</code>.<br> If the option is not set, the configuration <code>spark.sql.avro.compression.codec</code> config is taken into account.</td>
     <td>write</td>
     <td>2.4.0</td>
@@ -307,7 +307,7 @@ Data source options of Avro can be set via:
   <tr>
     <td><code>mode</code></td>
     <td>FAILFAST</td>
-    <td>The <code>mode</code> option allows to specify parse mode for function <code>from_avro</code>.<br>
+    <td>The <code>mode</code> option allows you to specify parse mode for function <code>from_avro</code>.<br>
       Currently supported modes are:
       <ul>
         <li><code>FAILFAST</code>: Throws an exception on processing corrupted record.</li>
@@ -321,7 +321,7 @@ Data source options of Avro can be set via:
   <tr>
     <td><code>datetimeRebaseMode</code></td>
     <td>(value of <code>spark.sql.avro.datetimeRebaseModeInRead</code> configuration)</td>
-    <td>The <code>datetimeRebaseMode</code> option allows to specify the rebasing mode for the values of the <code>date</code>, <code>timestamp-micros</code>, <code>timestamp-millis</code> logical types from the Julian to Proleptic Gregorian calendar.<br>
+    <td>The <code>datetimeRebaseMode</code> option allows you to specify the rebasing mode for the values of the <code>date</code>, <code>timestamp-micros</code>, <code>timestamp-millis</code> logical types from the Julian to Proleptic Gregorian calendar.<br>
       Currently supported modes are:
       <ul>
         <li><code>EXCEPTION</code>: fails in reads of ancient dates/timestamps that are ambiguous between the two calendars.</li>
@@ -349,7 +349,7 @@ Data source options of Avro can be set via:
   <tr>
     <td><code>stableIdentifierPrefixForUnionType</code></td>
     <td>member_</td>
-    <td>When `enableStableIdentifiersForUnionType` is enabled, the option allows to configure the prefix for fields of Avro Union type.</td>
+    <td>When `enableStableIdentifiersForUnionType` is enabled, the option allows you to configure the prefix for fields of Avro Union type.</td>
     <td>read</td>
     <td>4.0.0</td>
   </tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Four option descriptions in `docs/sql-data-sources-avro.md` use the ungrammatical phrasing "the option allows to &lt;verb&gt;" -- for the `compression`, `mode`, and `datetimeRebaseMode` options and the Avro Union-type field-prefix option. This changes them to "allows you to &lt;verb&gt;".

### Why are the changes needed?

"allows to &lt;verb&gt;" is not grammatical; "allows you to &lt;verb&gt;" reads correctly and matches the phrasing used elsewhere in the docs.

### Does this PR introduce _any_ user-facing change?

No. Documentation only.

### How was this patch tested?

N/A -- documentation-only change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
