### PR TITLE
[SPARK-59378][CORE] Cache the full-ASCII flag as a byproduct of UTF8String.numChars()

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -293,11 +293,23 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Private helper method to calculate the number of code points in the UTF-8 string. Counting
    * the code points is a linear time operation, as we need to scan the entire UTF-8 string.
    * Hence, this method should generally only be called once for non-empty UTF-8 strings.
+   *
+   * Because the scan reads every lead byte, it also caches ASCII-ness for free (see
+   * {@link #isFullAscii()}): any lead byte >= 0x80 (a multi-byte or invalid byte) is non-ASCII.
+   * The flag is only set when still UNKNOWN, preserving a value already computed elsewhere.
    */
   private int getNumChars() {
     int len = 0;
-    for (int i = 0; i < numBytes; i += numBytesForFirstByte(getByte(i))) {
+    boolean ascii = true;
+    int i = 0;
+    while (i < numBytes) {
+      byte b = getByte(i);
+      ascii &= b >= 0;
+      i += numBytesForFirstByte(b);
       len += 1;
+    }
+    if (isFullAscii == IsFullAscii.UNKNOWN) {
+      isFullAscii = ascii ? IsFullAscii.FULL_ASCII : IsFullAscii.NOT_ASCII;
     }
     return len;
   }

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -71,6 +71,36 @@ public class UTF8StringSuite {
   }
 
   @Test
+  public void numCharsCachesAsciiness() {
+    // numChars() determines ASCII-ness as a byproduct of its scan and caches it. Verify it
+    // agrees with getIsFullAscii() (reached via a fresh isFullAscii()), including for invalid
+    // UTF-8 where the code-point count equals the byte count but a byte is >= 0x80 (not ASCII).
+    byte[][] inputs = new byte[][] {
+      {0x68, 0x65, 0x6c, 0x6c, 0x6f},                     // "hello" - full ASCII
+      {},                                                 // empty
+      {0x61, (byte) 0x80},                                // 'a' + stray continuation (invalid)
+      {(byte) 0x80},                                      // lone continuation byte (invalid)
+      {(byte) 0xC3, (byte) 0xA9},                         // valid 2-byte char U+00E9
+      {0x61, (byte) 0xE5, (byte) 0xA4, (byte) 0xA7, 0x62} // 'a' + 3-byte char + 'b'
+    };
+    for (byte[] bytes : inputs) {
+      // Reference: a fresh string computes ASCII-ness via getIsFullAscii().
+      boolean expected = fromBytes(bytes).isFullAscii();
+      // Under test: numChars() runs first and must cache the identical answer.
+      UTF8String s = fromBytes(bytes);
+      s.numChars();
+      assertEquals(expected, s.isFullAscii(),
+        "numChars() cached wrong ASCII flag for " + Arrays.toString(bytes));
+    }
+
+    // The specific invalid case a naive `numChars == numBytes` test would misflag as ASCII:
+    // the count equals the byte count, but the 0x80 byte is not ASCII.
+    UTF8String invalid = fromBytes(new byte[] {0x61, (byte) 0x80});
+    assertEquals(invalid.numBytes(), invalid.numChars());
+    assertFalse(invalid.isFullAscii());
+  }
+
+  @Test
   public void emptyStringTest() {
     assertEquals(EMPTY_UTF8, fromString(""));
     assertEquals(EMPTY_UTF8, fromBytes(new byte[0]));


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UTF8String.numChars()` scans every lead byte of the string to count code points. Determining whether a string is full ASCII (`isFullAscii()` / `getIsFullAscii()`) requires the same kind of full scan. When both are needed for the same string, the string is scanned twice.

This PR computes the full-ASCII flag as a byproduct of the code-point count in `getNumChars()` and caches it in the existing `isFullAscii` field, so a subsequent `isFullAscii()` call is answered from cache instead of triggering a second scan.

```java
private int getNumChars() {
  int len = 0;
  boolean ascii = true;
  int i = 0;
  while (i < numBytes) {
    byte b = getByte(i);
    ascii &= b >= 0;
    i += numBytesForFirstByte(b);
    len += 1;
  }
  if (isFullAscii == IsFullAscii.UNKNOWN) {
    isFullAscii = ascii ? IsFullAscii.FULL_ASCII : IsFullAscii.NOT_ASCII;
  }
  return len;
}
```

Notes for reviewers:

- The scan reads each lead byte once into a local and uses it both for the width step (`numBytesForFirstByte`) and the ASCII check.
- The ASCII predicate is `b >= 0` per lead byte, which is **exactly equivalent** to `getIsFullAscii()`'s `getByte(i) < 0` check, including for invalid UTF-8. Any multi-byte lead (`0xC2`–`0xF4`) or invalid byte (`0x80`–`0xC1`, `0xF5`–`0xFF`) is negative and trips the flag; continuation bytes of a valid sequence are skipped, but their lead byte already tripped it.
- This is **not** a `numChars == numBytes` shortcut. That test would misclassify invalid UTF-8 such as `[0x61, 0x80]` (count 2 == 2 bytes) as ASCII, because `numBytesForFirstByte` treats invalid bytes as width 1. Mis-flagging would send case-conversion down the ASCII path (`convertAscii`) and corrupt the non-ASCII byte.
- The flag is only set when still `UNKNOWN`, preserving any value already computed by `getIsFullAscii()`. Both compute the same predicate, so they never disagree.
- `getIsFullAscii()` is retained: it short-circuits on the first non-ASCII byte, whereas `numChars()` must visit every code point to produce a correct count. For callers that only need ASCII-ness, the short-circuit is strictly cheaper, so `isFullAscii()` continues to use it. The two are complementary writers of the same cached flag, not duplicates.

### Why are the changes needed?

`numChars()` and `isFullAscii()` each perform a full scan of the same bytes. Callers that need both a code-point count and ASCII-ness on the same string (for example case-conversion helpers, and prospective ASCII fast-paths) currently pay for two scans. Folding the cheap ASCII check into the scan `numChars()` already performs removes the redundant second scan at no extra cost.

### Does this PR introduce _any_ user-facing change?

No. This is an internal caching optimization with no observable behavior change.

### How was this patch tested?

- Existing `UTF8StringSuite` passes (`build/sbt 'unsafe/testOnly org.apache.spark.unsafe.types.UTF8StringSuite'`).
- Adds `numCharsCachesAsciiness`, which asserts the flag cached by `numChars()` matches a fresh `isFullAscii()` (i.e. `getIsFullAscii()`) across ASCII, empty, valid multi-byte, and invalid inputs, and specifically that `[0x61, 0x80]` is not flagged as ASCII.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code
