### PR TITLE
[SPARK-59382][CORE] Avoid redundant volatile reads of lazy caches in UTF8String

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -285,8 +285,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * Returns the number of code points in it.
    */
   public int numChars() {
-    if (numChars == -1) numChars = getNumChars();
-    return numChars;
+    int chars = numChars;
+    if (chars == -1) {
+      chars = getNumChars();
+      numChars = chars;
+    }
+    return chars;
   }
 
   /**
@@ -376,8 +380,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * string (after possible replacement) must be evaluated first by calling `getIsValid`.
    */
   private byte[] makeValidBytes() {
-    assert(numBytesValid > 0);
-    byte[] bytes = new byte[numBytesValid];
+    int validBytes = numBytesValid;
+    assert(validBytes > 0);
+    byte[] bytes = new byte[validBytes];
     int byteIndex = 0, byteIndexValid = 0;
     while (byteIndex < numBytes) {
       // Read the first byte.
@@ -441,10 +446,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
    * @return If string represents a valid UTF8 string.
    */
   public boolean isValid() {
-    if (isValid == UTF8StringValidity.UNKNOWN) {
-      isValid = getIsValid();
+    UTF8StringValidity valid = isValid;
+    if (valid == UTF8StringValidity.UNKNOWN) {
+      valid = getIsValid();
+      isValid = valid;
     }
-    return isValid == UTF8StringValidity.IS_VALID;
+    return valid == UTF8StringValidity.IS_VALID;
   }
 
   /**
@@ -817,10 +824,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   public boolean isFullAscii() {
-    if (isFullAscii == IsFullAscii.UNKNOWN) {
-      isFullAscii = getIsFullAscii();
+    IsFullAscii ascii = isFullAscii;
+    if (ascii == IsFullAscii.UNKNOWN) {
+      ascii = getIsFullAscii();
+      isFullAscii = ascii;
     }
-    return isFullAscii == IsFullAscii.FULL_ASCII;
+    return ascii == IsFullAscii.FULL_ASCII;
   }
 
   private IsFullAscii getIsFullAscii() {
@@ -1638,7 +1647,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     // For the empty `pattern` a `split` function ignores trailing empty strings unless original
     // string is empty.
     if (numBytes() != 0 && pattern.numBytes() == 0) {
-      int newLimit = limit > numChars() || limit <= 0 ? numChars() : limit;
+      int nc = numChars();
+      int newLimit = limit > nc || limit <= 0 ? nc : limit;
       byte[] input = getBytes();
       int byteIndex = 0;
       UTF8String[] result = new UTF8String[newLimit];
@@ -1657,7 +1667,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     // For the empty `pattern` a `split` function ignores trailing empty strings unless original
     // string is empty.
     if (numBytes() != 0 && pattern.numBytes() == 0) {
-      int newLimit = limit > numChars() || limit <= 0 ? numChars() : limit;
+      int nc = numChars();
+      int newLimit = limit > nc || limit <= 0 ? nc : limit;
       byte[] input = getBytes();
       int byteIndex = 0;
       int charIndex = 0;


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UTF8String` lazily computes and caches several values in `volatile` fields: `numChars`, `isFullAscii`, `isValid`, and `numBytesValid`. The accessor methods read the `volatile` field two (or three) times per call — the "is it computed yet" check plus the return — and two callers invoke `numChars()` twice. A `volatile` read cannot be kept in a register or hoisted by the JIT, and on AArch64 it compiles to a load-acquire (`ldar`) rather than a plain load. This PR reads each field once into a local, halving the volatile reads on the warm path.

```java
// before
public int numChars() {
  if (numChars == -1) numChars = getNumChars();
  return numChars;                                  // second volatile read
}

// after
public int numChars() {
  int chars = numChars;                             // single volatile read
  if (chars == -1) {
    chars = getNumChars();
    numChars = chars;
  }
  return chars;
}
```

The same shape is applied to `isFullAscii()` and `isValid()`. In addition:
- `makeValidBytes()` reads `numBytesValid` once into a local (it was read by both the `assert` and the array allocation).
- `split()` and `splitLegacyTruncate()` call `numChars()` once into a local instead of twice.

Correctness is preserved: the field is still written on first computation, so subsequent calls remain cached; in `isValid()` the write order is unchanged (`getIsValid()` still sets `numBytesValid` before the `isValid` field is assigned). Single-read sites (such as the ASCII fast-path checks in `substring`/`getChar`) are unaffected — hoisting only helps where a field is read more than once.

### Why are the changes needed?

These fields are read on hot paths in string-heavy workloads. Reading a `volatile` field repeatedly within one call prevents the JIT from keeping the value in a register and, on AArch64, incurs a load-acquire per read. Reading once into a local removes the redundant reads at no cost and with no behavior change. It is a small micro-optimization, most measurable on ARM.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `UTF8StringSuite` passes (51/51). No new tests were added: these are behavior-preserving refactors of accessors already covered by the suite (`numChars`, `isValid`, `isFullAscii` via case conversion, `split`, and `makeValid`).

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code
