### PR TITLE
[SPARK-59377] DSv2 column statistics are silently dropped when the column name needs quoting or differs only in case

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.connector.read.{Scan, Statistics => V2Statistics, Su
 import org.apache.spark.sql.connector.read.colstats.{ColumnStatistics, Histogram => V2Histogram, HistogramBin => V2HistogramBin}
 import org.apache.spark.sql.connector.read.streaming.{Offset, SparkDataStream}
 import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.{SupportsRuntimeCatalystFiltering, V2StatisticsUtils}
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
@@ -573,6 +574,12 @@ object DataSourceV2Relation {
     }
 
     var colStats: Seq[(Attribute, ColumnStat)] = Seq.empty[(Attribute, ColumnStat)]
+    // A column statistic corresponds to a single top-level output column, so match the connector's
+    // field reference to an output attribute by its (unquoted) name, honoring the configured case
+    // sensitivity. Do not compare against NamedReference.describe(): describe() back-tick-quotes
+    // names that are not plain identifiers (e.g. `col-1`) and compares case-sensitively, which
+    // silently drops such statistics from the cost-based optimizer.
+    val resolver = SQLConf.get.resolver
     // columnStats() may be null even when numRows/sizeInBytes are present, so normalize it to an
     // empty map before conversion to avoid an NPE.
     val v2ColumnStats = Option(v2Statistics.columnStats()).getOrElse(EMPTY_V2_COLUMN_STATS)
@@ -602,11 +609,16 @@ object DataSourceV2Relation {
 
         val catalystColStat = ColumnStat(distinct, min, max, nullCount, avgLen, maxLen, histogram)
 
-        output.foreach(attribute => {
-          if (attribute.name.equals(key.describe())) {
-            colStats = colStats :+ (attribute -> catalystColStat)
-          }
-        })
+        // Only single-part references can name a top-level output attribute; nested references
+        // (fieldNames.length > 1) have no place in the attribute-keyed catalyst statistics.
+        val fieldNames = key.fieldNames
+        if (fieldNames.length == 1) {
+          output.foreach(attribute => {
+            if (resolver(attribute.name, fieldNames.head)) {
+              colStats = colStats :+ (attribute -> catalystColStat)
+            }
+          })
+        }
       })
     }
     val attributeStats = AttributeMap(colStats)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -574,11 +574,6 @@ object DataSourceV2Relation {
     }
 
     var colStats: Seq[(Attribute, ColumnStat)] = Seq.empty[(Attribute, ColumnStat)]
-    // A column statistic corresponds to a single top-level output column, so match the connector's
-    // field reference to an output attribute by its (unquoted) name, honoring the configured case
-    // sensitivity. Do not compare against NamedReference.describe(): describe() back-tick-quotes
-    // names that are not plain identifiers (e.g. `col-1`) and compares case-sensitively, which
-    // silently drops such statistics from the cost-based optimizer.
     val resolver = SQLConf.get.resolver
     // columnStats() may be null even when numRows/sizeInBytes are present, so normalize it to an
     // empty map before conversion to avoid an NPE.
