### PR TITLE
[SPARK-59390][CORE] Build padding in UTF8String.lpad/rpad with a shared repeat-fill helper

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1196,24 +1196,38 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return this;
     }
 
-    if (numBytes == 1) {
-      byte[] newBytes = new byte[times];
-      byte b = getByte(0);
-      Arrays.fill(newBytes, b);
-      return fromBytes(newBytes);
-    }
-
     byte[] newBytes = new byte[Math.multiplyExact(numBytes, times)];
-    copyMemory(this.base, this.offset, newBytes, BYTE_ARRAY_OFFSET, numBytes);
+    fillRepeated(newBytes, 0, this.base, this.offset, numBytes, times);
+    return UTF8String.fromBytes(newBytes);
+  }
 
+  /**
+   * Writes `count` back-to-back copies of the `patternNumBytes` bytes at
+   * `(patternBase, patternOffset)` into `data` starting at byte index `destPos`, using exponential
+   * doubling so the fill takes O(log count) copies rather than O(count). Returns the byte index
+   * just past the written region.
+   */
+  private static int fillRepeated(
+      byte[] data, int destPos, Object patternBase, long patternOffset, int patternNumBytes,
+      int count) {
+    if (count <= 0 || patternNumBytes == 0) {
+      return destPos;
+    }
+    if (patternNumBytes == 1) {
+      // Single-byte pattern (e.g. padding with a space or '0'): one Arrays.fill beats the loop.
+      int end = destPos + count;
+      Arrays.fill(data, destPos, end, Platform.getByte(patternBase, patternOffset));
+      return end;
+    }
+    copyMemory(patternBase, patternOffset, data, BYTE_ARRAY_OFFSET + destPos, patternNumBytes);
     int copied = 1;
-    while (copied < times) {
-      int toCopy = Math.min(copied, times - copied);
-      System.arraycopy(newBytes, 0, newBytes, copied * numBytes, numBytes * toCopy);
+    while (copied < count) {
+      int toCopy = Math.min(copied, count - copied);
+      System.arraycopy(data, destPos, data, destPos + copied * patternNumBytes,
+        patternNumBytes * toCopy);
       copied += toCopy;
     }
-
-    return UTF8String.fromBytes(newBytes);
+    return destPos + count * patternNumBytes;
   }
 
   /**
@@ -1501,13 +1515,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         Math.toIntExact((long) numBytes + (long) pad.numBytes * count + remain.numBytes);
       byte[] data = new byte[resultSize];
       copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET, this.numBytes);
-      int offset = this.numBytes;
-      int idx = 0;
-      while (idx < count) {
-        copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
-        ++ idx;
-        offset += pad.numBytes;
-      }
+      int offset = fillRepeated(data, this.numBytes, pad.base, pad.offset, pad.numBytes, count);
       copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
 
       return UTF8String.fromBytes(data);
@@ -1540,13 +1548,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
         Math.toIntExact((long) numBytes + (long) pad.numBytes * count + remain.numBytes);
       byte[] data = new byte[resultSize];
 
-      int offset = 0;
-      int idx = 0;
-      while (idx < count) {
-        copyMemory(pad.base, pad.offset, data, BYTE_ARRAY_OFFSET + offset, pad.numBytes);
-        ++ idx;
-        offset += pad.numBytes;
-      }
+      int offset = fillRepeated(data, 0, pad.base, pad.offset, pad.numBytes, count);
       copyMemory(remain.base, remain.offset, data, BYTE_ARRAY_OFFSET + offset, remain.numBytes);
       offset += remain.numBytes;
       copyMemory(this.base, this.offset, data, BYTE_ARRAY_OFFSET + offset, numBytes());

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -426,6 +426,7 @@ public class UTF8StringSuite {
     assertEquals(fromString("数d数d数d数d数d"), fromString("数d").repeat(5));
     assertEquals(fromString("数d"), fromString("数d").repeat(1));
     assertEquals(EMPTY_UTF8, fromString("数d").repeat(-1));
+    assertEquals(fromString("aaaaa"), fromString("a").repeat(5)); // single-byte Arrays.fill path
   }
 
   @Test
@@ -482,6 +483,21 @@ public class UTF8StringSuite {
       assertEquals(EMPTY_UTF8, fromString("hello").lpad(len, EMPTY_UTF8));
       assertEquals(EMPTY_UTF8, fromString("hello").rpad(len, EMPTY_UTF8));
     }
+  }
+
+  @Test
+  public void padExponentialDoubling() {
+    // Exercise the doubling fill with counts that trigger multiple doubling steps and the
+    // toCopy clamp (counts 3, 4 and 5), plus a multi-byte pad.
+    assertEquals(fromString("abababax"), fromString("x").lpad(8, fromString("ab")));
+    assertEquals(fromString("xabababa"), fromString("x").rpad(8, fromString("ab")));
+    assertEquals(fromString("abababababx"), fromString("x").lpad(11, fromString("ab")));
+    assertEquals(fromString("Zababababab"), fromString("Z").rpad(11, fromString("ab")));
+    assertEquals(fromString("数数数数x"), fromString("x").lpad(5, fromString("数")));
+    assertEquals(fromString("x数数数数"), fromString("x").rpad(5, fromString("数")));
+    // Single-byte pad takes the Arrays.fill fast path.
+    assertEquals(fromString("-----x"), fromString("x").lpad(6, fromString("-")));
+    assertEquals(fromString("x-----"), fromString("x").rpad(6, fromString("-")));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

`lpad` and `rpad` build the padding by copying the pad string `count` times in a loop — one `copyMemory` per repetition, i.e. O(count) copy calls. `repeat()` already solves the same "repeat these bytes N times" problem more efficiently, with a single-byte `Arrays.fill` fast path and exponential doubling. This factors that logic into a shared private helper (`fillRepeated`) used by `repeat()`, `lpad`, and `rpad`:

- Single-byte pattern — the common padding case (space, `0`, `?`) — fills the region with a single `Arrays.fill`.
- Multi-byte pattern — seed one copy, then exponential doubling: O(log count) copies instead of O(count).
- The total number of bytes copied is unchanged; only the number of copy calls drops. `repeat()` now delegates to the shared helper, and its previous inline doubling and single-byte branch are removed, leaving a single implementation.

### Why are the changes needed?

Padding a short value to a large width with a short pad currently issues O(count) copy calls, and the common single-character pad hits that loop rather than a single `Arrays.fill`. Reusing `repeat()`'s strategy makes the single-char case one fill and bounds the multi-byte case to O(log count) copies, at no cost to normal small-width padding — and removes the duplicated repeat logic. This is a modest, targeted change.

### Does this PR introduce _any_ user-facing change?

No. Behavior is identical; only the way the padding bytes are written into the result buffer changes.

### How was this patch tested?

Existing `UTF8StringSuite` passes (52/52), including `pad()` and `repeat()`. Adds `padExponentialDoubling`, which exercises counts that trigger multiple doubling steps and the `toCopy` clamp, plus multi-byte and single-byte pads, and adds a single-byte `repeat` case.

### Was this patch authored or co-authored using generative AI tooling?

Yes. Generated-by: Claude Code
