### PR TITLE
[SPARK-59376][ML][PYTHON] Add frequency encoding to ml.feature

### DIFF
--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -965,6 +965,74 @@ for more details on the API.
 
 </div>
 
+## FrequencyEncoder
+
+Frequency encoding maps a column of categorical indices to how often each category occurs in the training data.
+
+`FrequencyEncoder` needs no label, which is what separates it from `TargetEncoder`, so it is available in unsupervised pipelines such as clustering or anomaly detection. It also adds one output column per input column rather than one per category, unlike `OneHotEncoder`, which keeps it practical when a feature has many thousands of distinct values.
+
+`FrequencyEncoder` supports the `normalize` parameter to choose what the encoding measures. When 'true', the default, each category is encoded as the proportion of the training rows it accounts for, so the encodings for a feature sum to one and stay comparable across datasets of different sizes. When 'false', each category is encoded as its raw count.
+
+`FrequencyEncoder` supports the `handleInvalid` parameter to choose how to handle invalid input, meaning categories not seen at training, when encoding new data. Available options include 'keep' (unseen categories are encoded as zero, which is the frequency actually observed for them) and 'error' (throw an exception).
+
+Note that categories occurring equally often in the training data receive the same encoding. That is inherent to the technique rather than a limitation of this implementation: the encoding carries how common a category is and nothing that distinguishes one equally common category from another. Where that distinction matters, `OneHotEncoder` or `TargetEncoder` are the better fit.
+
+**Examples**
+
+Assume we have the following DataFrame with columns `categoryIndex1` and `categoryIndex2`, of six rows:
+
+~~~~
+categoryIndex1 | categoryIndex2
+---------------|---------------
+           0.0 |            1.0
+           1.0 |            0.0
+           2.0 |            1.0
+           0.0 |            2.0
+           0.0 |            1.0
+           2.0 |            0.0
+~~~~
+
+In `categoryIndex1`, category 0.0 occurs three times out of six, 2.0 twice and 1.0 once. Applying `FrequencyEncoder` with the default `normalize` of 'true', we get:
+
+~~~~
+categoryIndex1 | categoryIndex2 | categoryIndex1Freq | categoryIndex2Freq
+---------------|----------------|--------------------|-------------------
+           0.0 |            1.0 |            0.5     |            0.5
+           1.0 |            0.0 |            0.16666 |            0.33333
+           2.0 |            1.0 |            0.33333 |            0.5
+           0.0 |            2.0 |            0.5     |            0.16666
+           0.0 |            1.0 |            0.5     |            0.5
+           2.0 |            0.0 |            0.33333 |            0.33333
+~~~~
+
+With `normalize` set to 'false' the same fit produces raw counts instead, so `categoryIndex1Freq` would read 3.0, 1.0, 2.0, 3.0, 3.0, 2.0.
+
+<div class="codetabs">
+
+<div data-lang="python" markdown="1">
+
+Refer to the [FrequencyEncoder Python docs](api/python/reference/api/pyspark.ml.feature.FrequencyEncoder.html) for more details on the API.
+
+{% include_example python/ml/frequency_encoder_example.py %}
+</div>
+
+<div data-lang="scala" markdown="1">
+
+Refer to the [FrequencyEncoder Scala docs](api/scala/org/apache/spark/ml/feature/FrequencyEncoder.html) for more details on the API.
+
+{% include_example scala/org/apache/spark/examples/ml/FrequencyEncoderExample.scala %}
+</div>
+
+<div data-lang="java" markdown="1">
+
+Refer to the [FrequencyEncoder Java docs](api/java/org/apache/spark/ml/feature/FrequencyEncoder.html)
+for more details on the API.
+
+{% include_example java/org/apache/spark/examples/ml/JavaFrequencyEncoderExample.java %}
+</div>
+
+</div>
+
 ## VectorIndexer
 
 `VectorIndexer` helps index categorical features in datasets of `Vector`s.

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -969,7 +969,7 @@ for more details on the API.
 
 `FrequencyEncoder` maps a column of categorical indices to how often each category occurs in the training data.
 
-Unlike `TargetEncoder`, it requires no label column, so it can be used in unsupervised pipelines. Unlike `OneHotEncoder`, it produces one output column per input column rather than one column per category, so it stays practical for features with many distinct values.
+Unlike `TargetEncoder`, it requires no label column, so it can be used in unsupervised pipelines. Where `OneHotEncoder` represents a feature as a vector with one dimension per category, `FrequencyEncoder` reduces it to a single scalar, so the feature space stays flat however many distinct values a column has. The trade is that the encoding carries how common a category is rather than which category it was.
 
 `FrequencyEncoder` supports the `normalize` parameter to choose what the encoding measures. Available options include 'true' (the default, where each category is encoded as its proportion of the training rows) and 'false' (where each category is encoded as its raw count).
 

--- a/docs/ml-features.md
+++ b/docs/ml-features.md
@@ -967,15 +967,15 @@ for more details on the API.
 
 ## FrequencyEncoder
 
-Frequency encoding maps a column of categorical indices to how often each category occurs in the training data.
+`FrequencyEncoder` maps a column of categorical indices to how often each category occurs in the training data.
 
-`FrequencyEncoder` needs no label, which is what separates it from `TargetEncoder`, so it is available in unsupervised pipelines such as clustering or anomaly detection. It also adds one output column per input column rather than one per category, unlike `OneHotEncoder`, which keeps it practical when a feature has many thousands of distinct values.
+Unlike `TargetEncoder`, it requires no label column, so it can be used in unsupervised pipelines. Unlike `OneHotEncoder`, it produces one output column per input column rather than one column per category, so it stays practical for features with many distinct values.
 
-`FrequencyEncoder` supports the `normalize` parameter to choose what the encoding measures. When 'true', the default, each category is encoded as the proportion of the training rows it accounts for, so the encodings for a feature sum to one and stay comparable across datasets of different sizes. When 'false', each category is encoded as its raw count.
+`FrequencyEncoder` supports the `normalize` parameter to choose what the encoding measures. Available options include 'true' (the default, where each category is encoded as its proportion of the training rows) and 'false' (where each category is encoded as its raw count).
 
-`FrequencyEncoder` supports the `handleInvalid` parameter to choose how to handle invalid input, meaning categories not seen at training, when encoding new data. Available options include 'keep' (unseen categories are encoded as zero, which is the frequency actually observed for them) and 'error' (throw an exception).
+`FrequencyEncoder` supports the `handleInvalid` parameter to choose how to handle invalid input, meaning categories not seen at training, when encoding new data. Available options include 'keep' (unseen categories are encoded as zero) and 'error' (throw an exception).
 
-Note that categories occurring equally often in the training data receive the same encoding. That is inherent to the technique rather than a limitation of this implementation: the encoding carries how common a category is and nothing that distinguishes one equally common category from another. Where that distinction matters, `OneHotEncoder` or `TargetEncoder` are the better fit.
+Note that categories occurring equally often in the training data receive the same encoding.
 
 **Examples**
 
@@ -998,9 +998,9 @@ In `categoryIndex1`, category 0.0 occurs three times out of six, 2.0 twice and 1
 categoryIndex1 | categoryIndex2 | categoryIndex1Freq | categoryIndex2Freq
 ---------------|----------------|--------------------|-------------------
            0.0 |            1.0 |            0.5     |            0.5
-           1.0 |            0.0 |            0.16666 |            0.33333
+           1.0 |            0.0 |            0.16667 |            0.33333
            2.0 |            1.0 |            0.33333 |            0.5
-           0.0 |            2.0 |            0.5     |            0.16666
+           0.0 |            2.0 |            0.5     |            0.16667
            0.0 |            1.0 |            0.5     |            0.5
            2.0 |            0.0 |            0.33333 |            0.33333
 ~~~~

--- a/examples/src/main/java/org/apache/spark/examples/ml/JavaFrequencyEncoderExample.java
+++ b/examples/src/main/java/org/apache/spark/examples/ml/JavaFrequencyEncoderExample.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.examples.ml;
+
+import org.apache.spark.sql.SparkSession;
+
+// $example on$
+import org.apache.spark.ml.feature.FrequencyEncoder;
+import org.apache.spark.ml.feature.FrequencyEncoderModel;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.Arrays;
+import java.util.List;
+// $example off$
+
+public class JavaFrequencyEncoderExample {
+  public static void main(String[] args) {
+    SparkSession spark = SparkSession
+      .builder()
+      .appName("JavaFrequencyEncoderExample")
+      .getOrCreate();
+
+    // Note: categorical features are usually first encoded with StringIndexer
+    // $example on$
+    List<Row> data = Arrays.asList(
+      RowFactory.create(0.0, 1.0),
+      RowFactory.create(1.0, 0.0),
+      RowFactory.create(2.0, 1.0),
+      RowFactory.create(0.0, 2.0),
+      RowFactory.create(0.0, 1.0),
+      RowFactory.create(2.0, 0.0)
+    );
+
+    StructType schema = new StructType(new StructField[]{
+      new StructField("categoryIndex1", DataTypes.DoubleType, false, Metadata.empty()),
+      new StructField("categoryIndex2", DataTypes.DoubleType, false, Metadata.empty())
+    });
+
+    Dataset<Row> df = spark.createDataFrame(data, schema);
+
+    // proportions of the training rows, the default
+    FrequencyEncoder encoder = new FrequencyEncoder()
+      .setInputCols(new String[]{"categoryIndex1", "categoryIndex2"})
+      .setOutputCols(new String[]{"categoryIndex1Freq", "categoryIndex2Freq"});
+
+    FrequencyEncoderModel model = encoder.fit(df);
+    Dataset<Row> encoded = model.transform(df);
+    encoded.show();
+
+    // raw counts instead of proportions
+    FrequencyEncoder countEncoder = new FrequencyEncoder()
+      .setInputCols(new String[]{"categoryIndex1", "categoryIndex2"})
+      .setOutputCols(new String[]{"categoryIndex1Count", "categoryIndex2Count"})
+      .setNormalize(false);
+
+    FrequencyEncoderModel countModel = countEncoder.fit(df);
+    Dataset<Row> countEncoded = countModel.transform(df);
+    countEncoded.show();
+    // $example off$
+
+    spark.stop();
+  }
+}

--- a/examples/src/main/python/ml/frequency_encoder_example.py
+++ b/examples/src/main/python/ml/frequency_encoder_example.py
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# $example on$
+from pyspark.ml.feature import FrequencyEncoder
+
+# $example off$
+from pyspark.sql import SparkSession
+
+if __name__ == "__main__":
+    spark = SparkSession.builder.appName("FrequencyEncoderExample").getOrCreate()
+
+    # Note: categorical features are usually first encoded with StringIndexer
+    # $example on$
+    df = spark.createDataFrame(
+        [
+            (0.0, 1.0),
+            (1.0, 0.0),
+            (2.0, 1.0),
+            (0.0, 2.0),
+            (0.0, 1.0),
+            (2.0, 0.0),
+        ],
+        ["categoryIndex1", "categoryIndex2"],
+    )
+
+    # proportions of the training rows, the default
+    encoder = FrequencyEncoder(
+        inputCols=["categoryIndex1", "categoryIndex2"],
+        outputCols=["categoryIndex1Freq", "categoryIndex2Freq"],
+    )
+    model = encoder.fit(df)
+    encoded = model.transform(df)
+    encoded.show()
+
+    # raw counts instead of proportions
+    count_encoder = FrequencyEncoder(
+        inputCols=["categoryIndex1", "categoryIndex2"],
+        outputCols=["categoryIndex1Count", "categoryIndex2Count"],
+        normalize=False,
+    )
+    count_model = count_encoder.fit(df)
+    count_encoded = count_model.transform(df)
+    count_encoded.show()
+    # $example off$
+
+    spark.stop()

--- a/examples/src/main/scala/org/apache/spark/examples/ml/FrequencyEncoderExample.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/ml/FrequencyEncoderExample.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// scalastyle:off println
+package org.apache.spark.examples.ml
+
+// $example on$
+import org.apache.spark.ml.feature.FrequencyEncoder
+// $example off$
+import org.apache.spark.sql.SparkSession
+
+object FrequencyEncoderExample {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder()
+      .appName("FrequencyEncoderExample")
+      .getOrCreate()
+
+    // Note: categorical features are usually first encoded with StringIndexer
+    // $example on$
+    val df = spark.createDataFrame(Seq(
+      (0.0, 1.0),
+      (1.0, 0.0),
+      (2.0, 1.0),
+      (0.0, 2.0),
+      (0.0, 1.0),
+      (2.0, 0.0)
+    )).toDF("categoryIndex1", "categoryIndex2")
+
+    // proportions of the training rows, the default
+    val encoder = new FrequencyEncoder()
+      .setInputCols(Array("categoryIndex1", "categoryIndex2"))
+      .setOutputCols(Array("categoryIndex1Freq", "categoryIndex2Freq"))
+
+    val model = encoder.fit(df)
+    val encoded = model.transform(df)
+    encoded.show()
+
+    // raw counts instead of proportions
+    val countEncoder = new FrequencyEncoder()
+      .setInputCols(Array("categoryIndex1", "categoryIndex2"))
+      .setOutputCols(Array("categoryIndex1Count", "categoryIndex2Count"))
+      .setNormalize(false)
+
+    val countModel = countEncoder.fit(df)
+    val countEncoded = countModel.transform(df)
+    countEncoded.show()
+    // $example off$
+
+    spark.stop()
+  }
+}
+// scalastyle:on println

