### PR TITLE
[SPARK-57846][SQL] Add the try_make_time function

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -389,6 +389,7 @@ When ANSI mode is on, it throws exceptions for invalid operations. You can use t
   - `try_make_timestamp_ltz`: identical to the function `make_timestamp_ltz`, except that it returns `NULL` result instead of throwing an exception on error.
   - `try_make_timestamp_ntz`: identical to the function `make_timestamp_ntz`, except that it returns `NULL` result instead of throwing an exception on error.
   - `try_make_interval`: identical to the function `make_interval`, except that it returns `NULL` result instead of throwing an exception on invalid interval.
+  - `try_make_time`: identical to the function `make_time`, except that it returns `NULL` result instead of throwing an exception on error.
   - `try_to_time`: identical to the function `to_time`, except that it returns `NULL` result instead of throwing an exception on string parsing error.
   - `try_to_date`: identical to the function `to_date`, except that it returns `NULL` result instead of throwing an exception on string parsing error.
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -768,6 +768,7 @@ object FunctionRegistry {
     expression[WindowTime]("window_time"),
     expression[MakeDate]("make_date"),
     expression[MakeTime]("make_time"),
+    expressionBuilder("try_make_time", TryMakeTimeExpressionBuilder, setAlias = true),
     expression[TimeTrunc]("time_trunc"),
     expression[TimeFromSeconds]("time_from_seconds"),
     expression[TimeFromMillis]("time_from_millis"),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -654,7 +654,7 @@ case class MakeTime(
         An expression that evaluates to an integer.
       * minute - the minute to represent, from 0 to 59
         An expression that evaluates to an integer.
-      * second - the second to represent, from 0 to 59.999999.
+      * second - the second to represent, from 0 to 59.999999
         An expression that evaluates to a decimal.
   """,
   examples = """

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/timeExpressions.scala
@@ -645,6 +645,41 @@ case class MakeTime(
     copy(hours = newChildren(0), minutes = newChildren(1), secsAndMicros = newChildren(2))
 }
 
+// scalastyle:off line.size.limit
+@ExpressionDescription(
+  usage = "_FUNC_(hour, minute, second) - Try to create time from hour, minute and second fields. The function returns NULL on invalid inputs.",
+  arguments = """
+    Arguments:
+      * hour - the hour to represent, from 0 to 23
+        An expression that evaluates to an integer.
+      * minute - the minute to represent, from 0 to 59
+        An expression that evaluates to an integer.
+      * second - the second to represent, from 0 to 59.999999.
+        An expression that evaluates to a decimal.
+  """,
+  examples = """
+    Examples:
+      > SELECT _FUNC_(6, 30, 45.887);
+       06:30:45.887
+      > SELECT _FUNC_(NULL, 30, 0);
+       NULL
+      > SELECT _FUNC_(25, 30, 45.887);
+       NULL
+  """,
+  group = "datetime_funcs",
+  since = "4.4.0")
+// scalastyle:on line.size.limit
+object TryMakeTimeExpressionBuilder extends ExpressionBuilder {
+  override def build(funcName: String, expressions: Seq[Expression]): Expression = {
+    val numArgs = expressions.length
+    if (numArgs == 3) {
+      TryEval(MakeTime(expressions(0), expressions(1), expressions(2)))
+    } else {
+      throw QueryCompilationErrors.wrongNumArgsError(funcName, Seq(3), numArgs)
+    }
+  }
+}
+
 /**
  * Adds day-time interval to time.
  */

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -269,6 +269,19 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(
       TryEval(MakeTime(Literal(23), Literal(12), Literal(Decimal(100.5, 16, 6)))),
       null)
+
+    // The builder reports a wrong number of arguments.
+    checkError(
+      exception = intercept[AnalysisException] {
+        TryMakeTimeExpressionBuilder.build("try_make_time", Seq(Literal(1), Literal(2)))
+      },
+      condition = "WRONG_NUM_ARGS.WITHOUT_SUGGESTION",
+      parameters = Map(
+        "functionName" -> "`try_make_time`",
+        "expectedNum" -> "3",
+        "actualNum" -> "2",
+        "docroot" -> SPARK_DOC_ROOT)
+    )
   }
 
   test("SecondExpressionBuilder") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/TimeExpressionsSuite.scala
@@ -247,6 +247,30 @@ class TimeExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     )
   }
 
