### PR TITLE
[SPARK-59394][SQL] UnBase64: decode the input bytes directly instead of converting to a String per row

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -3353,7 +3353,7 @@ case class UnBase64(child: Expression, failOnError: Boolean = false)
         UTF8String.fromString("BASE64"),
         "try_to_binary")
     }
-    JBase64.getMimeDecoder.decode(string.asInstanceOf[UTF8String].toString)
+    JBase64.getMimeDecoder.decode(string.asInstanceOf[UTF8String].getBytes)
   }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
@@ -3375,7 +3375,7 @@ case class UnBase64(child: Expression, failOnError: Boolean = false)
       }
       s"""
          $maybeValidateInputCode
-         ${ev.value} = ${classOf[JBase64].getName}.getMimeDecoder().decode($child.toString());
+         ${ev.value} = ${classOf[JBase64].getName}.getMimeDecoder().decode($child.getBytes());
        """})
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -530,7 +530,9 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
     checkEvaluation(Base64(UnBase64(Literal("AQIDBA=="))), "AQIDBA==", create_row("abdef"))
     // A non-base64 multi-byte char is ignored by the MIME decoder, so decoding the raw bytes
     // (getBytes) matches decoding the toString() form.
+    // scalastyle:off nonascii
     checkEvaluation(Base64(UnBase64(Literal("AQ数IDBA=="))), "AQIDBA==", create_row("abdef"))
+    // scalastyle:on nonascii
     checkEvaluation(Base64(UnBase64(Literal(""))), "", create_row("abdef"))
     checkEvaluation(Base64(UnBase64(Literal.create(null, StringType))), null, create_row("abdef"))
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/StringExpressionsSuite.scala
@@ -528,6 +528,9 @@ class StringExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper {
 
     checkEvaluation(Base64(Literal(bytes)), "AQIDBA==", create_row("abdef"))
     checkEvaluation(Base64(UnBase64(Literal("AQIDBA=="))), "AQIDBA==", create_row("abdef"))
+    // A non-base64 multi-byte char is ignored by the MIME decoder, so decoding the raw bytes
+    // (getBytes) matches decoding the toString() form.
+    checkEvaluation(Base64(UnBase64(Literal("AQ数IDBA=="))), "AQIDBA==", create_row("abdef"))
     checkEvaluation(Base64(UnBase64(Literal(""))), "", create_row("abdef"))
     checkEvaluation(Base64(UnBase64(Literal.create(null, StringType))), null, create_row("abdef"))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UnBase64` (SQL `unbase64`, and `try_to_binary(..., 'base64')`) decodes a base64 string to
bytes. Both its interpreted path and its generated code called `.toString()` on the input
`UTF8String` before decoding, which decodes the whole input from UTF-8 into a Java `String` on
every row purely to hand it to the decoder.

`java.util.Base64.Decoder` accepts a `byte[]` directly, so this PR passes the raw UTF-8 bytes
(`UTF8String.getBytes()`) in both paths and drops the `.toString()`:

- interpreted (`nullSafeEval`): `...getMimeDecoder.decode(string.asInstanceOf[UTF8String].getBytes)`
- codegen (`doGenCode`): `...getMimeDecoder().decode($child.getBytes())`

`UnBase64.isValidBase64` (used only by the `try_to_binary` validation path) still iterates the
string form and is left unchanged; converting it to iterate bytes is a separate, larger change and
out of scope here.

### Why are the changes needed?

It removes a per-row `String` allocation and UTF-8 decode on a hot path. The bytes are already
available on the `UTF8String`, and the decoder consumes bytes, so materializing an intermediate
Java `String` just to feed the decoder is unnecessary.

The change is behavior-preserving. `getMimeDecoder().decode(String)` internally converts the
string to bytes with ISO-8859-1 before decoding. For valid base64 -- which is always ASCII --
those bytes are identical to the raw UTF-8 bytes. For any non-ASCII or otherwise non-base64
content, the MIME decoder ignores every byte outside the base64 alphabet (`A-Za-z0-9+/=`) under
both paths, so the decoded output is the same. The result is therefore identical for all inputs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `StringExpressionsSuite` base64/unbase64 tests pass (round-trip, empty, null,
`failOnError`, and chunked/non-chunked encodings). Added an assertion whose base64 input embeds a
multi-byte character, confirming the MIME decoder still ignores it and the result is unchanged.
That same assertion was also run against the original `toString()`-based code and passes,
confirming the behavior is unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

This pull request and its description were written by Isaac.
