### PR TITLE
[SPARK-59387][SQL][TESTS] Cover restricted-mode rejection of banned functions in subqueries

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/RestrictedModeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/RestrictedModeSuite.scala
@@ -18,8 +18,10 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import org.apache.spark.sql.AnalysisException
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal, RestrictedModeInitFixture}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project, ScriptInputOutputSchema, ScriptTransformation}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Exists, Literal,
+  RestrictedModeInitFixture}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project,
+  ScriptInputOutputSchema, ScriptTransformation}
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.sql.types.StringType
 
@@ -135,6 +137,24 @@ class RestrictedModeSuite extends AnalysisTest {
     withRestrictedMode(true) {
       val e = intercept[AnalysisException](getAnalyzer.checkAnalysis(parent))
       checkRestrictedError(e, "The TRANSFORM ... USING clause")
+    }
+  }
+
+  test("restricted mode rejects banned functions nested in subqueries") {
+    Seq("reflect", "java_method", "try_reflect").foreach { fn =>
+      withRestrictedMode(true) {
+        val analyzer = getAnalyzer
+        val e = intercept[AnalysisException] {
+          analyzer.checkAnalysis(analyzer.execute(
+            Filter(Exists(functionProject(fn)), TestRelations.testRelation)))
+        }
+        checkRestrictedError(e, s"The `$fn` function")
+      }
+    }
+    withRestrictedMode(false) {
+      val analyzer = getAnalyzer
+      analyzer.checkAnalysis(analyzer.execute(
+        Filter(Exists(functionProject("reflect")), TestRelations.testRelation)))
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds a test to the catalyst `RestrictedModeSuite` verifying that the restricted SQL execution mode (SPARK-59319) rejects banned functions (`reflect` / `java_method` / `try_reflect`) when they are nested inside an `EXISTS` predicate, asserting `UNSUPPORTED_FEATURE.SQL_RESTRICTED_MODE` with the function-name parameter, plus a mode-off control proving the gate (and not general analysis) is what fires. No production code is changed.

This complements the `sql/core` `RestrictedModeCommandSuite`, which already covers a banned call inside a scalar subquery through real SQL (`SELECT (SELECT reflect(...))`) and the linear-traversal guarantee on deeply nested subqueries. What no suite covers — and this test adds — is the `EXISTS` predicate shape, and `java_method` / `try_reflect` nested in a subquery at all.

### Why are the changes needed?

The restricted mode exists so deployments can block dynamic code and external-script execution in SQL, and its core promise is that banned features "cannot slip through" — with subqueries being the most natural place to hide a banned call from a top-level-only check:

```sql
SELECT * FROM t WHERE EXISTS (SELECT reflect('java.lang.Runtime', 'getRuntime'));
```

The gate reaches subqueries through one traversal branch (`SubqueryExpression => checkPlan(s.plan)`). A regression that broke handling for the `EXISTS` shape specifically — say, the match narrowed to scalar subqueries only — or for `java_method` / `try_reflect` inside any subquery, would fail silently today, since none of that is exercised by the existing scalar-subquery-only coverage. This test pins those shapes so such a regression fails loudly instead. The test is analysis-only and deterministic, adding negligible CI cost.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test `restricted mode rejects banned functions nested in subqueries` in `RestrictedModeSuite` (analysis-only, no session needed):
```
build/sbt 'catalyst/testOnly org.apache.spark.sql.catalyst.analysis.RestrictedModeSuite'
```
Result: Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0 (4 existing, including the upstream init-fixture test, + 1 new).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: MetaCode