### PR TITLE
[SPARK-59295][SQL] Emit a common expression's definition once per scope under whole-stage codegen

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -425,8 +425,7 @@ case class CommonExpressionRef(id: CommonExpressionId, dataType: DataType, nulla
    * body encloses another, so repeating it declares nothing twice in one scope: a definition
    * reading a sibling is generated inside that sibling's guard, not inside its own, and one that
    * reaches its own id -- directly or around a cycle -- re-enters `fill` and is refused before any
-   * Java exists. See `CommonExprSlots.fill`, which also says what bounds the code when a method is
-   * not possible.
+   * Java exists. See `CommonExprSlots.fill`.
    */
   override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val slots = ctx.getCommonExpr(id.id)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -236,13 +236,10 @@ class CodegenContext extends Logging {
      * `filling` catches a definition that references its own id, which would otherwise re-enter and
      * recurse, since `fillCode` is set only after `definition.genCode` returns.
      *
-     * The body goes into a method where it can and is worth it -- a definition that is or holds
-     * another `With`, or a body past the split threshold -- so it is emitted once per scope rather
-     * than once per reference, which for nested `With`s would double per level. A method is only
-     * possible where the definition reads the input row rather than local variables, the condition
-     * `reduceCodeSize` splits under. That is not the same as whole-stage codegen being off: a
-     * whole-stage `Project` or `Filter` passes local variables, while
-     * `SortMergeJoinExec.createJoinKey` and the aggregate output paths generate against a row.
+     * The body goes into a method where it is worth it -- a definition that is or holds another
+     * `With`, or a body past the split threshold -- so it is emitted once per scope rather than
+     * once per reference, which for nested `With`s would double per level. `methodArgs` says what
+     * the method takes, and which definitions cannot have one.
      */
     def fill: Block = {
       if (fillCode.isEmpty) {
@@ -278,38 +275,88 @@ class CodegenContext extends Logging {
          |${value.value} = ${defGen.value};
          |$computed = true;
        """.stripMargin
-      // TODO(SPARK-59295): cover the local-variable case too, by passing the `currentVars` values a
-      //   definition reads into the method as parameters, the way
-      //   `subexpressionEliminationForWholeStageCodegen` does. It needs a decision first:
-      //   `getLocalInputVariableValues` hoists an input variable that is not evaluated yet to
-      //   before the call, which for a reference behind a branch means evaluating it on rows that
-      //   never reach the reference.
-      val canPutInMethod = INPUT_ROW != null && currentVars == null
-      // A definition that is or holds another `With` is the shape whose code doubles per level,
-      // and what this is aimed at. It is not the only one -- a definition referencing a sibling
-      // definition of the same `With` doubles the same way, and codegen accepts that, since the
-      // sibling's slots are in scope while this definition is generated (`With.refsToBind` says
-      // why nothing builds that tree, and that evaluating one raises). What bounds those is not
-      // the length arm below: `body` is assembled after `definition.genCode` already ran
-      // `reduceCodeSize`, so the arm fires only in the band just under the threshold. It is
-      // `reduceCodeSize` itself, which hoists whichever node's code first passes the threshold as
-      // generation walks up, capping what one level contributes, so the code stays linear in the
-      // depth either way. The length arm just keeps the same body from being split once per
-      // reference, which leaves the methods small and the code as large.
+      // A definition that is or holds another `With` is the shape whose code doubles per level, and
+      // what this is aimed at. A definition referencing a sibling definition of the same `With`
+      // doubles the same way and is covered by the same arm, though nothing builds that tree today
+      // (`With.refsToBind` says why). The length arm keeps one body from being split once per
+      // reference; it fires in the band just under the threshold where `reduceCodeSize` applies,
+      // since `body` is assembled after `definition.genCode` already ran it.
       val worthAMethod = definition.containsPattern(WITH_EXPRESSION) ||
         body.length > SQLConf.get.methodSplitThreshold
-      if (canPutInMethod && worthAMethod) {
-        val funcName = freshName("computeCommonExpr")
-        val funcFullName = addNewFunction(funcName,
-          s"""
-             |private void $funcName(InternalRow $INPUT_ROW) {
-             |  $body
-             |}
+      (if (worthAMethod) methodArgs else None) match {
+        case Some(args) =>
+          val funcName = freshName("computeCommonExpr")
+          val params = args.map(a => s"${typeName(a.javaType)} ${a.variableName}").mkString(", ")
+          val funcFullName = addNewFunction(funcName,
+            s"""
+               |private void $funcName($params) {
+               |  $body
+               |}
            """.stripMargin)
-        code"$funcFullName($INPUT_ROW);"
-      } else {
-        body
+          code"$funcFullName(${args.map(_.variableName).mkString(", ")});"
+        case None =>
+          body
       }
+    }
+
+    /**
+     * The locals to pass the method, or None where a method is not possible. What it collects are
+     * the values the body would otherwise read from the scope the call replaces it in -- the input
+     * row, an input variable the operator evaluated before generating this expression, a value
+     * subexpression elimination computed -- all of them declared in a scope that encloses the call.
+     *
+     * A definition that reads an input variable the operator has *not* evaluated yet gets no
+     * method. That variable's code cannot travel into one: it was generated by the operator that
+     * produces the row, against that operator's scope, so it names a local of that scope -- the
+     * column batch's row index, or the input adapter's row. Nor can it be hoisted to before the
+     * call, the way `getLocalInputVariableValues` does for subexpression elimination, since that
+     * evaluates it on rows that reach no reference.
+     */
+    private def methodArgs: Option[Seq[VariableValue]] = {
+      val args = mutable.LinkedHashMap.empty[String, VariableValue]
+      // False for a value no parameter can carry: `ExpandExec` hands out a `VariableValue` naming a
+      // slot of a compacted mutable state array, and a `SimpleExprValue` is an expression rather
+      // than a name. A field or a literal needs no parameter and is read as it stands.
+      def canPass(v: ExprValue): Boolean = v match {
+        case local: VariableValue =>
+          val name = local.variableName
+          val isName = name.nonEmpty && Character.isJavaIdentifierStart(name.head) &&
+            name.forall(Character.isJavaIdentifierPart)
+          if (isName) {
+            args.getOrElseUpdate(name, local)
+          }
+          isName
+        case _: GlobalValue | _: LiteralValue => true
+        case _ => false
+      }
+      var possible = INPUT_ROW == null ||
+        canPass(JavaCode.variable(INPUT_ROW, classOf[InternalRow]))
+      val visited = mutable.HashSet.empty[Long]
+      val toVisit = mutable.Stack[Expression](definition)
+      while (possible && toVisit.nonEmpty) {
+        toVisit.pop() match {
+          case ref: BoundReference if currentVars != null && currentVars(ref.ordinal) != null =>
+            val input = currentVars(ref.ordinal)
+            possible = input.code == EmptyBlock && canPass(input.value) && canPass(input.isNull)
+          case ref: CommonExpressionRef =>
+            // A reference to an enclosing scope, since one to this scope is refused. Its slots are
+            // filled inside this method, so what that definition reads has to come in as well.
+            if (visited.add(ref.id.id)) {
+              currentCommonExprs.get(ref.id.id).foreach(slot => toVisit.push(slot.definition))
+            }
+          case e =>
+            // Stopping where `Expression.genCode` stops: it reads a subexpression's value off the
+            // state instead of generating the subtree again.
+            subExprEliminationExprs.get(ExpressionEquals(e)) match {
+              case Some(state) =>
+                possible = canPass(state.eval.value) && canPass(state.eval.isNull)
+              case None => toVisit.pushAll(e.children)
+            }
+        }
+      }
+      val params = args.values.toSeq
+      Option.when(
+        possible && isValidParamLength(calculateParamLengthFromExprValues(params)))(params)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/WithExpressionEvalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/WithExpressionEvalSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, ExprCode, GenerateMutableProjection}
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, EmptyBlock, ExprCode, FalseLiteral, GenerateMutableProjection, JavaCode}
+import org.apache.spark.sql.catalyst.expressions.codegen.Block._
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{BooleanType, DataType, IntegerType}
@@ -168,10 +169,9 @@ class WithExpressionEvalSuite extends SparkFunSuite with SQLHelper {
 
   test("SPARK-58902: nesting does not multiply a definition's body when it can go in a method") {
     // Each level reads its definition twice, so pasting the body doubles it per level;
-    // `CommonExprSlots.fill` putting it in a method makes it 2 at any depth. Not covered here: the
-    // shape where the input arrives as local variables, as a whole-stage `Project` or `Filter`
-    // passes it, where no method is possible and the count is 2, 4, 8, ... 256 at depths 1 to 8 --
-    // see SPARK-59295. A bare `CodegenContext` has `INPUT_ROW` set and `currentVars` null.
+    // `CommonExprSlots.fill` putting it in a method makes it 2 at any depth. A bare
+    // `CodegenContext` has `INPUT_ROW` set and `currentVars` null; the case below covers the input
+    // arriving as local variables instead.
     val marker = 1234567
     def nested(depth: Int): Expression = {
       val leaf: Expression = Add(BoundReference(0, IntegerType, nullable = false), Literal(marker))
@@ -200,6 +200,86 @@ class WithExpressionEvalSuite extends SparkFunSuite with SQLHelper {
       // Four levels keeps the product inside Int, which ANSI `Add` would raise on past depth 10.
       val proj = GenerateMutableProjection.generate(Seq(nested(4)))
       assert(proj(InternalRow(1)).getInt(0) == (1 + marker) * 16)
+    }
+  }
+
+  test("SPARK-59295: a method for the local variables the operator has already evaluated") {
+    // What a whole-stage `Project` or `Filter` passes: no input row, the input as local variables.
+    // A method is possible for what the operator has already evaluated, and not for the rest --
+    // an unevaluated variable's code names a local of the operator that produces the row, so it
+    // cannot go inside a method, and those definitions stay inline as before.
+    val marker = 1234567
+    def nested(depth: Int): Expression = {
+      val leaf: Expression = Add(BoundReference(0, IntegerType, nullable = false), Literal(marker))
+      (1 to depth).foldLeft(leaf) { (inner, _) =>
+        With(inner) { case Seq(ref) => Add(ref, ref) }
+      }
+    }
+    // The input variable a whole-stage operator would have put in `currentVars`: `evaluated` is
+    // whether it emitted its code before generating this expression, which is what decides whether
+    // the method can take it.
+    def generate(e: Expression, input: ExprCode): (String, String) = {
+      val ctx = new CodegenContext
+      ctx.INPUT_ROW = null
+      ctx.currentVars = Seq(input)
+      (e.genCode(ctx).code.toString, ctx.declareAddedFunctions())
+    }
+    def intVar(evaluated: Boolean): ExprCode = {
+      val code = if (evaluated) EmptyBlock else code"int v0 = i.getInt(0);"
+      ExprCode(code, FalseLiteral, JavaCode.variable("v0", IntegerType))
+    }
+    def markerCount(source: (String, String)): Int =
+      marker.toString.r.findAllMatchIn(source._1 + source._2).size
+
+    withSQLConf(SQLConf.CODEGEN_METHOD_SPLIT_THRESHOLD.key -> "1024") {
+      (1 to 6).foreach { depth =>
+        val count = markerCount(generate(nested(depth), intVar(evaluated = true)))
+        assert(count == 2, s"the innermost body was emitted $count times at depth $depth")
+      }
+      // The variable is declared in the scope the call sits in, so the method takes it as a
+      // parameter rather than reading it as a field. A nullable one carries its nullness in a
+      // second local, which the method needs just as much.
+      val (inline, functions) = generate(nested(2), intVar(evaluated = true))
+      assert("private void computeCommonExpr_[0-9]+\\(int v0\\)".r
+        .findFirstIn(functions).isDefined, functions)
+      assert("computeCommonExpr_[0-9]+\\(v0\\);".r.findFirstIn(inline).isDefined, inline)
+      val nullableLeaf = Add(BoundReference(0, IntegerType, nullable = true), Literal(marker))
+      val nullable = With(nullableLeaf) { case Seq(ref) => Add(ref, ref) }
+      val (nullableInline, nullableFunctions) = generate(
+        With(nullable) { case Seq(ref) => Add(ref, ref) },
+        ExprCode(EmptyBlock, JavaCode.isNullVariable("v0IsNull"),
+          JavaCode.variable("v0", IntegerType)))
+      assert("private void computeCommonExpr_[0-9]+\\(int v0, boolean v0IsNull\\)".r
+        .findFirstIn(nullableFunctions).isDefined, nullableFunctions)
+      assert("computeCommonExpr_[0-9]+\\(v0, v0IsNull\\);".r
+        .findFirstIn(nullableInline).isDefined, nullableInline)
+
+      // An unevaluated variable gets no method: `int v0 = i.getInt(0);` names `i`, the producing
+      // operator's local, which is not in scope inside a method here. So the bodies stay inline and
+      // double per level, as they did before a method was possible at all.
+      (1 to 4).foreach { depth =>
+        val deferred = generate(nested(depth), intVar(evaluated = false))
+        val count = markerCount(deferred)
+        assert(count == (1 << depth),
+          s"the innermost body was emitted $count times at depth $depth")
+        assert(!deferred._2.contains("computeCommonExpr"), deferred._2)
+      }
+      // Nor does a value whose name is not one a parameter can take. `ExpandExec` hands out a
+      // compacted mutable state array slot as if it were a local.
+      val slot = ExprCode(EmptyBlock, FalseLiteral,
+        JavaCode.variable("mutableStateArray_0[3]", IntegerType))
+      assert(!generate(nested(2), slot)._2.contains("computeCommonExpr"))
+
+      // A definition reading an enclosing scope's reference needs what that definition reads, which
+      // is behind a `CommonExpressionRef` rather than in the tree being walked.
+      val outer = With(BoundReference(0, IntegerType, nullable = false)) { case Seq(outerRef) =>
+        With(With(outerRef) { case Seq(ref) => Add(ref, Literal(marker)) }) {
+          case Seq(ref) => Add(ref, ref)
+        }
+      }
+      val enclosing = generate(outer, intVar(evaluated = true))
+      assert("private void computeCommonExpr_[0-9]+\\(int v0\\)".r
+        .findFirstIn(enclosing._2).isDefined, enclosing._2)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/WholeStageCodegenSuite.scala
@@ -23,7 +23,7 @@ import java.time.Duration
 import org.apache.spark.SparkException
 import org.apache.spark.rdd.MapPartitionsWithEvaluatorRDD
 import org.apache.spark.sql.{Dataset, Row, SaveMode}
-import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, CodegenObjectFactoryMode, Expression, IsNotNull}
+import org.apache.spark.sql.catalyst.expressions.{And, Attribute, Cast, CodegenObjectFactoryMode, Expression, IsNotNull, With}
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeAndComment, CodeGenerator}
 import org.apache.spark.sql.execution.adaptive.DisableAdaptiveExecutionSuite
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, SortAggregateExec}
@@ -1732,5 +1732,62 @@ class WholeStageCodegenSuite extends SharedSparkSession
       "switch/case bodies should stay inline with a large methodSplitThreshold")
     assert(sinhPattern.findAllIn(inlineCode).length == 1,
       "sinh(v) should be evaluated only once per input row without function splitting")
+  }
+
+  test("SPARK-59295: a nested With in a branch is emitted once per scope under whole-stage") {
+    // A whole-stage `Project` passes its input as local variables, which is where
+    // `CommonExprSlots.fill` could not put a definition in a method before. Both `nullif`s survive
+    // the rewrite inside the branch and each reads its definition twice, so pasting the bodies
+    // would leave the innermost one 4 times over. The project list mentions `a` and `b` more than
+    // once, which is what has `ProjectExec` evaluate them before generating this expression -- the
+    // case below covers the other one.
+    val marker = 1234567
+    val df = spark.range(0, 10, 1, 1).selectExpr("cast(id as int) as a", "cast(id as int) + 1 as b")
+    val query = df.selectExpr(
+      s"CASE WHEN a < 0 THEN NULL ELSE nullif(nullif(a + b + $marker, b), a) END AS r")
+    assert(query.queryExecution.executedPlan.exists(_.expressions.exists(_.exists {
+      case _: With => true
+      case _ => false
+    })), "the rewrite left no With to generate")
+    // Pin the threshold: below the innermost body's length that body would go into a method of its
+    // own and the count would be 1, for a reason unrelated to nesting.
+    val source = withSQLConf(SQLConf.CODEGEN_METHOD_SPLIT_THRESHOLD.key -> "1024") {
+      genCode(query).map(_.body).mkString("\n")
+    }
+    val emitted = marker.toString.r.findAllMatchIn(source).size
+    assert(emitted == 2, s"the innermost definition was emitted $emitted times")
+    // One method for the outer definition, called at both of its references. The name carries the
+    // operator's fresh-name prefix, as in `project_computeCommonExpr_0`.
+    val declared = "private void \\w*computeCommonExpr_[0-9]+\\(".r.findAllMatchIn(source).size
+    assert(declared == 1, source)
+    // Runs it too, so the generated source above is known to compile.
+    checkAnswer(query, (0 until 10).map(i => Row(2 * i + marker + 1)))
+  }
+
+  test("SPARK-59295: a definition reading an input variable the operator has not evaluated") {
+    // Such a variable's code is written against the scope of the operator producing the row and
+    // names a local of it -- here the column batch's row index, and after an exchange the input
+    // adapter's row -- so it cannot go into a method along with the body that reads it. `b` is read
+    // once and only inside a definition, which is what leaves it unevaluated: `ProjectExec`
+    // evaluates an attribute up front only where the project list mentions it more than once.
+    val marker = 1234567
+    withTempPath { dir =>
+      val path = dir.getCanonicalPath
+      spark.range(0, 10).selectExpr("cast(id as int) as a", "cast(id as int) + 1 as b")
+        .write.mode(SaveMode.Overwrite).parquet(path)
+      val query = spark.read.parquet(path).selectExpr(
+        s"CASE WHEN a < 0 THEN NULL ELSE nullif(nullif(a + $marker, b), a) END AS r")
+      assert(query.queryExecution.executedPlan.exists(_.expressions.exists(_.exists {
+        case _: With => true
+        case _ => false
+      })), "the rewrite left no With to generate")
+      val code = genCode(query)
+      // Compiling it is the check: before this was refused, the method named the row index of the
+      // column batch and janino rejected it, which drops the whole stage.
+      code.foreach(CodeGenerator.compile)
+      assert(!code.map(_.body).mkString("\n").contains("computeCommonExpr"),
+        "the definition reads an unevaluated variable, so it cannot go in a method")
+      checkAnswer(query, (0 until 10).map(i => Row(i + marker)))
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`CodegenContext.CommonExprSlots.fill` emits a `With` common expression's definition once per scope by putting its body in a private method, but it could only do that where the definition read the input row (`INPUT_ROW != null && currentVars == null`), the condition `Expression.reduceCodeSize` splits under. A whole-stage `Project` or `Filter` passes its input as local variables instead, so there the body was pasted at every `CommonExpressionRef`, doubling per nesting level. This is the `TODO(SPARK-59295)` left by SPARK-58818.

This PR builds the method's parameter list, so the body goes into a method under whole-stage codegen too. The parameters are what the body would otherwise read from the scope the call replaces it in: the input row, and an input variable the operator evaluated before generating this expression. Everything else the body reads is a field -- the slots, a lambda variable, an expression's own mutable state -- and needs nothing passed. Collecting them follows the same laziness the generated code has: a `With`'s definition is part of the body only where a reference reaches it, so one that no reference reaches is not walked.

Four shapes are refused instead, and keep the inline body they have today:

- A definition reading an input variable the operator has **not** evaluated yet, which is any attribute a `Project`'s list mentions only once. That variable's code was generated against the scope of the operator producing the row and names a local of it -- the column batch's row index, the input adapter's row -- so it cannot travel into the method. Hoisting it to before the call, the way `getLocalInputVariableValues` does for subexpression elimination, would evaluate it on rows that reach no reference, which is the laziness SPARK-58818 exists to keep.
- A value whose name is not a Java identifier. `ExpandExec` allocates a varying output column as mutable state but hands it out as a local, and for a non-primitive type that name is a slot of the compacted array, `mutableStateArray_0[3]`.
- A value that is an expression rather than a name, where there is no way to tell which locals the expression names: `GenerateExec` gives the position of `posexplode_outer` the nullness `index == -1`, and a `Byte` or `Short` literal's value is `(byte)1`.
- A definition holding a node subexpression elimination has computed. `Expression.genCode` reads such a node off its state, while `Alias`, `Collate` and an identity `Cast` override `genCode` and generate their child again, so which values the body reads there cannot be told from the tree. Refusing also keeps the parameter list inside what `getLocalInputVariableValues` collects, which stops at a state and computes the parameters of the methods `ExpandExec` and the aggregates move this call into.

A parameter list too long for a valid method descriptor falls back the same way.

### Why are the changes needed?

Generated code size. For a `With` nested d levels deep, each level reading its definition twice, the whole-stage source of the expression was:

| depth | before | after |
|---|---|---|
| 2 | 2087 | 1315 |
| 3 | 4619 | 1810 |
| 4 | 9755 | 2314 |
| 5 | 19979 | 2812 |

Copies of the innermost body: 2, 4, 8, 16, 32 before, and 2 at every depth after. Exponential growth reaches the method size limit a few levels further on, and dropping the whole stage costs far more than the one call per row this adds.

### Does this PR introduce _any_ user-facing change?

No. The call replaces the body inside the same `if (!computed)` guard, so a definition is still evaluated at most once per row, at the first reference reached; only the generated Java differs.

### How was this patch tested?

New cases in `WithExpressionEvalSuite` and `WholeStageCodegenSuite`. In the first, one test generates against the context a whole-stage operator sets up and asserts the innermost body is emitted twice at any depth, that an evaluated variable and its nullness arrive as parameters, and that a definition no reference reaches neither contributes a parameter nor refuses the method; a second covers the shapes a method is not possible for, one case each, asserting the inline body doubled per level; a third covers the two inputs that need no parameter at all, a field and a subexpression elimination state. In the second suite, a nested `With` in a branch runs over a range and over a Parquet scan, asserting the emitted body count in both and, for the Parquet one, that the stage still compiles.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5
