### PR TITLE
[SPARK-48701][SQL][PS][FOLLOWUP] Make pandas_mode/mode null-safe for collated strings nested in complex types

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -28,8 +28,9 @@ import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.catalyst.util.{ArrayData, CollationFactory, GenericArrayData, MapData, UnsafeRowUtils}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLType
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, ArrayType, BooleanType, DataType, DoubleType, FloatType, MapType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, ArrayType, BooleanType, DataType, DoubleType, FloatType, MapType, StringType, StructType}
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.collection.OpenHashMap
 
 private[aggregate] object ModeKeyNormalizer {
@@ -70,21 +71,22 @@ private[aggregate] trait ModeCollationAware { self: Expression =>
         childDataType: DataType): Option[AnyRef => _] = {
       childDataType match {
         case _ if UnsafeRowUtils.isBinaryStable(child.dataType) => None
-        // A null key is kept as its own group: PandasMode may store one when `ignoreNA`
-        // is false, and passing null to collationAwareTransform would throw. Mode never
-        // stores a null key, so its behavior is unchanged.
-        case _ => Some((key: AnyRef) =>
-          if (key == null) null else collationAwareTransform(key, childDataType))
+        case _ => Some(collationAwareTransform(_, childDataType))
       }
     }
     determineBufferingFunction(childDataType).map(groupAndReduceBuffer).getOrElse(buffer)
   }
 
   protected[sql] def collationAwareTransform(data: AnyRef, dataType: DataType): AnyRef = {
+    // A null carries no collation, so it forms its own group. Guarding here (rather than only
+    // at the top-level key) also covers nulls nested in complex types: a null struct field,
+    // array element, or map value must not reach the string/collation-key path below, which
+    // throws on null. PandasMode stores a top-level null key when `ignoreNA` is false; Mode
+    // never stores one, so its behavior is unchanged.
+    if (data == null) return null
     dataType match {
       case _ if UnsafeRowUtils.isBinaryStable(dataType) => data
-      case st: StructType =>
-        processStructTypeWithBuffer(data.asInstanceOf[InternalRow].toSeq(st).zip(st.fields))
+      case st: StructType => processStructTypeWithBuffer(data.asInstanceOf[InternalRow], st)
       case at: ArrayType => processArrayTypeWithBuffer(at, data.asInstanceOf[ArrayData])
       case mt: MapType => processMapTypeWithBuffer(mt, data.asInstanceOf[MapData])
       case st: StringType =>
@@ -100,26 +102,32 @@ private[aggregate] trait ModeCollationAware { self: Expression =>
     }
   }
 
-  private def processStructTypeWithBuffer(
-      tuples: Seq[(Any, StructField)]): Seq[Any] = {
-    tuples.map(t => collationAwareTransform(t._1.asInstanceOf[AnyRef], t._2.dataType))
+  // The results below are used only as grouping keys, so they just need consistent
+  // element-wise equals/hashCode; a Scala immutable Seq/Map provides that. Each builds its
+  // result in a single pass (one array/map allocation) rather than chaining map/zip/toMap
+  // over per-element intermediate collections.
+
+  private def processStructTypeWithBuffer(row: InternalRow, st: StructType): Seq[Any] = {
+    val fields = st.fields
+    Array.tabulate(fields.length) { i =>
+      val fieldType = fields(i).dataType
+      collationAwareTransform(row.get(i, fieldType).asInstanceOf[AnyRef], fieldType)
+    }.toImmutableArraySeq
   }
 
-  private def processArrayTypeWithBuffer(
-      a: ArrayType,
-      data: ArrayData): Seq[Any] = {
-    (0 until data.numElements()).map(i =>
-      collationAwareTransform(data.get(i, a.elementType), a.elementType))
+  private def processArrayTypeWithBuffer(a: ArrayType, data: ArrayData): Seq[Any] = {
+    Array.tabulate(data.numElements()) { i =>
+      collationAwareTransform(data.get(i, a.elementType), a.elementType)
+    }.toImmutableArraySeq
   }
 
   private def processMapTypeWithBuffer(mt: MapType, data: MapData): Map[Any, Any] = {
-    val transformedKeys = (0 until data.numElements()).map { i =>
-      collationAwareTransform(data.keyArray().get(i, mt.keyType), mt.keyType)
-    }
-    val transformedValues = (0 until data.numElements()).map { i =>
-      collationAwareTransform(data.valueArray().get(i, mt.valueType), mt.valueType)
-    }
-    transformedKeys.zip(transformedValues).toMap
+    val keys = data.keyArray()
+    val values = data.valueArray()
+    (0 until data.numElements()).iterator.map { i =>
+      collationAwareTransform(keys.get(i, mt.keyType), mt.keyType) ->
+        collationAwareTransform(values.get(i, mt.valueType), mt.valueType)
+    }.toMap
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -616,6 +616,51 @@ class CollationAggregationSuite
     }
   }
 
+  // A null nested inside a collated complex type (struct field, array element, map value)
+  // must fold as its own group instead of reaching the collation-key path, which throws on
+  // null. These guard that null-safety while also confirming the collation fold still applies
+  // to the non-null siblings ('b'/'B' collapse to one group under UTF8_LCASE).
+
+  test("SPARK-48701: pandas_mode is null-safe for a null collated string nested in struct") {
+    withTable("t") {
+      sql("CREATE TABLE t (c STRUCT<f: STRING COLLATE UTF8_LCASE>) USING parquet")
+      sql(
+        """INSERT INTO t VALUES (named_struct('f', 'b')), (named_struct('f', 'B')),
+          |  (named_struct('f', CAST(null AS STRING)))""".stripMargin)
+      val modes = pandasMode(spark.table("t").repartition(4), "c", ignoreNA = true)
+        .map(_.asInstanceOf[Row])
+      // {b, B} fold to one group of 2, outvoting the null-field struct (1).
+      assert(modes.length == 1)
+      assert(modes.head.getString(0).toLowerCase(Locale.ROOT) == "b")
+    }
+  }
+
+  test("SPARK-48701: pandas_mode is null-safe for a null collated string nested in array") {
+    withTable("t") {
+      sql("CREATE TABLE t (c ARRAY<STRING COLLATE UTF8_LCASE>) USING parquet")
+      sql(
+        """INSERT INTO t VALUES (array('b')), (array('B')),
+          |  (array(CAST(null AS STRING)))""".stripMargin)
+      val modes = pandasMode(spark.table("t").repartition(4), "c", ignoreNA = true)
+        .map(_.asInstanceOf[collection.Seq[String]])
+      // [b] and [B] fold to one group of 2, outvoting [null] (1).
+      assert(modes.length == 1)
+      assert(modes.head.head.toLowerCase(Locale.ROOT) == "b")
+    }
+  }
+
+  test("SPARK-48701: pandas_mode is null-safe for a null collated string nested in map value") {
+    withTable("t") {
+      sql("CREATE TABLE t (c MAP<STRING, STRING COLLATE UTF8_LCASE>) USING parquet")
+      sql(
+        """INSERT INTO t VALUES (map('k', 'b')), (map('k', 'B')),
+          |  (map('k', CAST(null AS STRING)))""".stripMargin)
+      val modes = pandasMode(spark.table("t").repartition(4), "c", ignoreNA = true)
+      // {k->b, k->B} fold to one group of 2, outvoting {k->null} (1).
+      assert(modes.length == 1)
+    }
+  }
+
   // `mode` (the public aggregate) is already collation-aware; these tests guard that
   // behavior, which currently has no coverage (the original tests were removed with
   // CollationSQLExpressionsSuite by SPARK-51067). Unlike pandas_mode, `mode` returns a


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Follow-up to SPARK-48701 (#58233). The mode / pandas_mode collation fold rewrites each key through ModeCollationAware.collationAwareTransform, which recurses into struct/array/map values. The original null guard only covered a fully-null top-level key, so a null nested inside a non-binary-collated struct field, array element, or map value reached CollationFactory.getCollationKey(null, ...) and threw an NPE.

This moves the null check to the top of collationAwareTransform so it applies at any nesting depth. It also simplifies the three recursive helpers to build their result in a single pass.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
mode and pandas_mode (pandas-on-Spark Series.mode() / DataFrame.mode()) throw an NPE on a non-binary-collated complex type containing a nested null:

```
CREATE TABLE t (c STRUCT<f: STRING COLLATE UTF8_LCASE>) USING parquet;
INSERT INTO t VALUES (named_struct('f', 'b')), (named_struct('f', 'B')),
  (named_struct('f', CAST(null AS STRING)));
-- Series.mode() over c -> NullPointerException
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. It fixes an NPE

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added three tests to CollationAggregationSuite (nested null in struct, array, and map value)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Yes. Generated-by: Claude Code.