--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Estimator
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Estimator
@@ -69,5 +69,6 @@ org.apache.spark.ml.feature.Word2Vec
 org.apache.spark.ml.feature.CountVectorizer
 org.apache.spark.ml.feature.OneHotEncoder
 org.apache.spark.ml.feature.TargetEncoder
+org.apache.spark.ml.feature.FrequencyEncoder
 org.apache.spark.ml.feature.BucketedRandomProjectionLSH
 org.apache.spark.ml.feature.MinHashLSH

--- a/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
+++ b/mllib/src/main/resources/META-INF/services/org.apache.spark.ml.Transformer
@@ -91,5 +91,6 @@ org.apache.spark.ml.feature.Word2VecModel
 org.apache.spark.ml.feature.CountVectorizerModel
 org.apache.spark.ml.feature.OneHotEncoderModel
 org.apache.spark.ml.feature.TargetEncoderModel
+org.apache.spark.ml.feature.FrequencyEncoderModel
 org.apache.spark.ml.feature.BucketedRandomProjectionLSHModel
 org.apache.spark.ml.feature.MinHashLSHModel

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -363,9 +363,18 @@ class FrequencyEncoderModel private[ml] (
           when(castedCol.isNull, fillNullCol).otherwise(fillUnseenCol)
         } else {
           val targetCol = try_element_at(typedlit(filteredMapping), castedCol)
-          when(castedCol.isNull, fillNullCol)
-            .when(!targetCol.isNull, targetCol)
-            .otherwise(fillUnseenCol)
+          // coalesce, rather than testing the lookup for null and then reading it again. The
+          // second shape evaluated the lookup twice for a known category and common
+          // subexpression elimination did not remove the duplicate: the generated Java carried
+          // two scan loops below spark.sql.optimizer.mapLookupHashThreshold and two hash probes
+          // at or above it. coalesce evaluates its arguments lazily, so fillUnseenCol, which is
+          // a raise_error under handleInvalid=error, still fires only on an actual miss.
+          //
+          // The null branch stays explicit because a learned null category carries an encoding
+          // of its own, which coalesce could not distinguish from a miss. Every fitted value is
+          // a non-null double, so a null coming back from the lookup can only mean the category
+          // was absent.
+          when(castedCol.isNull, fillNullCol).otherwise(coalesce(targetCol, fillUnseenCol))
         }
 
         // Numeric, not nominal: an encoded frequency is a continuous quantity, and its ordering

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -46,7 +46,7 @@ private[ml] trait FrequencyEncoderBase extends Params
    * Default: "error"
    * @group param
    */
