### PR TITLE
[SPARK-57820][SQL] Support nanosecond-precision timestamps in time_bucket

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -5177,8 +5177,8 @@ case class TimeBucket(
 
   override def inputTypes: Seq[AbstractDataType] = Seq(
     TypeCollection(DayTimeIntervalType, YearMonthIntervalType),
-    AnyTimestampType,
-    AnyTimestampType)
+    TypeCollection(AnyTimestampType, AnyTimestampNanoType),
+    TypeCollection(AnyTimestampType, AnyTimestampNanoType))
 
   override def dataType: DataType = ts.dataType
 
@@ -5235,31 +5235,48 @@ case class TimeBucket(
     TypeCheckSuccess
   }
 
+  private def isTsNanos: Boolean = ts.dataType.isInstanceOf[AnyTimestampNanoType]
+
+  // The nanosecond carrier boxes as a TimestampNanosVal; the microsecond timestamp types box as
+  // a Long. Bucket boundaries are microsecond-granular (the bucket size is a microsecond or month
+  // interval), so a nanos operand contributes only its epochMicros and the bucket start is
+  // re-wrapped on a micro boundary (nanosWithinMicro = 0).
+  private def toMicros(value: Any): Long = value match {
+    case v: TimestampNanosVal => v.epochMicros
+    case l => l.asInstanceOf[Long]
+  }
+
   override def nullSafeEval(bucketSizeVal: Any, tsVal: Any, originVal: Any): Any = {
-    first.dataType match {
+    val startMicros = first.dataType match {
       case _: DayTimeIntervalType =>
         DateTimeUtils.timeBucketDTInterval(
-          bucketSizeVal.asInstanceOf[Long], tsVal.asInstanceOf[Long],
-          originVal.asInstanceOf[Long], zoneIdInEval)
+          bucketSizeVal.asInstanceOf[Long], toMicros(tsVal), toMicros(originVal), zoneIdInEval)
       case _: YearMonthIntervalType =>
         DateTimeUtils.timeBucketYMInterval(
-          bucketSizeVal.asInstanceOf[Int], tsVal.asInstanceOf[Long],
-          originVal.asInstanceOf[Long], zoneIdInEval)
+          bucketSizeVal.asInstanceOf[Int], toMicros(tsVal), toMicros(originVal), zoneIdInEval)
       case other => throw SparkException.internalError(
         s"Unexpected bucketSize type: $other")
     }
+    if (isTsNanos) TimestampNanosVal.fromParts(startMicros, 0) else startMicros
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val dtu = DateTimeUtils.getClass.getName.stripSuffix("$")
     val zid = ctx.addReferenceObj("zoneId", zoneIdInEval, classOf[ZoneId].getName)
+    // Nanosecond operands read epochMicros; the bucket start is re-wrapped on a micro boundary.
+    def micros(code: String): String = if (isTsNanos) s"$code.epochMicros" else code
+    def result(startMicros: String): String = if (isTsNanos) {
+      s"org.apache.spark.unsafe.types.TimestampNanosVal.fromParts($startMicros, (short) 0)"
+    } else startMicros
     first.dataType match {
       case _: DayTimeIntervalType =>
         defineCodeGen(ctx, ev, (bucketSizeCode, tsCode, originCode) =>
-          s"$dtu.timeBucketDTInterval($bucketSizeCode, $tsCode, $originCode, $zid)")
+          result(s"$dtu.timeBucketDTInterval(" +
+            s"$bucketSizeCode, ${micros(tsCode)}, ${micros(originCode)}, $zid)"))
       case _: YearMonthIntervalType =>
         defineCodeGen(ctx, ev, (bucketSizeCode, tsCode, originCode) =>
-          s"$dtu.timeBucketYMInterval($bucketSizeCode, $tsCode, $originCode, $zid)")
+          result(s"$dtu.timeBucketYMInterval(" +
+            s"$bucketSizeCode, ${micros(tsCode)}, ${micros(originCode)}, $zid)"))
       case other => throw SparkException.internalError(
         s"Unexpected bucketSize type: $other")
     }
