### PR TITLE
[SPARK-59385][SS] Enable dropDuplicatesWithinWatermark to be supported by RTM

### DIFF
--- a/docs/streaming/real-time-mode.md
+++ b/docs/streaming/real-time-mode.md
@@ -33,12 +33,12 @@ that must react to data the moment it arrives, such as fraud detection, real-tim
 personalization.
 
 Real-time Mode in Apache Spark supports **stateless queries** -- projections, filters and other
-map-like operations, unions, and stream-static joins -- and, starting in Spark 4.3.0, a first set of
-**stateful queries**: streaming **deduplication** (`dropDuplicates`, plus
-`dropDuplicatesWithinWatermark` starting in Spark 4.4.0), streaming **aggregations**
-(`groupBy(...).agg(...)`), and the JVM (Scala/Java) **`transformWithState`** operator. These
-stateful operations require a shuffle, which Real-time Mode runs as a *pipelined shuffle* so that
-records still stream through without waiting for a batch boundary; see
+map-like operations, unions, and stream-static joins. Stateful support starts in Spark 4.3.0 with
+streaming **deduplication** using `dropDuplicates`, streaming **aggregations**
+(`groupBy(...).agg(...)`), and the JVM (Scala/Java) **`transformWithState`** operator. Starting in
+Spark 4.4.0, Real-time Mode also supports `dropDuplicatesWithinWatermark`. These stateful operations
+require a shuffle, which Real-time Mode runs as a *pipelined shuffle* so that records still stream
+through without waiting for a batch boundary; see
 [How Stateful Queries Work](#how-stateful-queries-work). Other stateful operations, including
 stream-stream joins and `flatMapGroupsWithState`, are not yet supported. See
 [Supported Queries](#supported-queries) for the full list.
@@ -219,8 +219,9 @@ substantially:
 - **Real-time Mode** is designed to support all query shapes, including stateful operations, while
   reusing Spark's mature components such as state management, the Catalyst optimizer, and the
   existing SQL operators. It provides exactly-once processing semantics. It supports stateless
-  queries and, starting in Spark 4.3.0, stateful deduplication, aggregation, and JVM
-  `transformWithState`; support for the remaining stateful operations is ongoing.
+  queries and, starting in Spark 4.3.0, `dropDuplicates`, stateful aggregation, and JVM
+  `transformWithState`. Starting in Spark 4.4.0, it also supports
+  `dropDuplicatesWithinWatermark`; support for the remaining stateful operations is ongoing.
 
 For new low-latency workloads, prefer Real-time Mode over Continuous Processing.
 
@@ -355,9 +356,9 @@ The following operations, sources, and sinks are supported:
 - *Stateful operations*: support began in Spark 4.3.0. These regroup records by key through a
   pipelined shuffle (see [How Stateful Queries Work](#how-stateful-queries-work)) and keep their
   state in the state store, checkpointed each batch.
-  + **Deduplication**: `dropDuplicates`, and `dropDuplicatesWithinWatermark` starting in Spark
-    4.4.0. The latter requires `withWatermark` and bounds state retention according to the
-    event-time watermark.
+  + **Deduplication**: `dropDuplicates` is supported starting in Spark 4.3.0.
+    `dropDuplicatesWithinWatermark` is supported starting in Spark 4.4.0; it requires
+    `withWatermark` and bounds state retention according to the event-time watermark.
   + **Streaming aggregation**: `groupBy(...).agg(...)` (and the SQL `GROUP BY` equivalent), including
     windowed aggregations with `window(...)`. Distinct aggregates such as `count(distinct ...)` are
     not supported (see [Not supported](#not-supported)).
@@ -529,10 +530,93 @@ spark
 
 ### Deduplication
 
-Drop duplicate records by key. This is a stateful operation: Real-time Mode regroups records by the
-deduplication key through a pipelined shuffle and keeps the set of seen keys in the state store (see
-[How Stateful Queries Work](#how-stateful-queries-work)). No code changes are needed beyond running
-under a Real-time trigger.
+Real-time Mode supports two deduplication operations. Both regroup records by the deduplication key
+through a pipelined shuffle and keep seen keys in the state store (see
+[How Stateful Queries Work](#how-stateful-queries-work)).
+
+#### `dropDuplicates` (Real-time Mode support since Spark 4.3.0)
+
+This example uses `dropDuplicates` without a watermark, so it retains every distinct `id` for the
+lifetime of the query. `dropDuplicates` can use a watermark to bound state when the event-time
+column is included in the deduplication columns. Use `dropDuplicatesWithinWatermark` below when
+event time should bound state without being part of the deduplication key.
+
+<div class="codetabs">
+
+<div data-lang="python"  markdown="1">
+{% highlight python %}
+spark \
+  .readStream \
+  .format("kafka") \
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2") \
+  .option("subscribe", "input-topic") \
+  .load() \
+  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value") \
+  .dropDuplicates(["id"]) \
+  .writeStream \
+  .format("kafka") \
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2") \
+  .option("topic", "output-topic") \
+  .option("checkpointLocation", "/path/to/checkpoint") \
+  .outputMode("update") \
+  .trigger(realTime="5 minutes") \
+  .start()
+{% endhighlight %}
+</div>
+
+<div data-lang="scala"  markdown="1">
+{% highlight scala %}
+import org.apache.spark.sql.streaming.Trigger
+
+spark
+  .readStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("subscribe", "input-topic")
+  .load()
+  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value")
+  .dropDuplicates("id")
+  .writeStream
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("topic", "output-topic")
+  .option("checkpointLocation", "/path/to/checkpoint")
+  .outputMode("update")
+  .trigger(Trigger.RealTime("5 minutes"))
+  .start()
+{% endhighlight %}
+</div>
+
+<div data-lang="java"  markdown="1">
+{% highlight java %}
+import org.apache.spark.sql.streaming.Trigger;
+
+spark
+  .readStream()
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("subscribe", "input-topic")
+  .load()
+  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value")
+  .dropDuplicates("id")
+  .writeStream()
+  .format("kafka")
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
+  .option("topic", "output-topic")
+  .option("checkpointLocation", "/path/to/checkpoint")
+  .outputMode("update")
+  .trigger(Trigger.RealTime("5 minutes"))
+  .start();
+{% endhighlight %}
+</div>
+
+</div>
+
+#### `dropDuplicatesWithinWatermark` (Real-time Mode support since Spark 4.4.0)
+
+Use `dropDuplicatesWithinWatermark` with an event-time watermark to bound deduplication state
+without including event time in the deduplication key. This example aliases Kafka's record
+timestamp as `eventTime` and sets a 10-minute watermark delay threshold.
 
 <div class="codetabs">
 
@@ -617,14 +701,10 @@ spark
 
 </div>
 
-This bounded example aliases Kafka's record timestamp as `eventTime`, sets a 10-minute watermark
-delay threshold, and uses `dropDuplicatesWithinWatermark` to deduplicate by `id`. It bounds
-deduplication state as the event-time watermark advances. Records that pass deduplication are still
-emitted as they are processed, while watermark advancement and state eviction take effect at
-Real-time Mode batch boundaries. The trigger duration therefore determines how often cleanup has
-an opportunity to remove state after the watermark advances past a key's expiry. To deduplicate
-keys for the lifetime of the query instead, use `dropDuplicates`, which keeps every distinct key it
-has seen in the state store.
+Records that pass deduplication are emitted as they are processed, while watermark advancement and
+state eviction take effect at Real-time Mode batch boundaries. The trigger duration therefore
+determines how often cleanup has an opportunity to remove state after the watermark advances past a
+key's expiry.
 
 ### Streaming aggregation
 

--- a/docs/streaming/real-time-mode.md
+++ b/docs/streaming/real-time-mode.md
@@ -34,10 +34,11 @@ personalization.
 
 Real-time Mode in Apache Spark supports **stateless queries** -- projections, filters and other
 map-like operations, unions, and stream-static joins -- and, starting in Spark 4.3.0, a first set of
-**stateful queries**: streaming **deduplication** (`dropDuplicates`) and streaming **aggregations**
-(`groupBy(...).agg(...)`), and the JVM (Scala/Java) **`transformWithState`** operator. These stateful
-operations require a shuffle, which Real-time Mode runs as a *pipelined shuffle* so that records
-still stream through without waiting for a batch boundary; see
+**stateful queries**: streaming **deduplication** (`dropDuplicates`, plus
+`dropDuplicatesWithinWatermark` starting in Spark 5.0.0), streaming **aggregations**
+(`groupBy(...).agg(...)`), and the JVM (Scala/Java) **`transformWithState`** operator. These
+stateful operations require a shuffle, which Real-time Mode runs as a *pipelined shuffle* so that
+records still stream through without waiting for a batch boundary; see
 [How Stateful Queries Work](#how-stateful-queries-work). Other stateful operations, including
 stream-stream joins and `flatMapGroupsWithState`, are not yet supported. See
 [Supported Queries](#supported-queries) for the full list.
@@ -73,7 +74,8 @@ query checkpoints progress -- as the next section explains.
 
 Stateless operations are per-record: each long-running task reads a partition, transforms records,
 and ships them without ever needing data from another partition. Stateful operations are different.
-A streaming aggregation, `dropDuplicates`, or `transformWithState` groups records **by key**, so
+A streaming aggregation, `dropDuplicates`, `dropDuplicatesWithinWatermark`, or
+`transformWithState` groups records **by key**, so
 every record for a given key must reach the same task, no matter which partition it arrived on. In
 the micro-batch engine that regrouping is done by a **shuffle**: the batch's producer stage writes
 shuffle files, and only once those files are fully materialized does the consumer stage read them
@@ -350,11 +352,12 @@ The following operations, sources, and sinks are supported:
     side must be broadcast (use the `broadcast(...)` hint), because a stream-static join must not
     introduce a shuffle.
 
-- *Stateful operations* (supported since Spark 4.3.0): these regroup records by key through a
+- *Stateful operations*: support began in Spark 4.3.0. These regroup records by key through a
   pipelined shuffle (see [How Stateful Queries Work](#how-stateful-queries-work)) and keep their
   state in the state store, checkpointed each batch.
-  + **Deduplication**: `dropDuplicates`. (`dropDuplicatesWithinWatermark` is not yet supported in
-    Real-time Mode.)
+  + **Deduplication**: `dropDuplicates`, and `dropDuplicatesWithinWatermark` starting in Spark
+    5.0.0. The latter requires `withWatermark` and bounds state retention according to the
+    event-time watermark.
   + **Streaming aggregation**: `groupBy(...).agg(...)` (and the SQL `GROUP BY` equivalent), including
     windowed aggregations with `window(...)`. Distinct aggregates such as `count(distinct ...)` are
     not supported (see [Not supported](#not-supported)).
@@ -393,7 +396,7 @@ The following are not yet supported in Real-time Mode. Unless noted otherwise, a
 fails to start with `STREAMING_REAL_TIME_MODE.OPERATOR_OR_SINK_NOT_IN_ALLOWLIST`:
 
 - Stateful operations other than those listed above: **stream-stream joins**,
-  `flatMapGroupsWithState`, session-window aggregation, and `dropDuplicatesWithinWatermark`.
+  `flatMapGroupsWithState`, and session-window aggregation.
 - The PySpark `transformWithState` and `transformWithStateInPandas` APIs. Real-time Mode currently
   supports only the JVM (Scala/Java) `transformWithState` implementation.
 - **Range partitioning**: `repartitionByRange`, or an `ORDER BY` / sort that plans to a range
@@ -542,7 +545,7 @@ spark \
   .option("subscribe", "input-topic") \
   .load() \
   .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value") \
-  .dropDuplicates("id") \
+  .dropDuplicates(["id"]) \
   .writeStream \
   .format("kafka") \
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2") \
@@ -602,8 +605,15 @@ spark
 
 </div>
 
-This keeps every distinct key it has seen in the state store. `dropDuplicatesWithinWatermark`, which
-bounds how long keys are retained, is not yet supported in Real-time Mode.
+This example uses `dropDuplicates`, which keeps every distinct key it has seen in the state store.
+To bound state, define an event-time watermark and use `dropDuplicatesWithinWatermark`. For example,
+Scala and Java use
+`withWatermark("eventTime", "10 minutes").dropDuplicatesWithinWatermark("id")`; in PySpark, pass the
+column subset as a list:
+`withWatermark("eventTime", "10 minutes").dropDuplicatesWithinWatermark(["id"])`. Records are still
+emitted as they are processed, while watermark advancement and state eviction take effect at
+Real-time Mode batch boundaries. The trigger duration therefore determines how often cleanup has
+an opportunity to remove state after the event-time watermark advances past its expiry.
 
 ### Streaming aggregation
 

--- a/docs/streaming/real-time-mode.md
+++ b/docs/streaming/real-time-mode.md
@@ -35,7 +35,7 @@ personalization.
 Real-time Mode in Apache Spark supports **stateless queries** -- projections, filters and other
 map-like operations, unions, and stream-static joins -- and, starting in Spark 4.3.0, a first set of
 **stateful queries**: streaming **deduplication** (`dropDuplicates`, plus
-`dropDuplicatesWithinWatermark` starting in Spark 5.0.0), streaming **aggregations**
+`dropDuplicatesWithinWatermark` starting in Spark 4.4.0), streaming **aggregations**
 (`groupBy(...).agg(...)`), and the JVM (Scala/Java) **`transformWithState`** operator. These
 stateful operations require a shuffle, which Real-time Mode runs as a *pipelined shuffle* so that
 records still stream through without waiting for a batch boundary; see
@@ -356,7 +356,7 @@ The following operations, sources, and sinks are supported:
   pipelined shuffle (see [How Stateful Queries Work](#how-stateful-queries-work)) and keep their
   state in the state store, checkpointed each batch.
   + **Deduplication**: `dropDuplicates`, and `dropDuplicatesWithinWatermark` starting in Spark
-    5.0.0. The latter requires `withWatermark` and bounds state retention according to the
+    4.4.0. The latter requires `withWatermark` and bounds state retention according to the
     event-time watermark.
   + **Streaming aggregation**: `groupBy(...).agg(...)` (and the SQL `GROUP BY` equivalent), including
     windowed aggregations with `window(...)`. Distinct aggregates such as `count(distinct ...)` are
@@ -544,8 +544,12 @@ spark \
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2") \
   .option("subscribe", "input-topic") \
   .load() \
-  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value") \
-  .dropDuplicates(["id"]) \
+  .selectExpr(
+    "CAST(key AS STRING) AS id",
+    "CAST(value AS STRING) AS value",
+    "timestamp AS eventTime") \
+  .withWatermark("eventTime", "10 minutes") \
+  .dropDuplicatesWithinWatermark(["id"]) \
   .writeStream \
   .format("kafka") \
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2") \
@@ -567,8 +571,12 @@ spark
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
   .option("subscribe", "input-topic")
   .load()
-  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value")
-  .dropDuplicates("id")
+  .selectExpr(
+    "CAST(key AS STRING) AS id",
+    "CAST(value AS STRING) AS value",
+    "timestamp AS eventTime")
+  .withWatermark("eventTime", "10 minutes")
+  .dropDuplicatesWithinWatermark("id")
   .writeStream
   .format("kafka")
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
@@ -590,8 +598,12 @@ spark
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
   .option("subscribe", "input-topic")
   .load()
-  .selectExpr("CAST(key AS STRING) AS id", "CAST(value AS STRING) AS value")
-  .dropDuplicates("id")
+  .selectExpr(
+    "CAST(key AS STRING) AS id",
+    "CAST(value AS STRING) AS value",
+    "timestamp AS eventTime")
+  .withWatermark("eventTime", "10 minutes")
+  .dropDuplicatesWithinWatermark("id")
   .writeStream()
   .format("kafka")
   .option("kafka.bootstrap.servers", "host1:port1,host2:port2")
@@ -605,15 +617,14 @@ spark
 
 </div>
 
-This example uses `dropDuplicates`, which keeps every distinct key it has seen in the state store.
-To bound state, define an event-time watermark and use `dropDuplicatesWithinWatermark`. For example,
-Scala and Java use
-`withWatermark("eventTime", "10 minutes").dropDuplicatesWithinWatermark("id")`; in PySpark, pass the
-column subset as a list:
-`withWatermark("eventTime", "10 minutes").dropDuplicatesWithinWatermark(["id"])`. Records are still
+This bounded example aliases Kafka's record timestamp as `eventTime`, sets a 10-minute watermark
+delay threshold, and uses `dropDuplicatesWithinWatermark` to deduplicate by `id`. It bounds
+deduplication state as the event-time watermark advances. Records that pass deduplication are still
 emitted as they are processed, while watermark advancement and state eviction take effect at
 Real-time Mode batch boundaries. The trigger duration therefore determines how often cleanup has
-an opportunity to remove state after the event-time watermark advances past its expiry.
+an opportunity to remove state after the watermark advances past a key's expiry. To deduplicate
+keys for the lifetime of the query instead, use `dropDuplicates`, which keeps every distinct key it
+has seen in the state store.
 
 ### Streaming aggregation
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationChecker.scala
@@ -663,7 +663,8 @@ object UnsupportedOperationChecker extends Logging {
         // Block stateful operators before union
         u.foreachUp {
           case statefulOp @ (_: Aggregate | _: TransformWithState |
-               _: TransformWithStateInPySpark | _: Deduplicate) if statefulOp.isStateful =>
+               _: TransformWithStateInPySpark | _: Deduplicate |
+               _: DeduplicateWithinWatermark) if statefulOp.isStateful =>
             throwRealTimeError("STATEFUL_OPERATORS_BEFORE_UNION_NOT_SUPPORTED", Map.empty)
           case _ =>
         }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -973,10 +973,32 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
     Update
   )
 
+  assertSupportedForRealTime(
+    "real-time with deduplicate within watermark - update mode",
+    DeduplicateWithinWatermark(Seq(attribute), streamRelation),
+    Update
+  )
+
+  assertSupportedForRealTime(
+    "real-time with deduplicate within watermark after union - update mode",
+    DeduplicateWithinWatermark(
+      Seq(attribute),
+      streamRelation.union(new TestStreamingRelation(attribute.newInstance()))),
+    Update
+  )
+
   assertNotSupportedForRealTime(
     "real-time with Scala transformWithState on both sides of union - update mode",
     scalaTransformWithState(streamRelation)
       .union(scalaTransformWithState(new TestStreamingRelation(attribute.newInstance()))),
+    Update,
+    "STREAMING_REAL_TIME_MODE.STATEFUL_OPERATORS_BEFORE_UNION_NOT_SUPPORTED"
+  )
+
+  assertNotSupportedForRealTime(
+    "real-time with deduplicate within watermark before union - update mode",
+    DeduplicateWithinWatermark(Seq(attribute), streamRelation)
+      .union(new TestStreamingRelation(attribute.newInstance())),
     Update,
     "STREAMING_REAL_TIME_MODE.STATEFUL_OPERATORS_BEFORE_UNION_NOT_SUPPORTED"
   )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/RealTimeModeAllowlist.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/runtime/RealTimeModeAllowlist.scala
@@ -75,7 +75,8 @@ object RealTimeModeAllowlist extends Logging {
     // pipelined-shuffle consumer stage, keyed by the same columns the shuffle repartitions on.
     "org.apache.spark.sql.execution.streaming.operators.stateful.StateStoreRestoreExec",
     "org.apache.spark.sql.execution.streaming.operators.stateful.StateStoreSaveExec",
-    "org.apache.spark.sql.execution.streaming.operators.stateful.StreamingDeduplicateExec",
+    classOf[StreamingDeduplicateExec].getName,
+    classOf[StreamingDeduplicateWithinWatermarkExec].getName,
     classOf[EventTimeWatermarkExec].getName,
     classOf[TransformWithStateExec].getName,
     classOf[UpdateEventTimeColumnExec].getName

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamRealTimeModeSuite.scala
@@ -31,11 +31,12 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerJobStart, SparkLi
 import org.apache.spark.sql.execution.datasources.v2.RealTimeStreamScanExec
 import org.apache.spark.sql.execution.exchange.{ReusedExchangeExec, ShuffleExchangeExec}
 import org.apache.spark.sql.execution.streaming.RealTimeTrigger
+import org.apache.spark.sql.execution.streaming.operators.stateful.StreamingDeduplicateWithinWatermarkExec
 import org.apache.spark.sql.execution.streaming.runtime.{MemoryStream, StreamExecution}
 import org.apache.spark.sql.execution.streaming.sources.{ContinuousMemorySink, LowLatencyMemoryStream}
 import org.apache.spark.sql.execution.streaming.state.{FailureInjectionCheckpointFileManager,
   FailureInjectionFileSystem, RocksDBStateStoreProvider}
-import org.apache.spark.sql.functions.{broadcast, concat, lit, udf}
+import org.apache.spark.sql.functions.{broadcast, concat, lit, timestamp_seconds, udf}
 import org.apache.spark.sql.internal.SQLConf
 
 class StreamRealTimeModeSuite extends StreamRealTimeModeSuiteBase {
@@ -599,6 +600,52 @@ class StreamRealTimeModeWithManualClockSuite extends StreamRealTimeModeManualClo
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }
+  }
+
+  test("pipelined shuffle: dedup within watermark runs in Real-Time Mode") {
+    val inputData = LowLatencyMemoryStream.singlePartition[(String, Int)]
+    val result = inputData.toDF()
+      .withColumn("eventTime", timestamp_seconds($"_2"))
+      .withWatermark("eventTime", "10 seconds")
+      .dropDuplicatesWithinWatermark("_1")
+      .select($"_1")
+
+    testStream(result, OutputMode.Update, Map.empty, new ContinuousMemorySink())(
+      // The second "dup" is suppressed in the live first batch. The high event time advances the
+      // watermark to 20 seconds after that batch completes.
+      AddData(inputData,
+        ("expired", 1), ("dup", 15), ("dup", 16), ("high", 30)),
+      StartStream(),
+      CheckAnswerWithTimeout(60000, "expired", "dup", "high"),
+      Execute { q =>
+        val plan = q.lastExecution.executedPlan
+        assert(plan.exists(_.isInstanceOf[StreamingDeduplicateWithinWatermarkExec]),
+          s"expected StreamingDeduplicateWithinWatermarkExec, got:\n$plan")
+        assertAllExchangesPipelined(q)
+      },
+      advanceRealTimeClock,
+      WaitUntilBatchProcessed(0),
+
+      // "dup" remains in state across the batch boundary. At the end of this batch, "expired" is
+      // evicted because its expiry (11 seconds) is behind the 20-second eviction watermark
+      // inherited from batch 0.
+      AddData(inputData, ("dup", 26), ("middle", 32)),
+      CheckAnswerWithTimeout(60000, "expired", "dup", "high", "middle"),
+      advanceRealTimeClock,
+      WaitUntilBatchProcessed(1),
+
+      // Once its old state has been evicted, a new non-late "expired" record is emitted again.
+      // Late-event filtering deliberately trails eviction by one batch, so the event at 5 seconds
+      // is tested here, when the late-events watermark has advanced to 20 seconds.
+      AddData(inputData, ("expired", 31), ("dup", 27), ("late", 5), ("new", 35)),
+      CheckAnswerWithTimeout(
+        60000, "expired", "dup", "high", "middle", "expired", "new"),
+      advanceRealTimeClock,
+      WaitUntilBatchProcessed(2),
+      CheckAnswerWithTimeout(
+        60000, "expired", "dup", "high", "middle", "expired", "new"),
+      StopStream
+    )
   }
 
   test("pipelined shuffle: multi-key dedup runs in Real-Time Mode over a pipelined shuffle") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

  This PR enables `dropDuplicatesWithinWatermark` in Structured Streaming Real-Time Mode (RTM).

  It:

  - Adds `StreamingDeduplicateWithinWatermarkExec` to the RTM operator allowlist.
  - Applies the existing RTM restriction on stateful operators below a `Union` to `DeduplicateWithinWatermark`.
  - Adds positive and negative analysis tests for the directional union rule.
  - Adds an RTM test covering duplicate suppression, watermark-based eviction, late-data filtering, key re-admission, and pipelined shuffle execution.
  - Updates the RTM documentation and corrects the PySpark `dropDuplicates` subset syntax.

  The existing batch-end eviction behavior is preserved. Incremental mid-batch eviction is unsafe for this operator because the expiry timestamp is stored in the value rather than the
  deduplication key. Evicting a key while processing a batch could allow a later non-late row with the same key to be emitted, making results depend on input and state-store iteration
  order.

  ### Why are the changes needed?

  RTM supports `dropDuplicates`, but currently rejects the bounded-state `dropDuplicatesWithinWatermark` physical operator because it is missing from the allowlist.

  Supporting this operator lets RTM applications use event-time watermarks to bound deduplication state instead of retaining every observed key indefinitely. The existing planning,
  watermark propagation, state-store, and checkpoint mechanisms already support the operator; this PR enables it for RTM and adds the corresponding validation and coverage.

  ### Does this PR introduce _any_ user-facing change?

  Yes.

  Previously, an RTM query using `dropDuplicatesWithinWatermark` failed to start with `STREAMING_REAL_TIME_MODE.OPERATOR_OR_SINK_NOT_IN_ALLOWLIST`.

  After this change, queries such as the following are supported:

  ```python
  query = (
      df.withWatermark("eventTime", "10 minutes")
        .dropDuplicatesWithinWatermark(["id"])
        .writeStream
        .outputMode("update")
        .trigger(realTime="5 minutes")
        .start()
  )
```

  Watermark advancement and state eviction take effect at RTM batch boundaries.

  This changes targets Spark 4.4.0 and does not add a new API, configuration, or state format.

  ### How was this patch tested?

  Added tests covering:

  - Direct RTM support for DeduplicateWithinWatermark.
  - A stateful operator after Union, which is supported.
  - A stateful operator before Union, which remains unsupported.
  - Live duplicate suppression in RTM.
  - State retention across batch boundaries.
  - Watermark-driven eviction and subsequent key re-admission.
  - Late-event filtering.
  - Physical planning as StreamingDeduplicateWithinWatermarkExec.
  - Pipelined shuffle execution.

  The following suites passed:

  - UnsupportedOperationsSuite: 225 tests
  - StreamRealTimeModeWithManualClockSuite: 15 tests
  - StreamingDeduplicationWithinWatermarkSuite: 9 tests

  Catalyst and SQL main/test Scalastyle checks also passed.

  ### Was this patch authored or co-authored using generative AI tooling?

  Co-authored with OpenAI Codex (GPT-5)