@@ -609,15 +604,22 @@ object DataSourceV2Relation {
 
         val catalystColStat = ColumnStat(distinct, min, max, nullCount, avgLen, maxLen, histogram)
 
-        // Only single-part references can name a top-level output attribute; nested references
-        // (fieldNames.length > 1) have no place in the attribute-keyed catalyst statistics.
+        // Catalyst statistics are keyed by top-level Attribute, so only single-part references
+        // can be matched to an output column.
         val fieldNames = key.fieldNames
         if (fieldNames.length == 1) {
-          output.foreach(attribute => {
-            if (resolver(attribute.name, fieldNames.head)) {
-              colStats = colStats :+ (attribute -> catalystColStat)
+          val fieldName = fieldNames.head
+          val matches = output.filter(attribute => resolver(attribute.name, fieldName))
+          // On an ambiguous case-insensitive match (e.g. outputs "id" and "ID"), require a unique
+          // exact-name match, otherwise skip so CBO is not fed the wrong column.
+          val matched = matches match {
+            case Seq(single) => Some(single)
+            case multiple => multiple.filter(_.name == fieldName) match {
+              case Seq(exact) => Some(exact)
+              case _ => None
             }
-          })
+          }
+          matched.foreach(attribute => colStats = colStats :+ (attribute -> catalystColStat))
         }
       })
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2RelationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2RelationSuite.scala
@@ -164,9 +164,6 @@ class DataSourceV2RelationSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("DataSourceV2ScanRelation.computeStats matches column stats for names needing quoting") {
-    // A top-level column whose name is not a plain identifier ("col-1" contains a dash, so it is
-    // back-tick-quoted by NamedReference.describe()). The connector reports a column statistic
-    // keyed by this exact name; it must still be attached to the output attribute.
     val colAttr = AttributeReference("col-1", IntegerType)()
     val output = Seq(colAttr)
     val scan = new Scan with SupportsReportStatistics {
@@ -194,9 +191,6 @@ class DataSourceV2RelationSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("DataSourceV2ScanRelation.computeStats matches column stats respecting case sensitivity") {
-    // The connector reports the statistic under a differently-cased name ("ID") than the output
-    // attribute ("id"). Matching must honor spark.sql.caseSensitive: attach under the default
-    // (case-insensitive) resolution, and skip when case-sensitive resolution is enabled.
     val idAttr = AttributeReference("id", IntegerType)()
     val output = Seq(idAttr)
     val scan = new Scan with SupportsReportStatistics {
@@ -229,6 +223,40 @@ class DataSourceV2RelationSuite extends SparkFunSuite with SQLHelper {
       val stats = scanRel(output, scan).computeStats()
       assert(stats.attributeStats.isEmpty,
         "case-sensitive resolution should not match 'ID' to attribute 'id'")
+    }
+  }
+
+  test("DataSourceV2ScanRelation.computeStats resolves case-conflicting outputs uniquely") {
+    val idAttr = AttributeReference("id", IntegerType)()
+    val upperIdAttr = AttributeReference("ID", IntegerType)()
+    val output = Seq(idAttr, upperIdAttr)
+
+    def scanKeyed(name: String): Scan = new Scan with SupportsReportStatistics {
+      override def readSchema(): StructType =
+        StructType(Seq(StructField("id", IntegerType), StructField("ID", IntegerType)))
+      override def estimateStatistics(): V2Statistics = new V2Statistics {
+        override def sizeInBytes(): OptionalLong = OptionalLong.empty()
+        override def numRows(): OptionalLong = OptionalLong.of(42L)
+        override def columnStats(): java.util.Map[NamedReference, ColumnStatistics] = {
+          val stats = new java.util.HashMap[NamedReference, ColumnStatistics]()
+          stats.put(FieldReference.column(name), new ColumnStatistics {
+            override def distinctCount(): OptionalLong = OptionalLong.of(40L)
+          })
+          stats
+        }
+      }
+    }
+
+    withSQLConf(
+        SQLConf.CBO_ENABLED.key -> "true",
+        SQLConf.CASE_SENSITIVE.key -> "false") {
+      val idStats = scanRel(output, scanKeyed("id")).computeStats()
+      assert(idStats.attributeStats.size === 1)
+      assert(idStats.attributeStats(idAttr).distinctCount.contains(BigInt(40)))
+
+      val ambiguousStats = scanRel(output, scanKeyed("Id")).computeStats()
+      assert(ambiguousStats.attributeStats.isEmpty,
+        "an ambiguous case-insensitive match must not be attached to any attribute")
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2RelationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2RelationSuite.scala
@@ -163,6 +163,75 @@ class DataSourceV2RelationSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
+  test("DataSourceV2ScanRelation.computeStats matches column stats for names needing quoting") {
+    // A top-level column whose name is not a plain identifier ("col-1" contains a dash, so it is
+    // back-tick-quoted by NamedReference.describe()). The connector reports a column statistic
+    // keyed by this exact name; it must still be attached to the output attribute.
+    val colAttr = AttributeReference("col-1", IntegerType)()
+    val output = Seq(colAttr)
+    val scan = new Scan with SupportsReportStatistics {
+      override def readSchema(): StructType = StructType(Seq(StructField("col-1", IntegerType)))
+      override def estimateStatistics(): V2Statistics = new V2Statistics {
+        override def sizeInBytes(): OptionalLong = OptionalLong.empty()
+        override def numRows(): OptionalLong = OptionalLong.of(42L)
+        override def columnStats(): java.util.Map[NamedReference, ColumnStatistics] = {
+          val stats = new java.util.HashMap[NamedReference, ColumnStatistics]()
+          stats.put(FieldReference.column("col-1"), new ColumnStatistics {
+            override def distinctCount(): OptionalLong = OptionalLong.of(40L)
+          })
+          stats
+        }
+      }
+    }
+
+    withSQLConf(SQLConf.CBO_ENABLED.key -> "true") {
+      val stats = scanRel(output, scan).computeStats()
+      assert(stats.rowCount.contains(BigInt(42)))
+      assert(stats.attributeStats.size === 1,
+        "column stat keyed by a name needing quoting must be attached to its attribute")
+      assert(stats.attributeStats(colAttr).distinctCount.contains(BigInt(40)))
+    }
+  }
+
+  test("DataSourceV2ScanRelation.computeStats matches column stats respecting case sensitivity") {
+    // The connector reports the statistic under a differently-cased name ("ID") than the output
+    // attribute ("id"). Matching must honor spark.sql.caseSensitive: attach under the default
+    // (case-insensitive) resolution, and skip when case-sensitive resolution is enabled.
+    val idAttr = AttributeReference("id", IntegerType)()
+    val output = Seq(idAttr)
+    val scan = new Scan with SupportsReportStatistics {
+      override def readSchema(): StructType = StructType(Seq(StructField("id", IntegerType)))
+      override def estimateStatistics(): V2Statistics = new V2Statistics {
+        override def sizeInBytes(): OptionalLong = OptionalLong.empty()
+        override def numRows(): OptionalLong = OptionalLong.of(42L)
+        override def columnStats(): java.util.Map[NamedReference, ColumnStatistics] = {
+          val stats = new java.util.HashMap[NamedReference, ColumnStatistics]()
+          stats.put(FieldReference.column("ID"), new ColumnStatistics {
+            override def distinctCount(): OptionalLong = OptionalLong.of(40L)
+          })
+          stats
+        }
+      }
+    }
+
+    withSQLConf(
+        SQLConf.CBO_ENABLED.key -> "true",
+        SQLConf.CASE_SENSITIVE.key -> "false") {
+      val stats = scanRel(output, scan).computeStats()
+      assert(stats.attributeStats.size === 1,
+        "case-insensitive resolution should match 'ID' to attribute 'id'")
+      assert(stats.attributeStats(idAttr).distinctCount.contains(BigInt(40)))
+    }
+
+    withSQLConf(
+        SQLConf.CBO_ENABLED.key -> "true",
+        SQLConf.CASE_SENSITIVE.key -> "true") {
+      val stats = scanRel(output, scan).computeStats()
+      assert(stats.attributeStats.isEmpty,
+        "case-sensitive resolution should not match 'ID' to attribute 'id'")
+    }
+  }
+
   test("DataSourceV2ScanRelation.computeStats derives size 1 for a zero-row scan with CBO") {
     val idAttr = AttributeReference("id", IntegerType)()
     val output = Seq(idAttr)


### PR DESCRIPTION
**What changes were proposed in this pull request?**                                                                                                                                                           
                                                                                                                                                                                                                 
  DataSourceV2Relation.transformV2Stats matched connector-reported column statistics to output attributes via                                                                                                  
 `attribute.name.equals(key.describe())`. This PR matches on the NamedReference's raw field name (key.fieldNames)                                                                                           
 compared through SQLConf.get.resolver, restricted to single-part references, and no longer compares against describe().                                                                                                 

**Why are the changes needed?**                                                                                                                                                                                
                                                                                                                                                                                                                 
 NamedReference.describe() returns a quoted display string (QuotingUtils.quoteIfNeeded). For a top-level column                                                                                                whose name is not a plain identifier (e.g. col-1, 1col, or names with dots/spaces), describe() yields col-1, which                                                                 never equals the attribute name col-1, so the column statistic is silently dropped. The  comparison is  also case-sensitive                                                                                                
regardless of `spark.sql.caseSensitive`, so a stat keyed ID is dropped for an attribute `id` under the default case-insensitive resolution . The lost stats degrade cost-based optimizer estimates with no error surfaced. 

**Does this PR introduce _any_ user-facing change?**
   No public API change

**How was this patch tested?** 
Added unit tests to DataSourceV2RelationSuite: one for a column name needing quoting (col-1), and one asserting                                                                                           case-sensitivity is honored (ID→id matches under case-insensitive resolution

**Was this patch authored or co-authored using generative AI tooling?**
No