+  test("try_make_time returns null instead of throwing on invalid input") {
+    // Valid input behaves like make_time.
+    checkEvaluation(
+      TryEval(MakeTime(Literal(13), Literal(2), Literal(Decimal(23.5, 16, 6)))),
+      LocalTime.of(13, 2, 23, 500000000))
+
+    // Null input propagates as null.
+    checkEvaluation(
+      TryEval(MakeTime(
+        Literal.create(null, IntegerType), Literal(18), Literal(Decimal(23.5, 16, 6)))),
+      null)
+
+    // Invalid inputs that make_time would reject with an error return null instead.
+    checkEvaluation(
+      TryEval(MakeTime(Literal(25), Literal(2), Literal(Decimal(23.5, 16, 6)))),
+      null)
+    checkEvaluation(
+      TryEval(MakeTime(Literal(23), Literal(-1), Literal(Decimal(23.5, 16, 6)))),
+      null)
+    checkEvaluation(
+      TryEval(MakeTime(Literal(23), Literal(12), Literal(Decimal(100.5, 16, 6)))),
+      null)
+  }
+
   test("SecondExpressionBuilder") {
     // Empty expressions list
     checkError(

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -407,6 +407,7 @@
 | org.apache.spark.sql.catalyst.expressions.TryDivide | try_divide | SELECT try_divide(3, 2) | struct<try_divide(3, 2):double> |
 | org.apache.spark.sql.catalyst.expressions.TryElementAt | try_element_at | SELECT try_element_at(array(1, 2, 3), 2) | struct<try_element_at(array(1, 2, 3), 2):int> |
 | org.apache.spark.sql.catalyst.expressions.TryMakeInterval | try_make_interval | SELECT try_make_interval(100, 11, 1, 1, 12, 30, 01.001001) | struct<try_make_interval(100, 11, 1, 1, 12, 30, 1.001001):interval> |
+| org.apache.spark.sql.catalyst.expressions.TryMakeTimeExpressionBuilder | try_make_time | SELECT try_make_time(6, 30, 45.887) | struct<try_make_time(make_time(6, 30, 45.887)):time(6)> |
 | org.apache.spark.sql.catalyst.expressions.TryMakeTimestampExpressionBuilder | try_make_timestamp | SELECT try_make_timestamp(2014, 12, 28, 6, 30, 45.887) | struct<try_make_timestamp(2014, 12, 28, 6, 30, 45.887):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.TryMakeTimestampLTZExpressionBuilder | try_make_timestamp_ltz | SELECT try_make_timestamp_ltz(2014, 12, 28, 6, 30, 45.887) | struct<try_make_timestamp_ltz(2014, 12, 28, 6, 30, 45.887):timestamp> |
 | org.apache.spark.sql.catalyst.expressions.TryMakeTimestampNTZExpressionBuilder | try_make_timestamp_ntz | SELECT try_make_timestamp_ntz(2014, 12, 28, 6, 30, 45.887) | struct<try_make_timestamp_ntz(2014, 12, 28, 6, 30, 45.887):timestamp_ntz> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time.sql.out
@@ -222,6 +222,48 @@ Project [make_time(1, 18, 4294967297.999999) AS make_time(1, 18, 4294967297.9999
 
 
 -- !query
+select try_make_time(1, 18, 19.87)
+-- !query analysis
+Project [try_make_time(make_time(1, 18, cast(19.87 as decimal(16,6)))) AS try_make_time(make_time(1, 18, 19.87))#x]
++- OneRowRelation
+
+
+-- !query
+select try_make_time(null, 18, 19.87)
+-- !query analysis
+Project [try_make_time(make_time(cast(null as int), 18, cast(19.87 as decimal(16,6)))) AS try_make_time(make_time(NULL, 18, 19.87))#x]
++- OneRowRelation
+
+
+-- !query
+select try_make_time(-1, 18, 19.87)
+-- !query analysis
+Project [try_make_time(make_time(-1, 18, cast(19.87 as decimal(16,6)))) AS try_make_time(make_time(-1, 18, 19.87))#x]
++- OneRowRelation
+
+
+-- !query
+select try_make_time(1, 60, 19.87)
+-- !query analysis
+Project [try_make_time(make_time(1, 60, cast(19.87 as decimal(16,6)))) AS try_make_time(make_time(1, 60, 19.87))#x]
++- OneRowRelation
+
+
+-- !query
+select try_make_time(1, 18, 60.0)
+-- !query analysis
+Project [try_make_time(make_time(1, 18, cast(60.0 as decimal(16,6)))) AS try_make_time(make_time(1, 18, 60.0))#x]
++- OneRowRelation
+
+
+-- !query
+select try_make_time(1, 18, 9999999999.999999)
+-- !query analysis
+Project [try_make_time(make_time(1, 18, 9999999999.999999)) AS try_make_time(make_time(1, 18, 9999999999.999999))#x]
++- OneRowRelation
+
+
+-- !query
 select second(to_time('23-59-58.987654', 'HH-mm-ss.SSSSSS'))
 -- !query analysis
 Project [second(to_time(23-59-58.987654, Some(HH-mm-ss.SSSSSS))) AS second(to_time(23-59-58.987654, HH-mm-ss.SSSSSS))#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/time.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/time.sql
@@ -40,6 +40,14 @@ select make_time(1, 18, -999999999.999999);
 -- Full seconds overflows to a valid seconds integer when converted from long to int
 select make_time(1, 18, 4294967297.999999);
 
+-- try_make_time returns NULL (instead of throwing) on invalid inputs
+select try_make_time(1, 18, 19.87);
+select try_make_time(null, 18, 19.87);
+select try_make_time(-1, 18, 19.87);
+select try_make_time(1, 60, 19.87);
+select try_make_time(1, 18, 60.0);
+select try_make_time(1, 18, 9999999999.999999);
+
 select second(to_time('23-59-58.987654', 'HH-mm-ss.SSSSSS'));
 select minute(to_time('23-59-58.987654', 'HH-mm-ss.SSSSSS'));
 select hour(to_time('23-59-58.987654', 'HH-mm-ss.SSSSSS'));

--- a/sql/core/src/test/resources/sql-tests/results/time.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time.sql.out
@@ -293,6 +293,54 @@ org.apache.spark.SparkDateTimeException
 
 
 -- !query
+select try_make_time(1, 18, 19.87)
+-- !query schema
+struct<try_make_time(make_time(1, 18, 19.87)):time(6)>
+-- !query output
+01:18:19.87
+
+
+-- !query
+select try_make_time(null, 18, 19.87)
+-- !query schema
+struct<try_make_time(make_time(NULL, 18, 19.87)):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+select try_make_time(-1, 18, 19.87)
+-- !query schema
+struct<try_make_time(make_time(-1, 18, 19.87)):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+select try_make_time(1, 60, 19.87)
+-- !query schema
+struct<try_make_time(make_time(1, 60, 19.87)):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+select try_make_time(1, 18, 60.0)
+-- !query schema
+struct<try_make_time(make_time(1, 18, 60.0)):time(6)>
+-- !query output
+NULL
+
+
+-- !query
+select try_make_time(1, 18, 9999999999.999999)
+-- !query schema
+struct<try_make_time(make_time(1, 18, 9999999999.999999)):time(6)>
+-- !query output
+NULL
+
+
+-- !query
 select second(to_time('23-59-58.987654', 'HH-mm-ss.SSSSSS'))
 -- !query schema
 struct<second(to_time(23-59-58.987654, HH-mm-ss.SSSSSS)):int>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds `try_make_time(hour, minute, second)`, the error-safe counterpart of `make_time`: it returns NULL instead of throwing when the fields are out of range. Implemented as a builder that wraps `MakeTime` in `TryEval`, mirroring `try_to_time`. This is a SQL-registry function; the DataFrame/PySpark APIs are left as a follow-up.


### Why are the changes needed?
`make_time` throws on invalid input, but there was no `try_` variant, unlike `to_time`/`try_to_time` and `make_timestamp`/`try_make_timestamp`. This closes that gap in the TIME function family (SPARK-57550 umbrella).


### Does this PR introduce _any_ user-facing change?
Yes, a new SQL function


### How was this patch tested?
catalyst `TimeExpressionsSuite` (null-on-invalid), golden cases in `time.sql`, and the regenerated `sql-expression-schema.md` row.


### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Opus 4.8