-  @Since("5.0.0")
+  @Since("4.4.0")
   override val handleInvalid: Param[String] = new Param[String](this, "handleInvalid",
     "How to handle invalid data during transform(). " +
       "Options are 'keep' (unseen categories are encoded as zero) " +
@@ -64,7 +64,7 @@ private[ml] trait FrequencyEncoderBase extends Params
    * Default: true
    * @group param
    */
-  @Since("5.0.0")
+  @Since("4.4.0")
   val normalize: BooleanParam = new BooleanParam(this, "normalize",
     "Whether to encode categories as a proportion of the training rows (true) or as a raw " +
       "count (false). Note that this Param is only used during fitting.")
@@ -72,7 +72,7 @@ private[ml] trait FrequencyEncoderBase extends Params
   setDefault(normalize -> true)
 
   /** @group getParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   final def getNormalize: Boolean = $(normalize)
 
   private[feature] def inputFeatures: Array[String] =
@@ -84,14 +84,32 @@ private[ml] trait FrequencyEncoderBase extends Params
       Array.empty[String]
     }
 
+  // No derived default such as `input_encoded`. Deriving one from the input name leaves
+  // `getOutputCol` reporting HasOutputCol's default while `transform` produces something else,
+  // so a caller passing the getter's answer downstream gets a column that does not exist.
+  // Falling through to `$(outputCol)` keeps the getters truthful.
   private[feature] def outputFeatures: Array[String] =
     if (isSet(outputCol)) {
       Array($(outputCol))
     } else if (isSet(outputCols)) {
       $(outputCols)
+    } else if (isSet(inputCol)) {
+      Array($(outputCol))
     } else {
-      inputFeatures.map { field: String => s"${field}_encoded" }
+      Array.empty[String]
     }
+
+  // One definition of the output schema, shared by the estimator and the model so they cannot
+  // disagree. SchemaUtils.appendColumn rejects a name that already exists, which gives output
+  // collisions a single consistent answer instead of a schema that claims a duplicate field
+  // while the transformed frame quietly replaces one.
+  private[feature] def outputSchema(schema: StructType): StructType = {
+    validateSchema(schema)
+    outputFeatures.foldLeft(schema) { (acc, name) =>
+      SchemaUtils.appendColumn(acc, StructField(name, DoubleType, nullable = false,
+        NumericAttribute.defaultAttr.withName(name).toMetadata()))
+    }
+  }
 
   private[feature] def validateSchema(schema: StructType): StructType = {
 
@@ -139,58 +157,70 @@ private[ml] trait FrequencyEncoderBase extends Params
  * @see `StringIndexer` for converting categorical values into category indices
  * @see `TargetEncoder` for encoding categories against a label
  */
-@Since("5.0.0")
-class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String)
+@Since("4.4.0")
+class FrequencyEncoder @Since("4.4.0") (@Since("4.4.0") override val uid: String)
   extends Estimator[FrequencyEncoderModel] with FrequencyEncoderBase with DefaultParamsWritable {
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   def this() = this(Identifiable.randomUID("frequencyEncoder"))
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setInputCol(value: String): this.type = set(inputCol, value)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setInputCols(values: Array[String]): this.type = set(inputCols, values)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setOutputCols(values: Array[String]): this.type = set(outputCols, values)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setNormalize(value: Boolean): this.type = set(normalize, value)
 
-  @Since("5.0.0")
-  override def transformSchema(schema: StructType): StructType = {
-    validateSchema(schema)
-  }
+  @Since("4.4.0")
+  override def transformSchema(schema: StructType): StructType = outputSchema(schema)
 
   private def extractValue(name: String): Column = {
     val c = col(name).cast(DoubleType)
-    // Integrality is tested with a remainder rather than by casting to Int. Casting raises
-    // CAST_OVERFLOW for an id beyond Int range, which is a confusing way to reject a perfectly
-    // good category and points the user at a `try_cast` they never wrote. A Double represents
-    // integers exactly up to 2^53, so anything accepted here is still a safe map key.
-    when(c >= 0 && c % 1 === 0, c)
-      .when(c.isNull, lit(FrequencyEncoder.NULL_CATEGORY))
-      .when(c.isNaN, raise_error(lit("Values MUST NOT be NaN")))
-      .otherwise(raise_error(
-        concat(lit("Values MUST be non-negative integers, but got "), c)))
+    val notAnIndex = raise_error(
+      concat(lit(s"Values from column $name MUST be non-negative integers, but got "), c))
+    val outOfRange = raise_error(
+      concat(lit(s"FrequencyEncoder only supports up to ${FrequencyEncoder.MAX_INDEX} " +
+        "indices, but got "), c))
+    // The order of these branches is load bearing. Categories are carried as Double map keys,
+    // and a Double represents integers exactly only up to 2^53, so a value above that would
+    // alias a different one and merge two distinct categories without saying so. The range is
+    // therefore checked before anything narrows, which also makes the integrality test below
+    // safe: by the time it runs the value is known to fit. `OneHotEncoder` caps category
+    // indices the same way, and `StringIndexer` is the documented way to produce them.
+    when(c.isNull, lit(FrequencyEncoder.NULL_CATEGORY))
+      .when(c.isNaN, raise_error(lit(s"Values from column $name MUST NOT be NaN")))
+      .when(c < 0, notAnIndex)
+      .when(c > FrequencyEncoder.MAX_INDEX, outOfRange)
+      // Integrality is tested on the source column, not on `c`. Casting to double first would
+      // hide a fractional decimal: decimal(38,18) 1.000000000000000001 becomes exactly 1.0 and
+      // would then pass as category 1, quietly merging with real 1s. By this branch the
+      // magnitude is known to be within range, so casting to long here cannot overflow.
+      .when(col(name) =!= col(name).cast(LongType), notAnIndex)
+      .otherwise(c)
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def fit(dataset: Dataset[_]): FrequencyEncoderModel = {
-    validateSchema(dataset.schema)
+    // transformSchema rather than validateSchema, so an output column that collides with an
+    // existing one is refused here rather than after the work of fitting is already done.
+    transformSchema(dataset.schema, logging = true)
     val numFeatures = inputFeatures.length
 
     // One array plus one posexplode, so a single groupBy aggregates every input column rather
@@ -224,11 +254,11 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
     copyValues(model)
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def copy(extra: ParamMap): FrequencyEncoder = defaultCopy(extra)
 }
 
-@Since("5.0.0")
+@Since("4.4.0")
 object FrequencyEncoder extends DefaultParamsReadable[FrequencyEncoder] {
 
   // handleInvalid parameter values
@@ -238,7 +268,12 @@ object FrequencyEncoder extends DefaultParamsReadable[FrequencyEncoder] {
 
   private[feature] val NULL_CATEGORY: Double = -1
 
-  @Since("5.0.0")
+  // Category indices are carried as Double map keys, which are exact only to 2^53. Capping at
+  // Int.MaxValue keeps every accepted index exactly representable, so two distinct inputs can
+  // never collapse onto one key. This is the same ceiling OneHotEncoder applies to indices.
+  private[feature] val MAX_INDEX: Int = Int.MaxValue
+
+  @Since("4.4.0")
   override def load(path: String): FrequencyEncoder = super.load(path)
 }
 
@@ -251,11 +286,14 @@ object FrequencyEncoder extends DefaultParamsReadable[FrequencyEncoder] {
  * @param encodings  Array of encodings for each input feature.
  *                   Array( Map( category, frequency ) )
  */
-@Since("5.0.0")
+@Since("4.4.0")
 class FrequencyEncoderModel private[ml] (
-    @Since("5.0.0") override val uid: String,
-    @Since("5.0.0") private[ml] val encodings: Array[Map[Double, Double]])
+    @Since("4.4.0") override val uid: String,
+    @Since("4.4.0") private[ml] val encodings: Array[Map[Double, Double]])
   extends Model[FrequencyEncoderModel] with FrequencyEncoderBase with MLWritable {
+
+  // For ml connect only
+  private[ml] def this() = this("", Array.empty)
 
   private[spark] override def estimatedSize: Long = {
     var size = estimateMatadataSize
@@ -265,39 +303,36 @@ class FrequencyEncoderModel private[ml] (
   }
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setInputCol(value: String): this.type = set(inputCol, value)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setInputCols(values: Array[String]): this.type = set(inputCols, values)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setOutputCols(values: Array[String]): this.type = set(outputCols, values)
 
   /** @group setParam */
-  @Since("5.0.0")
+  @Since("4.4.0")
   def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def transformSchema(schema: StructType): StructType = {
-    if (outputFeatures.length == encodings.length) {
-      outputFeatures.filter(_ != null)
-        .foldLeft(validateSchema(schema)) {
-          case (newSchema, outputField) =>
-            newSchema.add(StructField(outputField, DoubleType, nullable = false))
-        }
-    } else throw new SparkException("The number of features does not match the number of " +
-      s"encodings in the model (${encodings.length}). " +
-      s"found ${outputFeatures.length} output columns.")
+    if (outputFeatures.length != encodings.length) {
+      throw new SparkException("The number of features does not match the number of " +
+        s"encodings in the model (${encodings.length}). " +
+        s"found ${outputFeatures.length} output columns.")
+    }
+    outputSchema(schema)
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema)
 
@@ -339,16 +374,16 @@ class FrequencyEncoderModel private[ml] (
     dataset.withColumns(outputFeatures.toIndexedSeq, newCols.toIndexedSeq)
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def copy(extra: ParamMap): FrequencyEncoderModel = {
     val copied = new FrequencyEncoderModel(uid, encodings)
     copyValues(copied, extra).setParent(parent)
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def write: MLWriter = new FrequencyEncoderModel.FrequencyEncoderModelWriter(this)
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def toString: String = {
     s"FrequencyEncoderModel: uid=$uid, " +
       s"handleInvalid=${$(handleInvalid)}, normalize=${$(normalize)}, " +
@@ -356,7 +391,7 @@ class FrequencyEncoderModel private[ml] (
   }
 }
 
-@Since("5.0.0")
+@Since("4.4.0")
 object FrequencyEncoderModel extends MLReadable[FrequencyEncoderModel] {
   private[ml] case class Data(index: Int, categories: Array[Double], frequencies: Array[Double])
 
@@ -410,9 +445,9 @@ object FrequencyEncoderModel extends MLReadable[FrequencyEncoderModel] {
     }
   }
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def read: MLReader[FrequencyEncoderModel] = new FrequencyEncoderModelReader
 
-  @Since("5.0.0")
+  @Since("4.4.0")
   override def load(path: String): FrequencyEncoderModel = super.load(path)
 }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import java.io.{DataInputStream, DataOutputStream}
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.spark.SparkException
+import org.apache.spark.annotation.Since
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.attribute.NumericAttribute
+import org.apache.spark.ml.param._
+import org.apache.spark.ml.param.shared._
+import org.apache.spark.ml.util._
+import org.apache.spark.sql.{Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.util.SizeEstimator
+
+/** Private trait for params and common methods for FrequencyEncoder and FrequencyEncoderModel */
+private[ml] trait FrequencyEncoderBase extends Params
+  with HasInputCol with HasInputCols with HasOutputCol with HasOutputCols with HasHandleInvalid {
+
+  /**
+   * Param for how to handle invalid data during transform().
+   * Options are 'keep' (unseen categories encoded as zero, since a category absent from the
+   * training data was observed zero times) or 'error' (throw an error).
+   * Note that this Param is only used during transform; during fitting, invalid data
+   * will result in an error.
+   * Default: "error"
+   * @group param
+   */
+  @Since("5.0.0")
+  override val handleInvalid: Param[String] = new Param[String](this, "handleInvalid",
+    "How to handle invalid data during transform(). " +
+      "Options are 'keep' (unseen categories are encoded as zero) " +
+      "or 'error' (throw an error). Note that this Param is only used during transform; " +
+      "during fitting, invalid data will result in an error.",
+    ParamValidators.inArray(FrequencyEncoder.supportedHandleInvalids))
+
+  setDefault(handleInvalid -> FrequencyEncoder.ERROR_INVALID)
+
+  /**
+   * Param for whether to encode categories as a proportion of the training rows rather than
+   * as a raw count. Proportions are comparable across datasets of different sizes, which is
+   * usually what is wanted when the encoding feeds a model; raw counts preserve the absolute
+   * scale.
+   * Default: true
+   * @group param
+   */
+  @Since("5.0.0")
+  val normalize: BooleanParam = new BooleanParam(this, "normalize",
+    "Whether to encode categories as a proportion of the training rows (true) or as a raw " +
+      "count (false). Note that this Param is only used during fitting.")
+
+  setDefault(normalize -> true)
+
+  /** @group getParam */
+  @Since("5.0.0")
+  final def getNormalize: Boolean = $(normalize)
+
+  private[feature] def inputFeatures: Array[String] =
+    if (isSet(inputCol)) {
+      Array($(inputCol))
+    } else if (isSet(inputCols)) {
+      $(inputCols)
+    } else {
+      Array.empty[String]
+    }
+
+  private[feature] def outputFeatures: Array[String] =
+    if (isSet(outputCol)) {
+      Array($(outputCol))
+    } else if (isSet(outputCols)) {
+      $(outputCols)
+    } else {
+      inputFeatures.map { field: String => s"${field}_encoded" }
+    }
+
+  private[feature] def validateSchema(schema: StructType, fitting: Boolean): StructType = {
+
+    require(inputFeatures.length > 0,
+      s"At least one input column must be specified.")
+
+    require(inputFeatures.length == outputFeatures.length,
+      s"The number of input columns ${inputFeatures.length} must be the same as the number of " +
+        s"output columns ${outputFeatures.length}.")
+
+    inputFeatures.foreach { feature =>
+      try {
+        val field = schema(feature)
+        if (!field.dataType.isInstanceOf[NumericType]) {
+          throw new SparkException(s"Data type for column ${feature} is ${field.dataType}" +
+            s", but a subclass of ${NumericType} is required.")
+        }
+      } catch {
+        case e: IllegalArgumentException =>
+          throw new SparkException(s"No column named ${feature} found on dataset.")
+      }
+    }
+    schema
+  }
+}
+
+/**
+ * Frequency Encoding maps a column of categorical indices to how often each category occurs
+ * in the training data, either as a proportion of the training rows or as a raw count.
+ *
+ * Unlike `TargetEncoder` it needs no label, so it is available for unsupervised pipelines, and
+ * unlike `OneHotEncoder` it adds one column per input feature rather than one per category,
+ * which keeps it usable when a feature has many thousands of distinct values.
+ *
+ * Categories that occur equally often in the training data receive the same encoding. That is
+ * inherent to the technique rather than a limitation of this implementation: the encoding carries
+ * how common a category is and nothing else.
+ *
+ * When `handleInvalid` is configured to 'keep', categories not seen during fitting are encoded
+ * as zero, which is the frequency actually observed for them.
+ *
+ * @note When encoding multi-column by using `inputCols` and `outputCols` params, input/output cols
+ * come in pairs, specified by the order in the arrays, and each pair is treated independently.
+ *
+ * @see `StringIndexer` for converting categorical values into category indices
+ * @see `TargetEncoder` for encoding categories against a label
+ */
+@Since("5.0.0")
+class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String)
+  extends Estimator[FrequencyEncoderModel] with FrequencyEncoderBase with DefaultParamsWritable {
+
+  @Since("5.0.0")
+  def this() = this(Identifiable.randomUID("frequencyEncoder"))
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setInputCols(values: Array[String]): this.type = set(inputCols, values)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setOutputCols(values: Array[String]): this.type = set(outputCols, values)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setNormalize(value: Boolean): this.type = set(normalize, value)
+
+  @Since("5.0.0")
+  override def transformSchema(schema: StructType): StructType = {
+    validateSchema(schema, fitting = true)
+  }
+
+  private def extractValue(name: String): Column = {
+    val c = col(name).cast(DoubleType)
+    when(c >= 0 && c === c.cast(IntegerType), c)
+      .when(c.isNull, lit(FrequencyEncoder.NULL_CATEGORY))
+      .when(c.isNaN, raise_error(lit("Values MUST NOT be NaN")))
+      .otherwise(raise_error(
+        concat(lit("Values MUST be non-negative integers, but got "), c)))
+  }
+
+  @Since("5.0.0")
+  override def fit(dataset: Dataset[_]): FrequencyEncoderModel = {
+    validateSchema(dataset.schema, fitting = true)
+    val numFeatures = inputFeatures.length
+
+    // One array plus one posexplode, so a single groupBy aggregates every input column rather
+    // than one shuffle per column.
+    val arrayCol = array(inputFeatures.map(v => extractValue(v)).toIndexedSeq: _*)
+
+    val aggregated = dataset
+      .select(posexplode(arrayCol).as(Seq("index", "value")))
+      .groupBy("index", "value")
+      .agg(count(lit(1)).cast(DoubleType).as("count"))
+
+    // counts: Array[Map[category, count]]
+    val counts = Array.fill(numFeatures)(collection.mutable.Map.empty[Double, Double])
+    aggregated.select("index", "value", "count").collect()
+      .foreach { case Row(index: Int, value: Double, count: Double) =>
+        counts(index).update(value, count)
+      }
+
+    // Every row contributes exactly one value per feature, so the per-feature totals are already
+    // in hand and normalizing needs no second pass over the data.
+    val encodings = counts.map { featureCounts =>
+      val total = featureCounts.values.sum
+      if ($(normalize) && total > 0) {
+        featureCounts.map { case (category, count) => category -> count / total }.toMap
+      } else {
+        featureCounts.toMap
+      }
+    }
+
+    val model = new FrequencyEncoderModel(uid, encodings).setParent(this)
+    copyValues(model)
+  }
+
+  @Since("5.0.0")
+  override def copy(extra: ParamMap): FrequencyEncoder = defaultCopy(extra)
+}
+
+@Since("5.0.0")
+object FrequencyEncoder extends DefaultParamsReadable[FrequencyEncoder] {
+
+  // handleInvalid parameter values
+  private[feature] val KEEP_INVALID: String = "keep"
+  private[feature] val ERROR_INVALID: String = "error"
+  private[feature] val supportedHandleInvalids: Array[String] = Array(KEEP_INVALID, ERROR_INVALID)
+
+  private[feature] val NULL_CATEGORY: Double = -1
+
+  @Since("5.0.0")
+  override def load(path: String): FrequencyEncoder = super.load(path)
+}
+
+/**
+ * @param encodings  Array of encodings for each input feature.
+ *                   Array( Map( category, frequency ) )
+ */
+@Since("5.0.0")
+class FrequencyEncoderModel private[ml] (
+    @Since("5.0.0") override val uid: String,
+    @Since("5.0.0") private[ml] val encodings: Array[Map[Double, Double]])
+  extends Model[FrequencyEncoderModel] with FrequencyEncoderBase with MLWritable {
+
+  private[spark] override def estimatedSize: Long = {
+    var size = estimateMatadataSize
+    // encodings: Array[Map[Double, Double]]
+    size += SizeEstimator.estimate(encodings)
+    size
+  }
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setInputCols(values: Array[String]): this.type = set(inputCols, values)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setOutputCols(values: Array[String]): this.type = set(outputCols, values)
+
+  /** @group setParam */
+  @Since("5.0.0")
+  def setHandleInvalid(value: String): this.type = set(handleInvalid, value)
+
+  @Since("5.0.0")
+  override def transformSchema(schema: StructType): StructType = {
+    if (outputFeatures.length == encodings.length) {
+      outputFeatures.filter(_ != null)
+        .foldLeft(validateSchema(schema, fitting = false)) {
+          case (newSchema, outputField) =>
+            newSchema.add(StructField(outputField, DoubleType, nullable = false))
+        }
+    } else throw new SparkException("The number of features does not match the number of " +
+      s"encodings in the model (${encodings.length}). " +
+      s"Found ${outputFeatures.length} features)")
+  }
+
+  @Since("5.0.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema)
+
+    val newCols = inputFeatures.zip(outputFeatures).zip(encodings).map {
+      case ((featureIn, featureOut), mapping) =>
+        val unseenErrMsg = s"Unseen value %s in feature $featureIn. " +
+          s"To handle unseen values, set Param handleInvalid to ${FrequencyEncoder.KEEP_INVALID}."
+        val unseenErrCol = raise_error(printf(lit(unseenErrMsg), col(featureIn).cast(StringType)))
+
+        // A category absent from the training data was observed zero times, so that is what it
+        // encodes to.
+        val fillUnseenCol = $(handleInvalid) match {
+          case FrequencyEncoder.KEEP_INVALID => lit(0.0)
+          case _ => unseenErrCol
+        }
+        val fillNullCol = mapping.get(FrequencyEncoder.NULL_CATEGORY) match {
+          case Some(code) => lit(code)
+          case _ => fillUnseenCol
+        }
+        val filteredMapping = mapping.filter { case (k, _) => k != FrequencyEncoder.NULL_CATEGORY }
+
+        val castedCol = col(featureIn).cast(DoubleType)
+        // A feature can reach here with nothing but nulls in training, leaving no categories to
+        // look up. Building a map literal from an empty Map and indexing into it would be a
+        // needless analysis-time hazard, so short-circuit to the unseen branch instead.
+        val encodedCol = if (filteredMapping.isEmpty) {
+          when(castedCol.isNull, fillNullCol).otherwise(fillUnseenCol)
+        } else {
+          val targetCol = try_element_at(typedlit(filteredMapping), castedCol)
+          when(castedCol.isNull, fillNullCol)
+            .when(!targetCol.isNull, targetCol)
+            .otherwise(fillUnseenCol)
+        }
+
+        // Numeric, not nominal: an encoded frequency is a continuous quantity, and its ordering
+        // and magnitude are the whole point of the encoding.
+        encodedCol.as(featureOut, NumericAttribute.defaultAttr.withName(featureOut).toMetadata())
+    }
+    dataset.withColumns(outputFeatures.toIndexedSeq, newCols.toIndexedSeq)
+  }
+
+  @Since("5.0.0")
+  override def copy(extra: ParamMap): FrequencyEncoderModel = {
+    val copied = new FrequencyEncoderModel(uid, encodings)
+    copyValues(copied, extra).setParent(parent)
+  }
+
+  @Since("5.0.0")
+  override def write: MLWriter = new FrequencyEncoderModel.FrequencyEncoderModelWriter(this)
+
+  @Since("5.0.0")
+  override def toString: String = {
+    s"FrequencyEncoderModel: uid=$uid, " +
+      s"handleInvalid=${$(handleInvalid)}, normalize=${$(normalize)}, " +
+      s"numInputCols=${inputFeatures.length}, numOutputCols=${outputFeatures.length}"
+  }
+}
+
+@Since("5.0.0")
+object FrequencyEncoderModel extends MLReadable[FrequencyEncoderModel] {
+  private[ml] case class Data(index: Int, categories: Array[Double], frequencies: Array[Double])
+
+  private[ml] def serializeData(data: Data, dos: DataOutputStream): Unit = {
+    import ReadWriteUtils._
+    dos.writeInt(data.index)
+    serializeDoubleArray(data.categories, dos)
+    serializeDoubleArray(data.frequencies, dos)
+  }
+
+  private[ml] def deserializeData(dis: DataInputStream): Data = {
+    import ReadWriteUtils._
+    val index = dis.readInt()
+    val categories = deserializeDoubleArray(dis)
+    val frequencies = deserializeDoubleArray(dis)
+    Data(index, categories, frequencies)
+  }
+
+  private[FrequencyEncoderModel]
+  class FrequencyEncoderModelWriter(instance: FrequencyEncoderModel) extends MLWriter {
+
+    override protected def saveImpl(path: String): Unit = {
+      DefaultParamsWriter.saveMetadata(instance, path, sparkSession)
+      val datum = instance.encodings.iterator.zipWithIndex.map { case (mapping, index) =>
+        val (categories, frequencies) = mapping.toSeq.unzip
+        Data(index, categories.toArray, frequencies.toArray)
+      }.toSeq
+      val dataPath = new Path(path, "data").toString
+      ReadWriteUtils.saveArray[Data](dataPath, datum.toArray, sparkSession, serializeData)
+    }
+  }
+
+  private class FrequencyEncoderModelReader extends MLReader[FrequencyEncoderModel] {
+
+    private val className = classOf[FrequencyEncoderModel].getName
+
+    override def load(path: String): FrequencyEncoderModel = {
+      val metadata = DefaultParamsReader.loadMetadata(path, sparkSession, className)
+      val dataPath = new Path(path, "data").toString
+
+      val datum = ReadWriteUtils.loadArray[Data](dataPath, sparkSession, deserializeData)
+      // Sorted by index: the encodings are positional, matched to inputCols by their order, so
+      // reading them back in an arbitrary order would silently encode the wrong columns.
+      val encodings = datum.map { data =>
+        (data.index, data.categories.zip(data.frequencies).toMap)
+      }.sortBy(_._1).map(_._2)
+
+      val model = new FrequencyEncoderModel(metadata.uid, encodings)
+      metadata.getAndSetParams(model)
+      model
+    }
+  }
+
+  @Since("5.0.0")
+  override def read: MLReader[FrequencyEncoderModel] = new FrequencyEncoderModelReader
+
+  @Since("5.0.0")
+  override def load(path: String): FrequencyEncoderModel = super.load(path)
+}

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -93,7 +93,7 @@ private[ml] trait FrequencyEncoderBase extends Params
       inputFeatures.map { field: String => s"${field}_encoded" }
     }
 
-  private[feature] def validateSchema(schema: StructType, fitting: Boolean): StructType = {
+  private[feature] def validateSchema(schema: StructType): StructType = {
 
     require(inputFeatures.length > 0,
       s"At least one input column must be specified.")
@@ -110,7 +110,7 @@ private[ml] trait FrequencyEncoderBase extends Params
             s", but a subclass of ${NumericType} is required.")
         }
       } catch {
-        case e: IllegalArgumentException =>
+        case _: IllegalArgumentException =>
           throw new SparkException(s"No column named ${feature} found on dataset.")
       }
     }
@@ -172,7 +172,7 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
 
   @Since("5.0.0")
   override def transformSchema(schema: StructType): StructType = {
-    validateSchema(schema, fitting = true)
+    validateSchema(schema)
   }
 
   private def extractValue(name: String): Column = {
@@ -186,7 +186,7 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
 
   @Since("5.0.0")
   override def fit(dataset: Dataset[_]): FrequencyEncoderModel = {
-    validateSchema(dataset.schema, fitting = true)
+    validateSchema(dataset.schema)
     val numFeatures = inputFeatures.length
 
     // One array plus one posexplode, so a single groupBy aggregates every input column rather
@@ -201,8 +201,8 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
     // counts: Array[Map[category, count]]
     val counts = Array.fill(numFeatures)(collection.mutable.Map.empty[Double, Double])
     aggregated.select("index", "value", "count").collect()
-      .foreach { case Row(index: Int, value: Double, count: Double) =>
-        counts(index).update(value, count)
+      .foreach { case Row(index: Int, value: Double, occurrences: Double) =>
+        counts(index).update(value, occurrences)
       }
 
     // Every row contributes exactly one value per feature, so the per-feature totals are already
@@ -210,7 +210,7 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
     val encodings = counts.map { featureCounts =>
       val total = featureCounts.values.sum
       if ($(normalize) && total > 0) {
-        featureCounts.map { case (category, count) => category -> count / total }.toMap
+        featureCounts.map { case (category, n) => category -> n / total }.toMap
       } else {
         featureCounts.toMap
       }
@@ -239,6 +239,11 @@ object FrequencyEncoder extends DefaultParamsReadable[FrequencyEncoder] {
 }
 
 /**
+ * The `normalize` param is carried but not acted on here: it decides how `fit` computed these
+ * encodings, and the model keeps it so that save and load round-trip it and `toString` can report
+ * how the values were derived. Changing it on a fitted model does not recompute anything, which is
+ * why no setter is offered for it.
+ *
  * @param encodings  Array of encodings for each input feature.
  *                   Array( Map( category, frequency ) )
  */
@@ -279,13 +284,13 @@ class FrequencyEncoderModel private[ml] (
   override def transformSchema(schema: StructType): StructType = {
     if (outputFeatures.length == encodings.length) {
       outputFeatures.filter(_ != null)
-        .foldLeft(validateSchema(schema, fitting = false)) {
+        .foldLeft(validateSchema(schema)) {
           case (newSchema, outputField) =>
             newSchema.add(StructField(outputField, DoubleType, nullable = false))
         }
     } else throw new SparkException("The number of features does not match the number of " +
       s"encodings in the model (${encodings.length}). " +
-      s"Found ${outputFeatures.length} features)")
+      s"found ${outputFeatures.length} output columns.")
   }
 
   @Since("5.0.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -141,8 +141,9 @@ private[ml] trait FrequencyEncoderBase extends Params
  * in the training data, either as a proportion of the training rows or as a raw count.
  *
  * Unlike `TargetEncoder` it needs no label, so it is available for unsupervised pipelines, and
- * unlike `OneHotEncoder` it adds one column per input feature rather than one per category,
- * which keeps it usable when a feature has many thousands of distinct values.
+ * and where `OneHotEncoder` represents a feature as a vector with one dimension per category,
+ * this reduces it to a single scalar, trading the identity of a category for how common it is
+ * and so keeping the feature space flat however many distinct values there are.
  *
  * Categories that occur equally often in the training data receive the same encoding. That is
  * inherent to the technique rather than a limitation of this implementation: the encoding carries
@@ -355,9 +356,9 @@ class FrequencyEncoderModel private[ml] (
         val filteredMapping = mapping.filter { case (k, _) => k != FrequencyEncoder.NULL_CATEGORY }
 
         val castedCol = col(featureIn).cast(DoubleType)
-        // A feature can reach here with nothing but nulls in training, leaving no categories to
-        // look up. Building a map literal from an empty Map and indexing into it would be a
-        // needless analysis-time hazard, so short-circuit to the unseen branch instead.
+        // A feature can reach here with nothing but nulls in training, leaving no non-null
+        // categories to look up. Handling that explicitly is clearer than relying on an empty
+        // map literal returning null from try_element_at, which is what it does today.
         val encodedCol = if (filteredMapping.isEmpty) {
           when(castedCol.isNull, fillNullCol).otherwise(fillUnseenCol)
         } else {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/FrequencyEncoder.scala
@@ -177,7 +177,11 @@ class FrequencyEncoder @Since("5.0.0") (@Since("5.0.0") override val uid: String
 
   private def extractValue(name: String): Column = {
     val c = col(name).cast(DoubleType)
-    when(c >= 0 && c === c.cast(IntegerType), c)
+    // Integrality is tested with a remainder rather than by casting to Int. Casting raises
+    // CAST_OVERFLOW for an id beyond Int range, which is a confusing way to reject a perfectly
+    // good category and points the user at a `try_cast` they never wrote. A Double represents
+    // integers exactly up to 2^53, so anything accepted here is still a safe map key.
+    when(c >= 0 && c % 1 === 0, c)
       .when(c.isNull, lit(FrequencyEncoder.NULL_CATEGORY))
       .when(c.isNaN, raise_error(lit("Values MUST NOT be NaN")))
       .otherwise(raise_error(

--- a/mllib/src/test/java/org/apache/spark/ml/feature/JavaFrequencyEncoderSuite.java
+++ b/mllib/src/test/java/org/apache/spark/ml/feature/JavaFrequencyEncoderSuite.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature;
+
+import org.apache.spark.SharedSparkSession;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.spark.sql.types.DataTypes.*;
+
+public class JavaFrequencyEncoderSuite extends SharedSparkSession {
+
+  // Six rows. In input1, category 0 occurs three times, 2 twice and 1 once; in input2,
+  // category 1 occurs three times, 0 twice and 2 once. Expectations are written as x / 6.0
+  // to match the arithmetic fit performs.
+  private static final List<Row> DATA = Arrays.asList(
+    RowFactory.create(0.0, 1.0, 3.0 / 6.0, 3.0 / 6.0, 3.0, 3.0),
+    RowFactory.create(1.0, 0.0, 1.0 / 6.0, 2.0 / 6.0, 1.0, 2.0),
+    RowFactory.create(2.0, 1.0, 2.0 / 6.0, 3.0 / 6.0, 2.0, 3.0),
+    RowFactory.create(0.0, 2.0, 3.0 / 6.0, 1.0 / 6.0, 3.0, 1.0),
+    RowFactory.create(0.0, 1.0, 3.0 / 6.0, 3.0 / 6.0, 3.0, 3.0),
+    RowFactory.create(2.0, 0.0, 2.0 / 6.0, 2.0 / 6.0, 2.0, 2.0));
+
+  private static final StructType SCHEMA = createStructType(new StructField[]{
+    createStructField("input1", DoubleType, true),
+    createStructField("input2", DoubleType, true),
+    createStructField("expected1", DoubleType, false),
+    createStructField("expected2", DoubleType, false),
+    createStructField("count1", DoubleType, false),
+    createStructField("count2", DoubleType, false)
+  });
+
+  @Test
+  public void testFrequencyEncoderProportions() {
+    Dataset<Row> df = spark.createDataFrame(DATA, SCHEMA);
+
+    FrequencyEncoder encoder = new FrequencyEncoder()
+      .setInputCols(new String[]{"input1", "input2"})
+      .setOutputCols(new String[]{"output1", "output2"});
+
+    FrequencyEncoderModel model = encoder.fit(df);
+    Dataset<Row> encoded = model.transform(df);
+
+    Assertions.assertEquals(6, encoded.count());
+    List<Row> rows = encoded.select("output1", "expected1", "output2", "expected2")
+      .collectAsList();
+    for (Row row : rows) {
+      Assertions.assertEquals(row.getDouble(1), row.getDouble(0), 0.0);
+      Assertions.assertEquals(row.getDouble(3), row.getDouble(2), 0.0);
+    }
+  }
+
+  @Test
+  public void testFrequencyEncoderRawCounts() {
+    Dataset<Row> df = spark.createDataFrame(DATA, SCHEMA);
+
+    FrequencyEncoder encoder = new FrequencyEncoder()
+      .setInputCols(new String[]{"input1", "input2"})
+      .setOutputCols(new String[]{"output1", "output2"})
+      .setNormalize(false);
+
+    FrequencyEncoderModel model = encoder.fit(df);
+    Dataset<Row> encoded = model.transform(df);
+
+    List<Row> rows = encoded.select("output1", "count1", "output2", "count2").collectAsList();
+    for (Row row : rows) {
+      Assertions.assertEquals(row.getDouble(1), row.getDouble(0), 0.0);
+      Assertions.assertEquals(row.getDouble(3), row.getDouble(2), 0.0);
+    }
+  }
+
+  @Test
+  public void testFrequencyEncoderUnseenKeep() {
+    Dataset<Row> df = spark.createDataFrame(DATA, SCHEMA);
+
+    FrequencyEncoderModel model = new FrequencyEncoder()
+      .setInputCol("input1")
+      .setOutputCol("output1")
+      .setHandleInvalid("keep")
+      .fit(df);
+
+    Dataset<Row> unseen = spark.createDataFrame(
+      Arrays.asList(RowFactory.create(9.0, 1.0, 0.0, 0.0, 0.0, 0.0)), SCHEMA);
+
+    // Category 9 was never seen, so its observed frequency is zero.
+    Assertions.assertEquals(
+      0.0, model.transform(unseen).select("output1").head().getDouble(0), 0.0);
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.ml.feature
 
 import org.apache.spark.{SparkException, SparkRuntimeException}
+import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
 import org.apache.spark.sql.Row
@@ -281,20 +282,63 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
       .setOutputCol("output")
 
     val ex = intercept[SparkRuntimeException] { encoder.fit(df) }
-    assert(ex.getMessage.contains("Values MUST be non-negative integers"))
+    assert(ex.getMessage.contains("MUST be non-negative integers"))
   }
 
-  test("FrequencyEncoder - default output column names") {
+  test("FrequencyEncoder - the default output name is the one the getter reports") {
+
+    // Deriving a friendlier default from the input name broke the getter contract: getOutputCol
+    // still returned HasOutputCol's default while transform produced `input_encoded`, so a
+    // caller feeding the getter's answer to the next stage named a column that did not exist.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = new FrequencyEncoder().setInputCol("input1").fit(df)
+    val produced = model.transform(df).columns.toSet
+
+    assert(produced.contains(model.getOutputCol),
+      s"transform produced $produced, but getOutputCol says ${model.getOutputCol}")
+  }
+
+  test("FrequencyEncoder - multiple inputs need explicit output names") {
 
     val df = spark.createDataFrame(sc.parallelize(data), schema)
 
-    val model = new FrequencyEncoder()
-      .setInputCols(Array("input1", "input2"))
-      .fit(df)
+    val ex = intercept[IllegalArgumentException] {
+      new FrequencyEncoder().setInputCols(Array("input1", "input2")).fit(df)
+    }
+    assert(ex.getMessage.contains("must be the same as the number of"))
+  }
 
-    val transformed = model.transform(df)
-    assert(transformed.columns.contains("input1_encoded"))
-    assert(transformed.columns.contains("input2_encoded"))
+  test("FrequencyEncoder - composes in a Pipeline") {
+
+    // The defect this guards: the estimator's transformSchema returned the input schema
+    // unchanged, and Pipeline.fit folds transformSchema across its stages, so VectorAssembler
+    // was handed a schema with no `freq` in it and failed with FIELD_NOT_FOUND before any
+    // fitting happened. Direct estimator and model calls could never surface that.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val pipeline = new Pipeline().setStages(Array(
+      new FrequencyEncoder().setInputCol("input3").setOutputCol("freq"),
+      new VectorAssembler().setInputCols(Array("freq")).setOutputCol("features")))
+
+    val out = pipeline.fit(df).transform(df)
+
+    assert(out.columns.contains("freq"))
+    assert(out.columns.contains("features"))
+    assert(out.count() === data.length)
+  }
+
+  test("FrequencyEncoder - an output name that collides with an existing column is rejected") {
+
+    // transformSchema used to append a duplicate field while withColumns replaced the existing
+    // column, so the declared schema and the delivered frame disagreed. Rejecting the collision
+    // at fit time gives validation, schema inference and execution one answer.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val ex = intercept[IllegalArgumentException] {
+      new FrequencyEncoder().setInputCol("input3").setOutputCol("input1").fit(df)
+    }
+    assert(ex.getMessage.contains("already exists"))
   }
 
   test("FrequencyEncoder - wrong number of features") {
@@ -336,23 +380,54 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
     assert(distinct.head.getDouble(0) === 2.0 / 20000.0)
   }
 
-  test("FrequencyEncoder - category ids beyond Int range") {
+  test("FrequencyEncoder - ids above the supported range are rejected, not merged") {
 
-    // A bigint id is a legitimate category and high cardinality columns are exactly where such
-    // ids turn up. Checking integrality by casting to Int used to reject these with a
-    // CAST_OVERFLOW naming a cast the caller never wrote.
-    val wide = StructType(Array(StructField("cat", DoubleType, nullable = true)))
-    val df = spark.createDataFrame(
-      sc.parallelize(Seq(Row(3.0e9), Row(3.0e9), Row(1.0))), wide)
+    // Categories are carried as Double map keys, exact only to 2^53. 9007199254740992 and
+    // 9007199254740993 both become the same double, so accepting them would merge two distinct
+    // categories and report one count of 3 where the truth is 1 and 2. Rejecting on range
+    // before anything narrows is what makes that unreachable.
+    val df = spark.sql(
+      "SELECT * FROM VALUES (9007199254740992L), (9007199254740993L), " +
+        "(9007199254740993L) AS t(cat)")
 
-    val model = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq").fit(df)
+    val encoder = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq")
 
-    assert(model.encodings.head === Map(3.0e9 -> 2.0/3.0, 1.0 -> 1.0/3.0))
+    val ex = intercept[SparkRuntimeException] { encoder.fit(df) }
+    assert(ex.getMessage.contains("only supports up to"))
+    assert(ex.getMessage.contains(Int.MaxValue.toString))
+  }
 
-    model.transform(df).select("cat", "freq").collect().foreach { row =>
-      val expected = if (row.getDouble(0) == 1.0) 1.0/3.0 else 2.0/3.0
-      assert(row.getDouble(1) === expected)
-    }
+  test("FrequencyEncoder - a fractional decimal is rejected rather than truncated") {
+
+    // decimal(38,18) 1.000000000000000001 becomes exactly 1.0 once cast to double, so an
+    // integrality check performed after that cast would accept it as category 1 and merge it
+    // with genuine 1s. The check runs on the source column for this reason.
+    val df = spark.sql(
+      "SELECT CAST('1.000000000000000001' AS DECIMAL(38,18)) AS cat " +
+        "UNION ALL SELECT CAST('1' AS DECIMAL(38,18))")
+
+    val encoder = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq")
+
+    val ex = intercept[SparkRuntimeException] { encoder.fit(df) }
+    assert(ex.getMessage.contains("MUST be non-negative integers"))
+  }
+
+  test("FrequencyEncoder - an out of range value at transform time is unseen, not aliased") {
+
+    // The failure this guards: a value that no longer fits must not round down onto a category
+    // the model did learn and borrow its frequency. With keep it is unseen, so zero.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(df)
+
+    val far = spark.sql(
+      "SELECT CAST(0 AS SHORT) AS input1, 3 AS input2, 9007199254740993D AS input3, " +
+        "0D AS expected1, 0D AS expected2, 0D AS expected3, 0D AS count1, 0D AS count2, " +
+        "0D AS count3")
+
+    val row = model.transform(far).select("output3").head()
+    assert(row.getDouble(0) === 0.0, "an out of range value must not inherit a learned frequency")
   }
 
   test("FrequencyEncoder - R/W single-column") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.feature
+
+import org.apache.spark.{SparkException, SparkRuntimeException}
+import org.apache.spark.ml.param.ParamsSuite
+import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
+
+  import testImplicits._
+
+  @transient var data: Seq[Row] = _
+  @transient var schema: StructType = _
+  @transient var expected_proportions: Array[Map[Double, Double]] = _
+  @transient var expected_counts: Array[Map[Double, Double]] = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    // Nine rows. input1 gives every category the same count, which is what makes the
+    // equal-frequency case observable; input2 is uneven; input3 has a mix of common and
+    // singleton categories.
+    //
+    // Expectations are written as count/9.0 rather than as reduced fractions on purpose. fit
+    // computes count / total, and 1.0/3.0 is not guaranteed to be the same Double as 3.0/9.0.
+    // scalastyle:off
+    data = Seq(
+      Row(0.toShort, 3, 5.0, 3.0/9.0, 5.0/9.0, 3.0/9.0, 3.0, 5.0, 3.0),
+      Row(1.toShort, 4, 5.0, 3.0/9.0, 4.0/9.0, 3.0/9.0, 3.0, 4.0, 3.0),
+      Row(2.toShort, 3, 5.0, 3.0/9.0, 5.0/9.0, 3.0/9.0, 3.0, 5.0, 3.0),
+      Row(0.toShort, 4, 6.0, 3.0/9.0, 4.0/9.0, 3.0/9.0, 3.0, 4.0, 3.0),
+      Row(1.toShort, 3, 6.0, 3.0/9.0, 5.0/9.0, 3.0/9.0, 3.0, 5.0, 3.0),
+      Row(2.toShort, 4, 6.0, 3.0/9.0, 4.0/9.0, 3.0/9.0, 3.0, 4.0, 3.0),
+      Row(0.toShort, 3, 7.0, 3.0/9.0, 5.0/9.0, 1.0/9.0, 3.0, 5.0, 1.0),
+      Row(1.toShort, 4, 8.0, 3.0/9.0, 4.0/9.0, 1.0/9.0, 3.0, 4.0, 1.0),
+      Row(2.toShort, 3, 9.0, 3.0/9.0, 5.0/9.0, 1.0/9.0, 3.0, 5.0, 1.0))
+    // scalastyle:on
+
+    schema = StructType(Array(
+      StructField("input1", ShortType, nullable = true),
+      StructField("input2", IntegerType, nullable = true),
+      StructField("input3", DoubleType, nullable = true),
+      StructField("expected1", DoubleType),
+      StructField("expected2", DoubleType),
+      StructField("expected3", DoubleType),
+      StructField("count1", DoubleType),
+      StructField("count2", DoubleType),
+      StructField("count3", DoubleType)))
+
+    expected_proportions = Array(
+      Map(0.0 -> 3.0/9.0, 1.0 -> 3.0/9.0, 2.0 -> 3.0/9.0),
+      Map(3.0 -> 5.0/9.0, 4.0 -> 4.0/9.0),
+      Map(5.0 -> 3.0/9.0, 6.0 -> 3.0/9.0, 7.0 -> 1.0/9.0, 8.0 -> 1.0/9.0, 9.0 -> 1.0/9.0))
+
+    expected_counts = Array(
+      Map(0.0 -> 3.0, 1.0 -> 3.0, 2.0 -> 3.0),
+      Map(3.0 -> 5.0, 4.0 -> 4.0),
+      Map(5.0 -> 3.0, 6.0 -> 3.0, 7.0 -> 1.0, 8.0 -> 1.0, 9.0 -> 1.0))
+  }
+
+  private def multiColumnEncoder: FrequencyEncoder = new FrequencyEncoder()
+    .setInputCols(Array("input1", "input2", "input3"))
+    .setOutputCols(Array("output1", "output2", "output3"))
+
+  test("params") {
+    ParamsSuite.checkParams(new FrequencyEncoder)
+  }
+
+  test("model estimated size") {
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+    val model = multiColumnEncoder.fit(df)
+    val maxSize = 1024 * 6
+    assert(model.estimatedSize < maxSize,
+      s"Estimation (${model.estimatedSize}) should be less than $maxSize")
+  }
+
+  test("FrequencyEncoder - proportions") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder.fit(df)
+
+    model.encodings.zip(expected_proportions).foreach {
+      case (actual, expected) => assert(actual.equals(expected))
+    }
+
+    // Every proportion for a feature sums to one, because each row contributes exactly one
+    // category per feature.
+    model.encodings.foreach { mapping =>
+      assert(mapping.values.sum === 1.0)
+    }
+
+    testTransformer[(Double, Double, Double, Double, Double, Double)](
+      df.select("input1", "input2", "input3", "expected1", "expected2", "expected3"),
+      model,
+      "output1", "expected1",
+      "output2", "expected2",
+      "output3", "expected3") {
+      case Row(output1: Double, expected1: Double,
+      output2: Double, expected2: Double,
+      output3: Double, expected3: Double) =>
+        assert(output1 === expected1)
+        assert(output2 === expected2)
+        assert(output3 === expected3)
+    }
+  }
+
+  test("FrequencyEncoder - raw counts") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder.setNormalize(false).fit(df)
+
+    model.encodings.zip(expected_counts).foreach {
+      case (actual, expected) => assert(actual.equals(expected))
+    }
+
+    testTransformer[(Double, Double, Double, Double, Double, Double)](
+      df.select("input1", "input2", "input3", "count1", "count2", "count3"),
+      model,
+      "output1", "count1",
+      "output2", "count2",
+      "output3", "count3") {
+      case Row(output1: Double, expected1: Double,
+      output2: Double, expected2: Double,
+      output3: Double, expected3: Double) =>
+        assert(output1 === expected1)
+        assert(output2 === expected2)
+        assert(output3 === expected3)
+    }
+  }
+
+  test("FrequencyEncoder - equally common categories share an encoding") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder.fit(df)
+
+    // input1's three categories each occur three times, so all three collapse onto one value.
+    // This is inherent to the technique: the encoding carries how common a category is and
+    // nothing that distinguishes one equally common category from another.
+    val input1 = model.encodings(0)
+    assert(input1.keySet === Set(0.0, 1.0, 2.0))
+    assert(input1.values.toSet.size === 1)
+  }
+
+  test("FrequencyEncoder - unseen value - keep") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(df)
+
+    // Category 10.0 never appears in training, so its observed frequency is zero.
+    val data_unseen = Row(0.toShort, 3, 10.0, 3.0/9.0, 5.0/9.0, 0.0, 3.0, 5.0, 0.0)
+
+    val df_unseen = spark.createDataFrame(sc.parallelize(data :+ data_unseen), schema)
+
+    testTransformer[(Double, Double, Double, Double, Double, Double)](
+      df_unseen.select("input1", "input2", "input3", "expected1", "expected2", "expected3"),
+      model,
+      "output1", "expected1",
+      "output2", "expected2",
+      "output3", "expected3") {
+      case Row(output1: Double, expected1: Double,
+      output2: Double, expected2: Double,
+      output3: Double, expected3: Double) =>
+        assert(output1 === expected1)
+        assert(output2 === expected2)
+        assert(output3 === expected3)
+    }
+  }
+
+  test("FrequencyEncoder - unseen value - error") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.ERROR_INVALID)
+      .fit(df)
+
+    val data_unseen = Row(0.toShort, 3, 10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    val df_unseen = spark.createDataFrame(sc.parallelize(data :+ data_unseen), schema)
+
+    val ex = intercept[SparkRuntimeException] {
+      model.transform(df_unseen).select("output3").collect()
+    }
+    assert(ex.getMessage.contains("Unseen value"))
+  }
+
+  test("FrequencyEncoder - seen null category") {
+
+    val data_null = data :+ Row(null, 3, 5.0, 1.0/10.0, 6.0/10.0, 4.0/10.0, 1.0, 6.0, 4.0)
+    val df = spark.createDataFrame(sc.parallelize(data_null), schema)
+
+    // A null is a category in its own right: it occurs once in ten rows.
+    val model = multiColumnEncoder.fit(df)
+
+    assert(model.encodings(0).get(FrequencyEncoder.NULL_CATEGORY).contains(1.0/10.0))
+
+    // Collected directly rather than through testTransformer: its typed encoder cannot
+    // deserialize a null into a non-nullable Double, and a null input is the point here.
+    model.transform(df).select("input1", "output1").collect().foreach { row =>
+      val expected = if (row.isNullAt(0)) 1.0/10.0 else 3.0/10.0
+      assert(row.getDouble(1) === expected)
+    }
+  }
+
+  test("FrequencyEncoder - unseen null category - keep") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    // Fitted without nulls, so null has no learned frequency and falls to the unseen branch.
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(df)
+
+    assert(!model.encodings(0).contains(FrequencyEncoder.NULL_CATEGORY))
+
+    val df_null = spark.createDataFrame(
+      sc.parallelize(data :+ Row(null, 3, 5.0, 0.0, 5.0/9.0, 3.0/9.0, 0.0, 5.0, 3.0)), schema)
+
+    // As above, collected directly because the row under test carries a null input.
+    model.transform(df_null).select("input1", "output1").collect().foreach { row =>
+      val expected = if (row.isNullAt(0)) 0.0 else 3.0/9.0
+      assert(row.getDouble(1) === expected)
+    }
+  }
+
+  test("FrequencyEncoder - missing feature") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val encoder = new FrequencyEncoder()
+      .setInputCols(Array("input1", "absent"))
+      .setOutputCols(Array("output1", "output2"))
+
+    val ex = intercept[SparkException] { encoder.fit(df) }
+    assert(ex.getMessage.contains("No column named absent found on dataset"))
+  }
+
+  test("FrequencyEncoder - wrong data type") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+      .withColumn("stringy", $"input1".cast(StringType))
+
+    val encoder = new FrequencyEncoder()
+      .setInputCol("stringy")
+      .setOutputCol("output")
+
+    val ex = intercept[SparkException] { encoder.fit(df) }
+    assert(ex.getMessage.contains("Data type for column stringy"))
+  }
+
+  test("FrequencyEncoder - non-indexed categories") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+      .withColumn("fractional", $"input3" + 0.5)
+
+    val encoder = new FrequencyEncoder()
+      .setInputCol("fractional")
+      .setOutputCol("output")
+
+    val ex = intercept[SparkRuntimeException] { encoder.fit(df) }
+    assert(ex.getMessage.contains("Values MUST be non-negative integers"))
+  }
+
+  test("FrequencyEncoder - default output column names") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = new FrequencyEncoder()
+      .setInputCols(Array("input1", "input2"))
+      .fit(df)
+
+    val transformed = model.transform(df)
+    assert(transformed.columns.contains("input1_encoded"))
+    assert(transformed.columns.contains("input2_encoded"))
+  }
+
+  test("FrequencyEncoder - wrong number of features") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder.fit(df)
+
+    // Three encodings were fitted; asking the model for two outputs must not silently encode
+    // the wrong columns.
+    val ex = intercept[SparkException] {
+      model
+        .setInputCols(Array("input1", "input2"))
+        .setOutputCols(Array("output1", "output2"))
+        .transform(df)
+    }
+    assert(ex.getMessage.contains("does not match the number of"))
+  }
+
+  test("FrequencyEncoder - R/W single-column") {
+    val encoder = new FrequencyEncoder()
+      .setInputCol("input1")
+      .setOutputCol("output1")
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+    testDefaultReadWrite(encoder)
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+    val model = encoder.fit(df)
+    testDefaultReadWrite(model)
+  }
+
+  test("FrequencyEncoder - R/W multi-column") {
+    val encoder = multiColumnEncoder.setNormalize(false)
+    testDefaultReadWrite(encoder)
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+    val model = encoder.fit(df)
+
+    // The encodings are positional, matched to inputCols by order, so a round trip must
+    // preserve that order and not just the set of maps.
+    val reloaded = testDefaultReadWrite(model)
+    reloaded.encodings.zip(expected_counts).foreach {
+      case (actual, expected) => assert(actual.equals(expected))
+    }
+  }
+}

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.ml.Pipeline
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 
 class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
@@ -40,8 +41,9 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
     // equal-frequency case observable; input2 is uneven; input3 has a mix of common and
     // singleton categories.
     //
-    // Expectations are written as count/9.0 rather than as reduced fractions on purpose. fit
-    // computes count / total, and 1.0/3.0 is not guaranteed to be the same Double as 3.0/9.0.
+    // Expectations are written as count/9.0 because that is the arithmetic fit performs, which
+    // keeps the fixture readable against the implementation. For these operands it makes no
+    // numerical difference: 1.0/3.0 and 3.0/9.0 are the same Double.
     // scalastyle:off
     data = Seq(
       Row(0.toShort, 3, 5.0, 3.0/9.0, 5.0/9.0, 3.0/9.0, 3.0, 5.0, 3.0),
@@ -360,24 +362,32 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
 
   test("FrequencyEncoder - a feature with many distinct categories") {
 
-    // This encoder exists for high cardinality features, so the case it is built for is worth
-    // exercising rather than assuming. fit collects one entry per category to the driver and
+    // This encoder exists for high cardinality features, so the case it is built for is
+    // exercised rather than assumed: fit collects one entry per category to the driver and
     // transform ships that map into the plan as a literal, and neither of those is free.
     //
-    // 10,000 categories over 20,000 rows, each category appearing exactly twice, so every
-    // encoding is the same 2/20000 and a single distinct output value proves the whole mapping
-    // was applied rather than spot-checking one row.
-    val rows = (0 until 20000).map(i => Row((i / 2).toDouble))
+    // The frequencies are deliberately unequal. An earlier version of this test gave every
+    // category the same count, which meant a transform that ignored the fitted map entirely and
+    // returned that one constant would still have satisfied it. Here the expected value is
+    // derived independently, from a grouped count joined back on, so the assertion is about the
+    // mapping rather than about a single number.
+    val counts = (0 until 10000).flatMap(i => Seq.fill(1 + (i % 3))(Row(i.toDouble)))
     val wideSchema = StructType(Array(StructField("cat", DoubleType, nullable = true)))
-    val df = spark.createDataFrame(sc.parallelize(rows), wideSchema)
+    val df = spark.createDataFrame(sc.parallelize(counts), wideSchema)
 
     val model = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq").fit(df)
 
     assert(model.encodings.head.size === 10000)
 
-    val distinct = model.transform(df).select("freq").distinct().collect()
-    assert(distinct.length === 1, s"expected one distinct encoding, got ${distinct.length}")
-    assert(distinct.head.getDouble(0) === 2.0 / 20000.0)
+    val total = df.count().toDouble
+    val oracle = df.groupBy("cat").count()
+      .select(col("cat"), (col("count") / lit(total)).alias("want"))
+    val joined = model.transform(df).join(oracle, "cat")
+
+    assert(joined.filter(col("freq") =!= col("want")).count() === 0,
+      "a category was encoded with a frequency that is not its own")
+    // Three distinct counts went in, so no constant could have passed the check above.
+    assert(joined.select("freq").distinct().count() === 3)
   }
 
   test("FrequencyEncoder - ids above the supported range are rejected, not merged") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
@@ -19,10 +19,12 @@ package org.apache.spark.ml.feature
 
 import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.attribute.NumericAttribute
 import org.apache.spark.ml.param.ParamsSuite
 import org.apache.spark.ml.util.{DefaultReadWriteTest, MLTest}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
@@ -438,6 +440,125 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
 
     val row = model.transform(far).select("output3").head()
     assert(row.getDouble(0) === 0.0, "an out of range value must not inherit a learned frequency")
+  }
+
+  test("FrequencyEncoder - a known category does not raise under handleInvalid error") {
+
+    // transform looks the category up once and coalesces the miss handler in, rather than
+    // testing the lookup for null and reading it again. Under handleInvalid=error that miss
+    // handler is a raise_error, so this asserts the property the shape depends on: coalesce
+    // evaluates its second argument only when the first is null. A known category must come
+    // back with its own encoding and must not trip the error.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.ERROR_INVALID)
+      .fit(df)
+
+    val rows = model.transform(df).select("output1", "output2", "output3").collect()
+    assert(rows.length === data.length)
+    rows.foreach { row =>
+      assert(row.getDouble(0) === 3.0/9.0)
+      assert(row.getDouble(1) === 5.0/9.0 || row.getDouble(1) === 4.0/9.0)
+    }
+  }
+
+  test("FrequencyEncoder - a feature that trained on nothing but nulls") {
+
+    // Every value is null, so the only category learned is the null one and the non-null mapping
+    // is empty. Nulls take their learned encoding of 1.0; anything else is unseen.
+    val nullSchema = StructType(Array(StructField("cat", DoubleType, nullable = true)))
+    val allNull = spark.createDataFrame(
+      sc.parallelize(Seq(Row(null), Row(null), Row(null))), nullSchema)
+
+    val model = new FrequencyEncoder()
+      .setInputCol("cat").setOutputCol("freq")
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(allNull)
+
+    assert(model.encodings.head === Map(FrequencyEncoder.NULL_CATEGORY -> 1.0))
+
+    val mixed = spark.createDataFrame(
+      sc.parallelize(Seq(Row(null), Row(7.0))), nullSchema)
+    val got = model.transform(mixed).select("cat", "freq").collect()
+      .map(r => (if (r.isNullAt(0)) None else Some(r.getDouble(0))) -> r.getDouble(1)).toMap
+    assert(got(None) === 1.0, "a learned null keeps its own encoding")
+    assert(got(Some(7.0)) === 0.0, "a value never seen is unseen, not the null encoding")
+  }
+
+  test("FrequencyEncoder - a fit over zero rows learns nothing") {
+
+    // An empty mapping is the other way into the short-circuit branch: nothing was learned, so
+    // every value is unseen, including null, which has no learned encoding to fall back on.
+    val nullSchema = StructType(Array(StructField("cat", DoubleType, nullable = true)))
+    val empty = spark.createDataFrame(sc.emptyRDD[Row], nullSchema)
+
+    val keep = new FrequencyEncoder()
+      .setInputCol("cat").setOutputCol("freq")
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(empty)
+    assert(keep.encodings.head.isEmpty)
+
+    val probe = spark.createDataFrame(sc.parallelize(Seq(Row(1.0), Row(null))), nullSchema)
+    assert(keep.transform(probe).select("freq").collect().forall(_.getDouble(0) === 0.0))
+
+    val strict = new FrequencyEncoder()
+      .setInputCol("cat").setOutputCol("freq")
+      .setHandleInvalid(FrequencyEncoder.ERROR_INVALID)
+      .fit(empty)
+    intercept[SparkRuntimeException] {
+      strict.transform(probe).select("freq").collect()
+    }
+  }
+
+  test("FrequencyEncoder - output type, metadata and nullability") {
+
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+
+    for (mode <- Seq(FrequencyEncoder.KEEP_INVALID, FrequencyEncoder.ERROR_INVALID)) {
+      val model = multiColumnEncoder.setHandleInvalid(mode).fit(df)
+
+      val declared = model.transformSchema(df.schema)("output1")
+      val delivered = model.transform(df).schema("output1")
+
+      for (field <- Seq(declared, delivered)) {
+        assert(field.dataType === DoubleType)
+        assert(NumericAttribute.fromStructField(field).name === Some("output1"))
+      }
+      assert(!declared.nullable, "schema inference promises a value for every row")
+
+      // Under keep the single-lookup shape is provably non-null: coalesce falls back to a
+      // literal. Under error the fallback is raise_error, which Catalyst types as nullable, so
+      // the delivered field still reports nullable even though it can only ever throw or
+      // produce a double. Either way no null is ever emitted, which is what matters.
+      if (mode == FrequencyEncoder.KEEP_INVALID) {
+        assert(!delivered.nullable, "keep mode coalesces to a literal, so nothing can be null")
+      }
+      assert(model.transform(df).filter(col("output1").isNull).count() === 0)
+    }
+  }
+
+  test("FrequencyEncoder - encoding is unchanged with codegen disabled") {
+
+    // The single-lookup shape is a Catalyst expression change, so it has an interpreted path as
+    // well as a generated one. Both must produce the same values.
+    val df = spark.createDataFrame(sc.parallelize(data), schema)
+    val model = multiColumnEncoder
+      .setHandleInvalid(FrequencyEncoder.KEEP_INVALID)
+      .fit(df)
+
+    def encode(): Seq[Double] = model.transform(df)
+      .select("output1", "output2", "output3").collect()
+      .flatMap(r => Seq(r.getDouble(0), r.getDouble(1), r.getDouble(2))).toSeq
+
+    val generated = encode()
+    val interpreted = withSQLConf(
+      SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false",
+      SQLConf.CODEGEN_FACTORY_MODE.key -> "NO_CODEGEN") {
+      encode()
+    }
+    assert(generated === interpreted)
+    assert(generated.nonEmpty)
   }
 
   test("FrequencyEncoder - R/W single-column") {

--- a/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/feature/FrequencyEncoderSuite.scala
@@ -314,6 +314,47 @@ class FrequencyEncoderSuite extends MLTest with DefaultReadWriteTest {
     assert(ex.getMessage.contains("does not match the number of"))
   }
 
+  test("FrequencyEncoder - a feature with many distinct categories") {
+
+    // This encoder exists for high cardinality features, so the case it is built for is worth
+    // exercising rather than assuming. fit collects one entry per category to the driver and
+    // transform ships that map into the plan as a literal, and neither of those is free.
+    //
+    // 10,000 categories over 20,000 rows, each category appearing exactly twice, so every
+    // encoding is the same 2/20000 and a single distinct output value proves the whole mapping
+    // was applied rather than spot-checking one row.
+    val rows = (0 until 20000).map(i => Row((i / 2).toDouble))
+    val wideSchema = StructType(Array(StructField("cat", DoubleType, nullable = true)))
+    val df = spark.createDataFrame(sc.parallelize(rows), wideSchema)
+
+    val model = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq").fit(df)
+
+    assert(model.encodings.head.size === 10000)
+
+    val distinct = model.transform(df).select("freq").distinct().collect()
+    assert(distinct.length === 1, s"expected one distinct encoding, got ${distinct.length}")
+    assert(distinct.head.getDouble(0) === 2.0 / 20000.0)
+  }
+
+  test("FrequencyEncoder - category ids beyond Int range") {
+
+    // A bigint id is a legitimate category and high cardinality columns are exactly where such
+    // ids turn up. Checking integrality by casting to Int used to reject these with a
+    // CAST_OVERFLOW naming a cast the caller never wrote.
+    val wide = StructType(Array(StructField("cat", DoubleType, nullable = true)))
+    val df = spark.createDataFrame(
+      sc.parallelize(Seq(Row(3.0e9), Row(3.0e9), Row(1.0))), wide)
+
+    val model = new FrequencyEncoder().setInputCol("cat").setOutputCol("freq").fit(df)
+
+    assert(model.encodings.head === Map(3.0e9 -> 2.0/3.0, 1.0 -> 1.0/3.0))
+
+    model.transform(df).select("cat", "freq").collect().foreach { row =>
+      val expected = if (row.getDouble(0) == 1.0) 1.0/3.0 else 2.0/3.0
+      assert(row.getDouble(1) === expected)
+    }
+  }
+
   test("FrequencyEncoder - R/W single-column") {
     val encoder = new FrequencyEncoder()
       .setInputCol("input1")

--- a/python/docs/source/reference/pyspark.ml.rst
+++ b/python/docs/source/reference/pyspark.ml.rst
@@ -75,6 +75,8 @@ Feature
     DCT
     ElementwiseProduct
     FeatureHasher
+    FrequencyEncoder
+    FrequencyEncoderModel
     HashingTF
     IDF
     IDFModel

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -86,6 +86,8 @@ __all__ = [
     "DCT",
     "ElementwiseProduct",
     "FeatureHasher",
+    "FrequencyEncoder",
+    "FrequencyEncoderModel",
     "HashingTF",
     "IDF",
     "IDFModel",
@@ -1632,6 +1634,279 @@ class FeatureHasher(
         Sets the value of :py:attr:`numFeatures`.
         """
         return self._set(numFeatures=value)
+
+
+class _FrequencyEncoderParams(
+    HasInputCol, HasInputCols, HasOutputCol, HasOutputCols, HasHandleInvalid
+):
+    """
+    Params for :py:class:`FrequencyEncoder` and :py:class:`FrequencyEncoderModel`.
+
+    .. versionadded:: 5.0.0
+    """
+
+    handleInvalid: Param[str] = Param(
+        Params._dummy(),
+        "handleInvalid",
+        "How to handle invalid data during transform(). "
+        + "Options are 'keep' (unseen categories are encoded as zero) "
+        + "or error (throw an error).",
+        typeConverter=TypeConverters.toString,
+    )
+
+    normalize: Param[bool] = Param(
+        Params._dummy(),
+        "normalize",
+        "whether to encode categories as a proportion of the training rows (True) "
+        + "or as a raw count (False).",
+        typeConverter=TypeConverters.toBoolean,
+    )
+
+    def __init__(self, *args: Any):
+        super().__init__(*args)
+        self._setDefault(handleInvalid="error", normalize=True)
+
+    @since("5.0.0")
+    def getNormalize(self) -> bool:
+        """
+        Gets the value of normalize or its default value.
+        """
+        return self.getOrDefault(self.normalize)
+
+
+@inherit_doc
+class FrequencyEncoder(
+    JavaEstimator["FrequencyEncoderModel"],
+    _FrequencyEncoderParams,
+    JavaMLReadable["FrequencyEncoder"],
+    JavaMLWritable,
+):
+    """
+    Frequency Encoding maps a column of categorical indices to how often each category
+    occurs in the training data, either as a proportion of the training rows or as a raw
+    count.
+
+    Unlike :py:class:`TargetEncoder` it needs no label, so it is available for
+    unsupervised pipelines, and unlike :py:class:`OneHotEncoder` it adds one column per
+    input feature rather than one per category, which keeps it usable when a feature has
+    many thousands of distinct values.
+
+    Categories that occur equally often in the training data receive the same encoding.
+    That is inherent to the technique rather than a limitation of this implementation: the
+    encoding carries how common a category is and nothing else.
+
+    When :py:attr:`handleInvalid` is configured to 'keep', categories not seen during
+    fitting are encoded as zero, which is the frequency actually observed for them.
+
+    @note When encoding multi-column by using `inputCols` and `outputCols` params,
+    input/output cols come in pairs, specified by the order in the arrays, and each pair
+    is treated independently.
+
+    .. versionadded:: 5.0.0
+
+    See Also
+    --------
+    :py:class:`StringIndexer` : for converting categorical values into category indices
+    :py:class:`TargetEncoder` : for encoding categories against a label
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([(0.0,), (1.0,), (1.0,), (1.0,)], ["cat"])
+    >>> model = FrequencyEncoder(inputCol="cat", outputCol="freq").fit(df)
+    >>> sorted({row.freq for row in model.transform(df).collect()})
+    [0.25, 0.75]
+
+    Raw counts instead of proportions:
+
+    >>> counts = FrequencyEncoder(
+    ...     inputCol="cat", outputCol="freq", normalize=False).fit(df)
+    >>> sorted({row.freq for row in counts.transform(df).collect()})
+    [1.0, 3.0]
+
+    Unseen categories were observed zero times:
+
+    >>> unseen = spark.createDataFrame([(7.0,)], ["cat"])
+    >>> keep = model.setHandleInvalid("keep")
+    >>> keep.transform(unseen).head().freq
+    0.0
+    """
+
+    _input_kwargs: Dict[str, Any]
+
+    @overload
+    def __init__(
+        self,
+        *,
+        inputCols: Optional[List[str]] = ...,
+        outputCols: Optional[List[str]] = ...,
+        handleInvalid: str = ...,
+        normalize: bool = ...,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *,
+        handleInvalid: str = ...,
+        normalize: bool = ...,
+        inputCol: Optional[str] = ...,
+        outputCol: Optional[str] = ...,
+    ): ...
+
+    @keyword_only
+    def __init__(
+        self,
+        *,
+        inputCols: Optional[List[str]] = None,
+        outputCols: Optional[List[str]] = None,
+        handleInvalid: str = "error",
+        normalize: bool = True,
+        inputCol: Optional[str] = None,
+        outputCol: Optional[str] = None,
+    ):
+        """
+        __init__(self, \\*, inputCols=None, outputCols=None, handleInvalid="error", \
+                 normalize=True, inputCol=None, outputCol=None)
+        """
+        super().__init__()
+        self._java_obj = self._new_java_obj(
+            "org.apache.spark.ml.feature.FrequencyEncoder", self.uid
+        )
+        kwargs = self._input_kwargs
+        self.setParams(**kwargs)
+
+    @overload
+    def setParams(
+        self,
+        *,
+        inputCols: Optional[List[str]] = ...,
+        outputCols: Optional[List[str]] = ...,
+        handleInvalid: str = ...,
+        normalize: bool = ...,
+    ) -> "FrequencyEncoder": ...
+
+    @overload
+    def setParams(
+        self,
+        *,
+        handleInvalid: str = ...,
+        normalize: bool = ...,
+        inputCol: Optional[str] = ...,
+        outputCol: Optional[str] = ...,
+    ) -> "FrequencyEncoder": ...
+
+    @keyword_only
+    @since("5.0.0")
+    def setParams(
+        self,
+        *,
+        inputCols: Optional[List[str]] = None,
+        outputCols: Optional[List[str]] = None,
+        handleInvalid: str = "error",
+        normalize: bool = True,
+        inputCol: Optional[str] = None,
+        outputCol: Optional[str] = None,
+    ) -> "FrequencyEncoder":
+        """
+        setParams(self, \\*, inputCols=None, outputCols=None, handleInvalid="error", \
+                  normalize=True, inputCol=None, outputCol=None)
+        Sets params for this FrequencyEncoder.
+        """
+        kwargs = self._input_kwargs
+        return self._set(**kwargs)
+
+    @since("5.0.0")
+    def setInputCols(self, value: List[str]) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`inputCols`.
+        """
+        return self._set(inputCols=value)
+
+    @since("5.0.0")
+    def setOutputCols(self, value: List[str]) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`outputCols`.
+        """
+        return self._set(outputCols=value)
+
+    @since("5.0.0")
+    def setInputCol(self, value: str) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`inputCol`.
+        """
+        return self._set(inputCol=value)
+
+    @since("5.0.0")
+    def setOutputCol(self, value: str) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`outputCol`.
+        """
+        return self._set(outputCol=value)
+
+    @since("5.0.0")
+    def setHandleInvalid(self, value: str) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`handleInvalid`.
+        """
+        return self._set(handleInvalid=value)
+
+    @since("5.0.0")
+    def setNormalize(self, value: bool) -> "FrequencyEncoder":
+        """
+        Sets the value of :py:attr:`normalize`.
+        """
+        return self._set(normalize=value)
+
+    def _create_model(self, java_model: "JavaObject") -> "FrequencyEncoderModel":
+        return FrequencyEncoderModel(java_model)
+
+
+class FrequencyEncoderModel(
+    JavaModel, _FrequencyEncoderParams, JavaMLReadable["FrequencyEncoderModel"], JavaMLWritable
+):
+    """
+    Model fitted by :py:class:`FrequencyEncoder`.
+
+    Note that :py:attr:`normalize` is only used while fitting, so this model has no setter
+    for it; the encodings it carries were already computed one way or the other.
+
+    .. versionadded:: 5.0.0
+    """
+
+    @since("5.0.0")
+    def setInputCols(self, value: List[str]) -> "FrequencyEncoderModel":
+        """
+        Sets the value of :py:attr:`inputCols`.
+        """
+        return self._set(inputCols=value)
+
+    @since("5.0.0")
+    def setOutputCols(self, value: List[str]) -> "FrequencyEncoderModel":
+        """
+        Sets the value of :py:attr:`outputCols`.
+        """
+        return self._set(outputCols=value)
+
+    @since("5.0.0")
+    def setInputCol(self, value: str) -> "FrequencyEncoderModel":
+        """
+        Sets the value of :py:attr:`inputCol`.
+        """
+        return self._set(inputCol=value)
+
+    @since("5.0.0")
+    def setOutputCol(self, value: str) -> "FrequencyEncoderModel":
+        """
+        Sets the value of :py:attr:`outputCol`.
+        """
+        return self._set(outputCol=value)
+
+    @since("5.0.0")
+    def setHandleInvalid(self, value: str) -> "FrequencyEncoderModel":
+        """
+        Sets the value of :py:attr:`handleInvalid`.
+        """
+        return self._set(handleInvalid=value)
 
 
 @inherit_doc

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1642,7 +1642,7 @@ class _FrequencyEncoderParams(
     """
     Params for :py:class:`FrequencyEncoder` and :py:class:`FrequencyEncoderModel`.
 
-    .. versionadded:: 5.0.0
+    .. versionadded:: 4.4.0
     """
 
     handleInvalid: Param[str] = Param(
@@ -1666,7 +1666,7 @@ class _FrequencyEncoderParams(
         super().__init__(*args)
         self._setDefault(handleInvalid="error", normalize=True)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def getNormalize(self) -> bool:
         """
         Gets the value of normalize or its default value.
@@ -1703,7 +1703,7 @@ class FrequencyEncoder(
         cols come in pairs, specified by the order in the arrays, and each pair is treated
         independently.
 
-    .. versionadded:: 5.0.0
+    .. versionadded:: 4.4.0
 
     See Also
     --------
@@ -1797,7 +1797,7 @@ class FrequencyEncoder(
     ) -> "FrequencyEncoder": ...
 
     @keyword_only
-    @since("5.0.0")
+    @since("4.4.0")
     def setParams(
         self,
         *,
@@ -1816,42 +1816,42 @@ class FrequencyEncoder(
         kwargs = self._input_kwargs
         return self._set(**kwargs)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setInputCols(self, value: List[str]) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`inputCols`.
         """
         return self._set(inputCols=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setOutputCols(self, value: List[str]) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`outputCols`.
         """
         return self._set(outputCols=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setInputCol(self, value: str) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`inputCol`.
         """
         return self._set(inputCol=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setOutputCol(self, value: str) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setHandleInvalid(self, value: str) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`handleInvalid`.
         """
         return self._set(handleInvalid=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setNormalize(self, value: bool) -> "FrequencyEncoder":
         """
         Sets the value of :py:attr:`normalize`.
@@ -1871,38 +1871,38 @@ class FrequencyEncoderModel(
     Note that :py:attr:`normalize` is only used while fitting, so this model has no setter
     for it; the encodings it carries were already computed one way or the other.
 
-    .. versionadded:: 5.0.0
+    .. versionadded:: 4.4.0
     """
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setInputCols(self, value: List[str]) -> "FrequencyEncoderModel":
         """
         Sets the value of :py:attr:`inputCols`.
         """
         return self._set(inputCols=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setOutputCols(self, value: List[str]) -> "FrequencyEncoderModel":
         """
         Sets the value of :py:attr:`outputCols`.
         """
         return self._set(outputCols=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setInputCol(self, value: str) -> "FrequencyEncoderModel":
         """
         Sets the value of :py:attr:`inputCol`.
         """
         return self._set(inputCol=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setOutputCol(self, value: str) -> "FrequencyEncoderModel":
         """
         Sets the value of :py:attr:`outputCol`.
         """
         return self._set(outputCol=value)
 
-    @since("5.0.0")
+    @since("4.4.0")
     def setHandleInvalid(self, value: str) -> "FrequencyEncoderModel":
         """
         Sets the value of :py:attr:`handleInvalid`.

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1687,9 +1687,10 @@ class FrequencyEncoder(
     count.
 
     Unlike :py:class:`TargetEncoder` it needs no label, so it is available for
-    unsupervised pipelines, and unlike :py:class:`OneHotEncoder` it adds one column per
-    input feature rather than one per category, which keeps it usable when a feature has
-    many thousands of distinct values.
+    unsupervised pipelines. Where :py:class:`OneHotEncoder` represents a feature as a vector
+    with one dimension per category, this reduces it to a single scalar, trading the identity
+    of a category for how common it is and so keeping the feature space flat however many
+    distinct values there are.
 
     Categories that occur equally often in the training data receive the same encoding.
     That is inherent to the technique rather than a limitation of this implementation: the

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1698,9 +1698,10 @@ class FrequencyEncoder(
     When :py:attr:`handleInvalid` is configured to 'keep', categories not seen during
     fitting are encoded as zero, which is the frequency actually observed for them.
 
-    @note When encoding multi-column by using `inputCols` and `outputCols` params,
-    input/output cols come in pairs, specified by the order in the arrays, and each pair
-    is treated independently.
+    .. note::
+        When encoding multi-column by using `inputCols` and `outputCols` params, input/output
+        cols come in pairs, specified by the order in the arrays, and each pair is treated
+        independently.
 
     .. versionadded:: 5.0.0
 

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -1564,10 +1564,16 @@ class FeatureTestsMixin:
             [4.0, 5.0],
         )
 
-        # unseen categories were observed zero times
+        # unseen categories were observed zero times. Fitted separately rather than by mutating
+        # the model above: setHandleInvalid returns the same instance, and mutating it before the
+        # round-trip below makes that assertion depend on mutation order.
+        keeper = FrequencyEncoder(
+            inputCols=["input1", "input2", "input3"],
+            outputCols=["output", "output2", "output3"],
+            handleInvalid="keep",
+        ).fit(df)
         unseen = self.spark.createDataFrame([(9, 99, 99.0)], schema=df.schema)
-        kept = model.setHandleInvalid("keep").transform(unseen).head()
-        self.assertEqual(kept.output2, 0.0)
+        self.assertEqual(keeper.transform(unseen).head().output2, 0.0)
 
         # save & load
         with tempfile.TemporaryDirectory(prefix="frequency_encoder") as d:

--- a/python/pyspark/ml/tests/test_feature.py
+++ b/python/pyspark/ml/tests/test_feature.py
@@ -34,6 +34,8 @@ from pyspark.ml.feature import (
     CountVectorizerModel,
     ElementwiseProduct,
     FeatureHasher,
+    FrequencyEncoder,
+    FrequencyEncoderModel,
     HashingTF,
     IDFModel,
     Imputer,
@@ -1514,6 +1516,68 @@ class FeatureTestsMixin:
         self.assertEqual(model.getInputCols(), ["label1", "label2"])
         self.assertEqual(model.getOutputCols(), ["indexed1", "indexed2"])
         self.assertEqual(model.getHandleInvalid(), "keep")
+
+    def test_frequency_encoder(self):
+        df = self.spark.createDataFrame(
+            [
+                (0, 3, 5.0),
+                (1, 4, 5.0),
+                (2, 3, 5.0),
+                (0, 4, 6.0),
+                (1, 3, 6.0),
+                (2, 4, 6.0),
+                (0, 3, 7.0),
+                (1, 4, 8.0),
+                (2, 3, 9.0),
+            ],
+            schema="input1 short, input2 int, input3 double",
+        )
+        encoder = FrequencyEncoder(
+            inputCols=["input1", "input2", "input3"],
+            outputCols=["output", "output2", "output3"],
+        )
+        model = encoder.fit(df)
+        output = model.transform(df)
+        self.assertEqual(
+            output.columns,
+            ["input1", "input2", "input3", "output", "output2", "output3"],
+        )
+        self.assertEqual(output.count(), 9)
+
+        # input2 holds category 3 five times and category 4 four times, out of nine rows.
+        # Written as x / 9.0 to match the arithmetic fit performs, since 5.0 / 9.0 is not
+        # necessarily the same double as any reduced form of it.
+        self.assertEqual(
+            sorted({row.output2 for row in output.collect()}),
+            [4.0 / 9.0, 5.0 / 9.0],
+        )
+
+        # input1 gives all three categories the same count, so they share one encoding.
+        self.assertEqual(len({row.output for row in output.collect()}), 1)
+
+        # normalize=False keeps raw counts instead.
+        counts = FrequencyEncoder(
+            inputCols=["input2"], outputCols=["counted"], normalize=False
+        ).fit(df)
+        self.assertEqual(
+            sorted({row.counted for row in counts.transform(df).collect()}),
+            [4.0, 5.0],
+        )
+
+        # unseen categories were observed zero times
+        unseen = self.spark.createDataFrame([(9, 99, 99.0)], schema=df.schema)
+        kept = model.setHandleInvalid("keep").transform(unseen).head()
+        self.assertEqual(kept.output2, 0.0)
+
+        # save & load
+        with tempfile.TemporaryDirectory(prefix="frequency_encoder") as d:
+            encoder.write().overwrite().save(d)
+            encoder2 = FrequencyEncoder.load(d)
+            self.assertEqual(str(encoder), str(encoder2))
+
+            model.write().overwrite().save(d)
+            model2 = FrequencyEncoderModel.load(d)
+            self.assertEqual(str(model), str(model2))
 
     def test_target_encoder_binary(self):
         df = self.spark.createDataFrame(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add `FrequencyEncoder` and `FrequencyEncoderModel` to `ml.feature`, with Scala, Java, and Python APIs, Spark Connect registration, persistence, documentation, and examples. The estimator learns category counts or proportions from its training DataFrame; the fitted model applies the same mappings to subsequent data.

The API follows the existing feature encoders:

- `inputCol` / `outputCol`, or `inputCols` / `outputCols` for independently encoded feature pairs.
- `normalize=true` produces proportions of the training rows; `false` produces raw counts. Nulls observed during fitting are counted as a category and included in the denominator.
- `handleInvalid="error"` rejects unseen values during transformation; `"keep"` encodes unmatched values as zero. Invalid non-null training values are rejected in either mode.
- Inputs are integral numeric category indices from zero through `Int.MaxValue`. String inputs compose with `StringIndexer`. Multi-column input requires explicit output names.

Outputs use `NumericAttribute` metadata. Categories observed during fitting have positive encodings; equally frequent categories receive the same value. The model retains the normalization setting used during fitting, and changing that parameter does not recompute the stored values. Public APIs are annotated for 4.4.0.

Fit aggregates all input features through `posexplode` and grouped counts, deriving normalization totals from those counts. Transform applies the learned maps through Spark SQL expressions. Lookup results are evaluated once, with separate handling for learned nulls and empty mappings. The transformation introduces no join or shuffle of its own.

The fitted maps are collected to the driver and embedded in transformation plans. Model state grows with the total number of distinct categories across input features, so mappings must fit in driver memory.

### Why are the changes needed?

Spark ML has no built-in fitted count/frequency encoder. Category prevalence can be useful as a numerical feature in workflows with or without labels, including anomaly preprocessing and AutoML feature generation. It does not preserve categorical identity: categories with equal counts are indistinguishable in this representation.

There are concrete Spark implementations of this pattern:

- [DQX](https://github.com/databrickslabs/dqx/blob/a5b78de562408040c1a3dda2776009229eeaa68c/src/databricks/labs/dqx/anomaly/transformers.py#L559) learns category proportions for anomaly-feature preprocessing and retains mappings for subsequent transformations.
- [SLAMA, LightAutoML on Spark](https://github.com/sb-ai-lab/SLAMA/blob/7e25d0ef72b7847a73b6887b2d93dc8b07bfe3e3/sparklightautoml/transformers/categorical.py#L340), provides a frequency-encoding Estimator/Transformer used in feature pipelines, with persistence tests. Its count and fallback semantics differ from this proposal.

The method also appears in [Category Encoders](https://contrib.scikit-learn.org/category_encoders/count.html), [Feature-engine](https://feature-engine.trainindata.com/en/latest/api_doc/encoding/CountFrequencyEncoder.html), and [H2O Driverless AI](https://docs.h2o.ai/driverless-ai/latest-stable/docs/userguide/transformations.html), and is covered by a [NeurIPS 2023 benchmark of categorical encoders](https://arxiv.org/pdf/2307.09191). These are examples of established use, not adoption commitments or evidence of universal predictive improvement.

A standard Spark ML stage would let users compose `StringIndexer`, `FrequencyEncoder`, `VectorAssembler`, and a downstream estimator in one Pipeline. Fitting the complete Pipeline within model selection learns its preprocessing on each training split. Saving the fitted Pipeline preserves the index mapping, frequency mapping, and downstream model together.

SQL aggregation and a persisted lookup can implement the same semantics, and an external Spark package remains viable. Sampling is also appropriate when estimated proportions are sufficient; DQX itself samples before fitting. The proposed benefit is a common fitted-stage API for Spark users who otherwise maintain the mapping, persistence, and Pipeline integration themselves. Fit operates on whichever training DataFrame the caller supplies.

I am willing to maintain this component and address review feedback and regressions. The requirements and inclusion discussion are tracked in [SPARK-59376](https://issues.apache.org/jira/browse/SPARK-59376).

### Does this PR introduce _any_ user-facing change?

Yes. It adds `FrequencyEncoder` and `FrequencyEncoderModel` to Spark ML and PySpark, with documentation and examples.

Fitting `[0, 0, 0, 1]` with default normalization learns `0 -> 0.75` and `1 -> 0.25`. With `handleInvalid="keep"`, transforming `[1, 2]` returns `[0.25, 0.0]`. A scoring batch containing only category 1 still receives 0.25 for each row. With `normalize=false`, the learned values are counts instead. No label column is required.

### How was this patch tested?

Local JVM test reports show:

- `FrequencyEncoderSuite`: 28 tests, zero failures or errors.
- `JavaFrequencyEncoderSuite`: 3 tests, zero failures or errors.

The suites can be run with:

```sh
./build/sbt "mllib/testOnly org.apache.spark.ml.feature.FrequencyEncoderSuite org.apache.spark.ml.feature.JavaFrequencyEncoderSuite"
```

Coverage includes counts and proportions; null, unseen, and invalid values; numeric boundaries; empty and null-only training data; schema and metadata; Pipeline composition; and single- and multi-column persistence. The cardinality regression uses unequal frequencies and compares against independently grouped counts joined back to the input.

The lookup tests cover lazy error fallback, output nullability, and matching results with code generation enabled and disabled. The Python FrequencyEncoder test is shared by the classic feature tests and Connect parity tests; the Python API also includes doctest examples.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Code 2.1.266 (Claude Opus 5)