@@ -5311,6 +5328,11 @@ object TimeBucketExpressionBuilder extends ExpressionBuilder {
     case TimestampType =>
       val zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
       Literal(DateTimeUtils.daysToMicros(0, zoneId), TimestampType)
+    case _: TimestampLTZNanosType =>
+      val zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
+      Literal(TimestampNanosVal.fromParts(DateTimeUtils.daysToMicros(0, zoneId), 0), tsType)
+    case _: TimestampNTZNanosType =>
+      Literal(TimestampNanosVal.fromParts(0L, 0), tsType)
     case _ => Literal(0L, tsType)
   }
 
@@ -5320,7 +5342,7 @@ object TimeBucketExpressionBuilder extends ExpressionBuilder {
         val bucketSize = retypeNull(rawBucketSize, DayTimeIntervalType())
         // Fall back to TimestampType for bad ts types; ExpectsInputTypes will report it.
         val tsType = rawTs.dataType match {
-          case t if AnyTimestampType.acceptsType(t) => t
+          case t if AnyTimestampType.acceptsType(t) || t.isInstanceOf[AnyTimestampNanoType] => t
           case _ => TimestampType
         }
         val ts = retypeNull(rawTs, tsType)
@@ -5328,7 +5350,8 @@ object TimeBucketExpressionBuilder extends ExpressionBuilder {
       case Seq(rawBucketSize, rawTs, rawOrigin) =>
         val bucketSize = retypeNull(rawBucketSize, DayTimeIntervalType())
         val tsType = (rawTs.dataType, rawOrigin.dataType) match {
-          case (NullType, t) if AnyTimestampType.acceptsType(t) => t
+          case (NullType, t) if AnyTimestampType.acceptsType(t) ||
+              t.isInstanceOf[AnyTimestampNanoType] => t
           case (NullType, _) => TimestampType
           case (t, _) => t
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -5262,10 +5262,7 @@ case class TimeBucket(
 
   private def isTsNanos: Boolean = ts.dataType.isInstanceOf[AnyTimestampNanoType]
 
-  // The nanosecond carrier boxes as a TimestampNanosVal; the microsecond timestamp types box as
-  // a Long. Bucket boundaries are microsecond-granular (the bucket size is a microsecond or month
-  // interval), so a nanos operand contributes only its epochMicros and the bucket start is
-  // re-wrapped on a micro boundary (nanosWithinMicro = 0).
+  // A nanos operand boxes as a TimestampNanosVal, a micros one as a Long; take epochMicros.
   private def toMicros(value: Any): Long = value match {
     case v: TimestampNanosVal => v.epochMicros
     case l => l.asInstanceOf[Long]

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala
@@ -5153,6 +5153,12 @@ case class TimestampDiff(
  * For TIMESTAMP_NTZ, bucketing is performed in UTC. For TIMESTAMP, year-month
  * interval buckets and calendar-day components of day-time interval buckets align
  * to the session time zone.
+ *
+ * Nanosecond-precision timestamps (TIMESTAMP(p)/TIMESTAMP_NTZ(p)) are also supported. Because the
+ * bucket size is a microsecond or month interval, bucketing runs on the microsecond grid: ts's
+ * sub-microsecond fraction does not affect which bucket it falls into, and the returned bucket
+ * start carries a zero sub-microsecond fraction. `origin` must therefore be microsecond-aligned;
+ * a sub-microsecond origin is rejected at analysis.
  */
 case class TimeBucket(
     bucketSize: Expression,
@@ -5232,6 +5238,25 @@ case class TimeBucket(
           "inputType" -> toSQLType(originTs.dataType)))
     }
 
+    // Bucketing runs on the microsecond grid, so a sub-microsecond origin fraction would shift
+    // the bucket boundaries off the microsecond grid and yield a start that is not
+    // `origin + k * bucketSize`. Reject such an origin instead of silently truncating it. Here
+    // `origin` is a foldable literal of the same nanos type as `ts` (guaranteed by the checks
+    // above), so its fraction can be inspected at analysis time.
+    if (isTsNanos) {
+      val originValue = originTs.eval()
+      if (originValue != null &&
+          originValue.asInstanceOf[TimestampNanosVal].nanosWithinMicro != 0) {
+        return DataTypeMismatch(
+          errorSubClass = "INVALID_ARG_VALUE",
+          messageParameters = Map(
+            "inputName" -> toSQLId("origin"),
+            "requireType" -> toSQLType(originTs.dataType),
+            "validValues" -> "a microsecond-aligned value (no sub-microsecond fraction)",
+            "inputValue" -> toSQLExpr(originTs)))
+      }
+    }
+
     TypeCheckSuccess
   }
 
@@ -5257,7 +5282,7 @@ case class TimeBucket(
       case other => throw SparkException.internalError(
         s"Unexpected bucketSize type: $other")
     }
-    if (isTsNanos) TimestampNanosVal.fromParts(startMicros, 0) else startMicros
+    if (isTsNanos) TimestampNanosVal.fromParts(startMicros, 0.toShort) else startMicros
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -5301,8 +5326,8 @@ case class TimeBucket(
   arguments = """
     Arguments:
       * bucketSize - A day-time or year-month interval defining the bucket size. Must be positive and foldable.
-      * ts - A TIMESTAMP or TIMESTAMP_NTZ value to bucket.
-      * origin - Optional TIMESTAMP or TIMESTAMP_NTZ alignment anchor. Defaults to 1970-01-01 00:00:00. Must be the same type as ts and must be foldable.
+      * ts - A TIMESTAMP, TIMESTAMP_NTZ, or nanosecond-precision (TIMESTAMP(p)/TIMESTAMP_NTZ(p), p in [7, 9]) value to bucket. For a nanosecond input the sub-microsecond fraction is ignored (bucketing is on the microsecond grid) and the result's sub-microsecond fraction is zero.
+      * origin - Optional alignment anchor. Defaults to 1970-01-01 00:00:00. Must be the same type as ts and must be foldable; a nanosecond origin must be microsecond-aligned (no sub-microsecond fraction).
   """,
   examples = """
     Examples:
@@ -5330,9 +5355,10 @@ object TimeBucketExpressionBuilder extends ExpressionBuilder {
       Literal(DateTimeUtils.daysToMicros(0, zoneId), TimestampType)
     case _: TimestampLTZNanosType =>
       val zoneId = DateTimeUtils.getZoneId(SQLConf.get.sessionLocalTimeZone)
-      Literal(TimestampNanosVal.fromParts(DateTimeUtils.daysToMicros(0, zoneId), 0), tsType)
+      val originMicros = DateTimeUtils.daysToMicros(0, zoneId)
+      Literal(TimestampNanosVal.fromParts(originMicros, 0.toShort), tsType)
     case _: TimestampNTZNanosType =>
-      Literal(TimestampNanosVal.fromParts(0L, 0), tsType)
+      Literal(TimestampNanosVal.fromParts(0L, 0.toShort), tsType)
     case _ => Literal(0L, tsType)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -3487,6 +3487,63 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     assert(r5.errorSubClass == "UNEXPECTED_INPUT_TYPE")
   }
 
+  test("time_bucket: nanosecond-precision timestamps") {
+    // Pin session zone to UTC so LTZ and NTZ share the same epochMicros for a given wall clock.
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+      sdf.setTimeZone(TimeZone.getTimeZone(UTC))
+      val tsMicros =
+        timestampAnswer("2024-01-01 11:27:00.000", sdf, TimestampType).asInstanceOf[Long]
+      val hourBucketMicros =
+        timestampAnswer("2024-01-01 11:00:00.000", sdf, TimestampType).asInstanceOf[Long]
+      val monthBucketMicros =
+        timestampAnswer("2024-01-01 00:00:00.000", sdf, TimestampType).asInstanceOf[Long]
+
+      Seq[Int => DataType](TimestampLTZNanosType(_), TimestampNTZNanosType(_)).foreach { mk =>
+        Seq(7, 8, 9).foreach { p =>
+          val dt = mk(p)
+          val origin = Literal(TimestampNanosVal.fromParts(0L, 0), dt)
+          // A non-zero sub-microsecond component (100ns is valid at every supported precision)
+          // must not affect which bucket ts falls into, and the bucket start is cleared to a
+          // micro boundary (nanosWithinMicro = 0).
+          val tsNanos = Literal(TimestampNanosVal.fromParts(tsMicros, 100.toShort), dt)
+
+          // day-time interval: 1-hour bucket.
+          checkEvaluation(
+            TimeBucket(Literal(Duration.ofHours(1)), tsNanos, origin),
+            TimestampNanosVal.fromParts(hourBucketMicros, 0))
+          // year-month interval: 1-month bucket.
+          checkEvaluation(
+            TimeBucket(Literal(Period.ofMonths(1)), tsNanos, origin),
+            TimestampNanosVal.fromParts(monthBucketMicros, 0))
+          // The result keeps the ts's exact nanos type/precision.
+          assert(TimeBucket(Literal(Duration.ofHours(1)), tsNanos, origin).dataType === dt)
+          // NULL ts -> NULL.
+          checkEvaluation(
+            TimeBucket(Literal(Duration.ofHours(1)), Literal.create(null, dt), origin), null)
+        }
+      }
+    }
+  }
+
+  test("time_bucket: ExpressionBuilder with nanosecond timestamps") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      val hour = Literal(Duration.ofHours(1))
+      Seq(7, 8, 9).foreach { p =>
+        Seq(TimestampLTZNanosType(p), TimestampNTZNanosType(p)).foreach { dt =>
+          val tsN = Literal(TimestampNanosVal.fromParts(0L, 0), dt)
+          // 2-arg form supplies an epoch default origin with the ts's exact nanos type, so the
+          // ts/origin type check passes and the result keeps the nanos type.
+          val built = TimeBucketExpressionBuilder.build("time_bucket", Seq(hour, tsN))
+            .asInstanceOf[TimeBucket]
+          assert(built.dataType === dt)
+          assert(built.originTs.dataType === dt)
+          assert(built.checkInputDataTypes().isSuccess)
+        }
+      }
+    }
+  }
+
   test("SPARK-57837: CurrentTimestampExpressionBuilder") {
     // No argument keeps the historical micro TIMESTAMP expressions.
     assert(CurrentTimestampExpressionBuilder.build("current_timestamp", Seq.empty) ===

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala
@@ -3539,7 +3539,49 @@ class DateExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
           assert(built.dataType === dt)
           assert(built.originTs.dataType === dt)
           assert(built.checkInputDataTypes().isSuccess)
+
+          // 3-arg NULL ts + nanos origin: ts is retyped to the origin's nanos type.
+          val built3 = TimeBucketExpressionBuilder.build(
+            "time_bucket", Seq(hour, Literal(null, NullType), tsN)).asInstanceOf[TimeBucket]
+          assert(built3.ts.dataType === dt)
+          assert(built3.checkInputDataTypes().isSuccess)
         }
+      }
+    }
+  }
+
+  test("time_bucket: a sub-microsecond nanos origin is rejected") {
+    val hour = Literal(Duration.ofHours(1))
+    Seq(TimestampLTZNanosType(9), TimestampNTZNanosType(9)).foreach { dt =>
+      val ts = Literal(TimestampNanosVal.fromParts(0L, 0.toShort), dt)
+      // A non-zero sub-microsecond origin fraction would shift the grid off the micro boundary.
+      val subMicroOrigin = Literal(TimestampNanosVal.fromParts(0L, 500.toShort), dt)
+      val mismatch =
+        TimeBucket(hour, ts, subMicroOrigin).checkInputDataTypes().asInstanceOf[DataTypeMismatch]
+      assert(mismatch.errorSubClass == "INVALID_ARG_VALUE")
+      // A microsecond-aligned origin is accepted.
+      val goodOrigin = Literal(TimestampNanosVal.fromParts(123L, 0.toShort), dt)
+      assert(TimeBucket(hour, ts, goodOrigin).checkInputDataTypes().isSuccess)
+    }
+  }
+
+  test("time_bucket: LTZ nanos honors the session time zone") {
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
+      val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+      sdf.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"))
+      val tsMicros =
+        timestampAnswer("2024-07-15 10:00:00.000", sdf, TimestampType).asInstanceOf[Long]
+      val originMicros = DateTimeUtils.daysToMicros(0, getZoneId("America/Los_Angeles"))
+      // Summer ts in LA (PDT); the 1-month bucket aligns to the local calendar month start.
+      val expectedMicros =
+        timestampAnswer("2024-07-01 00:00:00.000", sdf, TimestampType).asInstanceOf[Long]
+      Seq(7, 8, 9).foreach { p =>
+        val dt = TimestampLTZNanosType(p)
+        val tsN = Literal(TimestampNanosVal.fromParts(tsMicros, 100.toShort), dt)
+        val origin = Literal(TimestampNanosVal.fromParts(originMicros, 0.toShort), dt)
+        checkEvaluation(
+          TimeBucket(Literal(Period.ofMonths(1)), tsN, origin),
+          TimestampNanosVal.fromParts(expectedMicros, 0.toShort))
       }
     }
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/time-bucket.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/time-bucket.sql.out
@@ -318,7 +318,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"DATE '2024-01-15'\"",
     "inputType" : "\"DATE\"",
     "paramIndex" : "second",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, DATE '2024-01-15', TIMESTAMP '1970-01-01 00:00:00')\""
   },
   "queryContext" : [ {
@@ -342,7 +342,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"2024-01-15 10:23:00\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "second",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, 2024-01-15 10:23:00, TIMESTAMP '1970-01-01 00:00:00')\""
   },
   "queryContext" : [ {
@@ -366,7 +366,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"DATE '2024-01-01'\"",
     "inputType" : "\"DATE\"",
     "paramIndex" : "third",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-15 10:23:00', DATE '2024-01-01')\""
   },
   "queryContext" : [ {
@@ -390,7 +390,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"2024-01-01 00:00:00\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "third",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-15 10:23:00', 2024-01-01 00:00:00)\""
   },
   "queryContext" : [ {

--- a/sql/core/src/test/resources/sql-tests/results/time-bucket.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/time-bucket.sql.out
@@ -348,7 +348,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"DATE '2024-01-15'\"",
     "inputType" : "\"DATE\"",
     "paramIndex" : "second",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, DATE '2024-01-15', TIMESTAMP '1970-01-01 00:00:00')\""
   },
   "queryContext" : [ {
@@ -374,7 +374,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"2024-01-15 10:23:00\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "second",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, 2024-01-15 10:23:00, TIMESTAMP '1970-01-01 00:00:00')\""
   },
   "queryContext" : [ {
@@ -400,7 +400,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"DATE '2024-01-01'\"",
     "inputType" : "\"DATE\"",
     "paramIndex" : "third",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-15 10:23:00', DATE '2024-01-01')\""
   },
   "queryContext" : [ {
@@ -426,7 +426,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
     "inputSql" : "\"2024-01-01 00:00:00\"",
     "inputType" : "\"STRING\"",
     "paramIndex" : "third",
-    "requiredType" : "\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\"",
+    "requiredType" : "(\"(TIMESTAMP OR TIMESTAMP WITHOUT TIME ZONE)\" or \"(TIMESTAMP_LTZ(P) OR TIMESTAMP_NTZ(P) WITH P IN [7, 9])\")",
     "sqlExpr" : "\"time_bucket(INTERVAL '15' MINUTE, TIMESTAMP '2024-01-15 10:23:00', 2024-01-01 00:00:00)\""
   },
   "queryContext" : [ {


### PR DESCRIPTION

### What changes were proposed in this pull request?
`time_bucket(bucketSize, ts[, origin])` now accepts and returns nanosecond-precision timestamps (`TIMESTAMP_LTZ(p)` / `TIMESTAMP_NTZ(p)`, p ∈ [7, 9]), alongside the existing microsecond types.

### Why are the changes needed?
Part of nanosecond-precision timestamp support (SPARK-56822). `time_bucket` previously rejected nanosecond timestamps at analysis.

### Does this PR introduce _any_ user-facing change?
Yes, `time_bucket` now works on nanosecond-precision timestamp columns.


### How was this patch tested?
New `DateExpressionsSuite` cases covering day-time and year-month buckets


### Was this patch authored or co-authored using generative AI tooling?
Co-authored-by: Claude Code 4.8
