### PR TITLE
[SPARK-59383][INFRA] Upgrade `actions/setup-java` to v6 and `actions/setup-python` to v7

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -130,7 +130,7 @@ jobs:
         run: cd tpcds-kit/tools && make OS=LINUX
       - name: Install Java ${{ inputs.jdk }}
         if: steps.cache-tpcds-sf-1.outputs.cache-hit != 'true'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.jdk }}
@@ -199,7 +199,7 @@ jobs:
         restore-keys: |
           benchmark-coursier-${{ inputs.jdk }}
     - name: Install Java ${{ inputs.jdk }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.jdk }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -387,12 +387,12 @@ jobs:
           ./dev/free_disk_space
         fi
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
     - name: Install Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       # We should install one Python that is higher than 3+ for SQL and Yarn because:
       # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
       # - Yarn has a Python specific test too, for example, YarnClusterSuite.
@@ -581,7 +581,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -705,7 +705,7 @@ jobs:
       shell: 'script -q -e -c "bash {0}"'
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -861,7 +861,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -925,7 +925,7 @@ jobs:
         input: sql/connect/common/src/main
         against: 'https://github.com/apache/spark.git#branch=branch-4.0,subdir=sql/connect/common/src/main'
     - name: Install Python 3.12
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
     - name: Install dependencies for Python CodeGen check
@@ -987,7 +987,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1060,7 +1060,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - uses: actions/checkout@v6
-    - uses: actions/setup-java@v5
+    - uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: 25
@@ -1123,7 +1123,7 @@ jobs:
       continue-on-error: true
       run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1199,7 +1199,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1322,7 +1322,7 @@ jobs:
         restore-keys: |
           coursier-${{ runner.os }}-
     - name: Install Java ${{ inputs.java }}
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: ${{ inputs.java }}
@@ -1400,7 +1400,7 @@ jobs:
             ./dev/free_disk_space
           fi
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
@@ -1488,7 +1488,7 @@ jobs:
             ./dev/free_disk_space
           fi
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}

--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -52,12 +52,12 @@ jobs:
           restore-keys: |
             coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17
       - name: Install Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           architecture: x64

--- a/.github/workflows/build_python_connect40.yml
+++ b/.github/workflows/build_python_connect40.yml
@@ -54,12 +54,12 @@ jobs:
           restore-keys: |
             coursier-build-spark-connect-python-only-${{ runner.os }}-
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17
       - name: Install Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
           architecture: x64

--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -47,7 +47,7 @@ jobs:
         restore-keys: |
           build-sparkr-windows-maven-${{ runner.os }}-
     - name: Install Java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: zulu
         java-version: 17
@@ -65,7 +65,7 @@ jobs:
     # includes Python 3.7, which Spark does not support. Therefore, we simply install the proper Python
     # for simplicity, see SPARK-47116.
     - name: Install Python 3.11
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v7
       with:
         python-version: '3.11'
         architecture: x64

--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -99,7 +99,7 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-java${{ inputs.java }}-
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
@@ -243,12 +243,12 @@ jobs:
           restore-keys: |
             maven-${{ runner.os }}-java${{ matrix.java }}-
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Install Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         # We should install one Python that is higher than 3+ for SQL and Yarn because:
         # - SQL component also has Python related tests, for example, IntegratedUDFTestUtils.
         # - Yarn has a Python specific test too, for example, YarnClusterSuite.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Free up disk space
         run: ./dev/free_disk_space_container
       - name: Install Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: 17

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -54,13 +54,13 @@ jobs:
           snapshot-maven-${{ runner.os }}-
     - name: Install Java 8 for branch-3.x
       if: matrix.branch == 'branch-3.5'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 8
     - name: Install Java 17
       if: matrix.branch != 'branch-3.5'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: 17

--- a/.github/workflows/python_hosted_runner_test.yml
+++ b/.github/workflows/python_hosted_runner_test.yml
@@ -103,7 +103,7 @@ jobs:
           restore-keys: |
             coursier-${{ runner.os }}-
       - name: Install Java ${{ inputs.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
@@ -206,12 +206,12 @@ jobs:
           restore-keys: |
             coursier-${{ runner.os }}-
       - name: Install Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: zulu
           java-version: ${{ matrix.java }}
       - name: Install Python ${{matrix.python}}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: ${{matrix.python}}
           architecture: ${{ inputs.arch }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `actions/setup-java` from v5 to v6 and `actions/setup-python` from v6 to v7.

- `actions/setup-java` v6.0.0 (2026-08-24): https://github.com/actions/setup-java/releases/tag/v6.0.0
- `actions/setup-python` v7.0.0 (2026-07-20): https://github.com/actions/setup-python/releases/tag/v7.0.0

### Why are the changes needed?

To bring the latest bug fixes and improvements to our CI.

The breaking changes in these major releases do not affect Spark: `actions/setup-java` renamed `jdkFile` to `jdk-file` and `actions/setup-python` removed `pip-install`, and neither input is used in this repository.

### Does this PR introduce _any_ user-facing change?

No, this is an infra-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5