### PR TITLE
[SPARK-59386][CORE] Avoid redundant byte reads in the UTF8String.levenshteinDistance inner loop

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -2162,18 +2162,21 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
 
     for (j = 0, j_bytes = 0; j < m; j_bytes += num_bytes_j, j++) {
-      num_bytes_j = numBytesForFirstByte(t.getByte(j_bytes));
+      byte t_byte = t.getByte(j_bytes);
+      num_bytes_j = numBytesForFirstByte(t_byte);
       d[0] = j + 1;
 
-      for (i = 0, i_bytes = 0; i < n; i_bytes += numBytesForFirstByte(s.getByte(i_bytes)), i++) {
-        if (s.getByte(i_bytes) != t.getByte(j_bytes) ||
-              num_bytes_j != numBytesForFirstByte(s.getByte(i_bytes))) {
+      for (i = 0, i_bytes = 0; i < n; i++) {
+        byte s_byte = s.getByte(i_bytes);
+        int num_bytes_i = numBytesForFirstByte(s_byte);
+        if (s_byte != t_byte || num_bytes_j != num_bytes_i) {
           cost = 1;
         } else {
           cost = (ByteArrayMethods.arrayEquals(t.base, t.offset + j_bytes, s.base,
               s.offset + i_bytes, num_bytes_j)) ? 0 : 1;
         }
         d[i + 1] = Math.min(Math.min(d[i] + 1, p[i + 1] + 1), p[i] + cost);
+        i_bytes += num_bytes_i;
       }
 
       swap = p;


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UTF8String` stores UTF-8, a variable-width encoding, so locating the i-th code point is O(N): the string must be scanned from the start, advancing past each code point by its byte width (`numBytesForFirstByte` of the leading byte). There is no O(1) random access to the i-th character the way there is for a fixed-width array. To avoid an O(N) character lookup inside the dynamic-programming loop — which would push the whole computation to O(n^2 * m) — `levenshteinDistance` carries the byte offsets `i_bytes`/`j_bytes` alongside the character indices `i`/`j` and advances them by each code point's width as it goes.

That per-character width bookkeeping sits on the innermost hot path, and the unlimited `levenshteinDistance(UTF8String)` overload currently does it redundantly: `numBytesForFirstByte(s.getByte(i_bytes))` is evaluated both in the loop increment and again in the comparison, and `s.getByte(i_bytes)` / `t.getByte(j_bytes)` are re-read within the body. This PR reads the source byte and its width once per iteration into locals and hoists the loop-invariant target byte out to the outer loop.

The redundancy exists only in the unlimited overload. The limited/threshold overload `levenshteinDistance(UTF8String, int)` already reads each source byte once per iteration and does not read `t.getByte(j_bytes)` in its inner loop (it uses the precomputed `num_bytes_j` with `arrayEquals`), so it is left unchanged.

### Why are the changes needed?

The inner loop runs O(n*m) times, so removing the duplicated per-character byte reads and width computations reduces the constant factor of a hot path. It is a constant-factor improvement; the O(n*m) complexity is unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `UTF8StringSuite` passes (51/51), including the multi-byte `levenshteinDistance` case. This is a behavior-preserving refactor, so no new tests were added.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code
