### PR TITLE
[SPARK-59379][CORE] Add ASCII fast-path to UTF8String character/byte position lookups

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -635,20 +635,28 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return EMPTY_UTF8;
     }
 
-    int i = 0;
-    int c = 0;
-    while (i < numBytes && c < start) {
-      i += numBytesForFirstByte(getByte(i));
-      c += 1;
-    }
-
-    int j = i;
-    if (until == Integer.MAX_VALUE) {
-      i = numBytes;
+    int i;
+    int j;
+    if (isFullAscii == IsFullAscii.FULL_ASCII) {
+      // ASCII fast-path: code point index == byte index, so locate directly. The scan below
+      // clamps a negative start to 0 and stops at numBytes; replicate that with min/max.
+      j = Math.max(start, 0);
+      i = (until == Integer.MAX_VALUE) ? numBytes : Math.min(until, numBytes);
     } else {
-      while (i < numBytes && c < until) {
+      i = 0;
+      int c = 0;
+      while (i < numBytes && c < start) {
         i += numBytesForFirstByte(getByte(i));
         c += 1;
+      }
+      j = i;
+      if (until == Integer.MAX_VALUE) {
+        i = numBytes;
+      } else {
+        while (i < numBytes && c < until) {
+          i += numBytesForFirstByte(getByte(i));
+          c += 1;
+        }
       }
     }
 
@@ -716,6 +724,10 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    */
   public int getChar(int charIndex) {
     Objects.checkIndex(charIndex, numChars());
+    if (isFullAscii == IsFullAscii.FULL_ASCII) {
+      // ASCII: byte index == char index, and checkIndex guarantees it is in range.
+      return codePointFrom(charIndex);
+    }
     int charCount = 0, byteCount = 0;
     while (charCount < charIndex) {
       byteCount += numBytesForFirstByte(getByte(byteCount));
@@ -1376,6 +1388,10 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (charPos < 0) {
       return -1;
     }
+    if (isFullAscii == IsFullAscii.FULL_ASCII) {
+      // ASCII: byte index == char index, clamped to the end of the string.
+      return Math.min(charPos, numBytes);
+    }
 
     int i = 0;
     int c = 0;
@@ -1387,6 +1403,10 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   public int bytePosToChar(int bytePos) {
+    if (isFullAscii == IsFullAscii.FULL_ASCII) {
+      // ASCII: char index == byte index, clamped to [0, numBytes].
+      return Math.max(0, Math.min(bytePos, numBytes));
+    }
     int i = 0;
     int c = 0;
     while (i < numBytes && i < bytePos) {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -229,6 +229,44 @@ public class UTF8StringSuite {
   }
 
   @Test
+  public void asciiLocateFastPathMatchesScan() {
+    // substring, getChar, charPosToByte and bytePosToChar take an ASCII fast-path when the
+    // isFullAscii flag is already FULL_ASCII. For each input, compare a cold instance (flag
+    // UNKNOWN -> general scan) against a warmed instance (isFullAscii() called -> fast-path for
+    // ASCII) and assert identical results. Covers ASCII, empty, multi-byte, and invalid UTF-8.
+    byte[][] inputs = new byte[][] {
+      "hello world".getBytes(StandardCharsets.UTF_8), // full ASCII -> exercises the fast-path
+      {}, // empty (vacuously ASCII)
+      {0x61, (byte) 0xC3, (byte) 0xA9, 0x62}, // 'a' + U+00E9 (2-byte) + 'b' (not ASCII)
+      {0x61, (byte) 0x80, 0x62} // invalid UTF-8, stray continuation (not ASCII)
+    };
+    int[] positions = {Integer.MIN_VALUE, -3, -1, 0, 1, 2, 3, 5, 100, Integer.MAX_VALUE};
+
+    for (byte[] bytes : inputs) {
+      UTF8String cold = fromBytes(bytes);
+      UTF8String warm = fromBytes(bytes);
+      warm.isFullAscii(); // warm the cached flag; fast-path branches read it without recomputing
+      String label = Arrays.toString(bytes);
+
+      for (int a : positions) {
+        for (int b : positions) {
+          assertEquals(cold.substring(a, b), warm.substring(a, b),
+            "substring(" + a + ", " + b + ") on " + label);
+        }
+        assertEquals(cold.charPosToByte(a), warm.charPosToByte(a),
+          "charPosToByte(" + a + ") on " + label);
+        assertEquals(cold.bytePosToChar(a), warm.bytePosToChar(a),
+          "bytePosToChar(" + a + ") on " + label);
+      }
+
+      for (int idx = 0; idx < warm.numChars(); idx++) {
+        assertEquals(cold.getChar(idx), warm.getChar(idx),
+          "getChar(" + idx + ") on " + label);
+      }
+    }
+  }
+
+  @Test
   public void trims() {
     assertEquals(fromString("1"), fromString("1").trim());
     assertEquals(fromString("1"), fromString("1\t").trimAll());


### PR DESCRIPTION
### What changes were proposed in this pull request?

Several `UTF8String` methods convert a character index to/from a byte offset by walking the string one code point at a time (`i += numBytesForFirstByte(getByte(i))`). For a full-ASCII string every code point is exactly one byte, so **character index == byte index** and that scan can be replaced with O(1) arithmetic.

This PR adds an ASCII fast-path to the four char<->byte "locate" methods: `substring(int, int)`, `getChar(int)`, `charPosToByte(int)`, and `bytePosToChar(int)`. The fast-path is gated on the cached ASCII flag already being warm, read without forcing a scan:

```java
if (isFullAscii == IsFullAscii.FULL_ASCII) {
  // ASCII: char index == byte index, so locate directly.
  ...
}
```

Notes for reviewers:

- Pure win with **no regression**: when the flag is cold (`UNKNOWN`) the methods fall back to the existing per-code-point scan. It deliberately does NOT call `isFullAscii()`, which would force a full scan and could regress cold long strings (e.g. `SUBSTR(s, 1, 5)`).
- The arithmetic replicates the scan's behavior exactly: a negative index clamps to 0, the `until == Integer.MAX_VALUE` sentinel maps to `numBytes`, and endpoints clamp to `numBytes`. For example `substring` computes `j = max(start, 0)` and `i = (until == Integer.MAX_VALUE) ? numBytes : min(until, numBytes)`; `getChar` returns `codePointFrom(charIndex)` directly (the existing `Objects.checkIndex` guarantees the index is in range).
- Non-ASCII and invalid-UTF-8 strings have the flag set to `NOT_ASCII` when warmed, so they take the unchanged scan path.

**Relationship to SPARK-59378 (#58667):** the benefit depends on the ASCII flag being warm. SPARK-59378 makes `numChars()` cache the flag as a byproduct of its scan, which warms it for the natural callers here (`getChar()` calls `numChars()` for its bounds check; `substringSQL(pos < 0)` calls `numChars()` before `substring()`). Until SPARK-59378 lands, `numChars()` does not warm the flag, so these fast-paths are **dormant** on master (still fully correct; they fire whenever `isFullAscii()` or a case-conversion warmed the flag) and activate automatically once it merges.

### Why are the changes needed?

`substring` and the char/byte position lookups are hot in string-heavy workloads and currently pay an O(n) code-point walk even for ASCII data, where the position is directly computable. This removes that walk when the string is already known to be full ASCII, at no cost when it is not.

### Does this PR introduce _any_ user-facing change?

No. Internal optimization with no observable behavior change.

### How was this patch tested?

- Existing `UTF8StringSuite` passes, including the `substring()`/`substringSQL()` cases.
- Adds `asciiLocateFastPathMatchesScan`, which for each input compares a cold instance (scan path) against a warmed instance (fast-path) and asserts identical results for `substring`, `getChar`, `charPosToByte`, and `bytePosToChar`, over ASCII, empty, multi-byte, and invalid UTF-8 inputs and a range of boundary positions (negatives, `Integer.MAX_VALUE`, out-of-range).

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code
