### PR TITLE
[SPARK-58968][SQL][4.0] Enforce subset clustering before non-join operators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/exchange/EnsureRequirements.scala
@@ -62,9 +62,18 @@ case class EnsureRequirements(
       shuffleOrigin: ShuffleOrigin): Seq[SparkPlan] = {
     assert(requiredChildDistributions.length == originalChildren.length)
     assert(requiredChildOrderings.length == originalChildren.length)
+    // Get the indexes of children which have specified distribution requirements and need to be
+    // co-partitioned.
+    val childrenIndexes = requiredChildDistributions.zipWithIndex.filter {
+      case (_: ClusteredDistribution, _) => true
+      case _ => false
+    }.map(_._2)
+    val isCoPartitioned = childrenIndexes.length > 1
+
     // Ensure that the operator's children satisfy their output distribution requirements.
     var children = originalChildren.zip(requiredChildDistributions).map {
-      case (child, distribution) if child.outputPartitioning.satisfies(distribution) =>
+      case (child, distribution) if satisfiesDistribution(
+          child.outputPartitioning, distribution, isCoPartitioned) =>
         ensureOrdering(child, distribution)
       case (child, BroadcastDistribution(mode)) =>
         BroadcastExchangeExec(mode, child)
@@ -82,13 +91,6 @@ case class EnsureRequirements(
               distribution.createPartitioning(numPartitions), child, shuffleOrigin)
         }
     }
-
-    // Get the indexes of children which have specified distribution requirements and need to be
-    // co-partitioned.
-    val childrenIndexes = requiredChildDistributions.zipWithIndex.filter {
-      case (_: ClusteredDistribution, _) => true
-      case _ => false
-    }.map(_._2)
 
     // Special case: if all sides of the join are single partition and it's physical size less than
     // or equal spark.sql.maxSinglePartitionBytes.
@@ -231,6 +233,31 @@ case class EnsureRequirements(
     }
 
     children
+  }
+
+  private def satisfiesDistribution(
+      partitioning: Partitioning,
+      distribution: Distribution,
+      isCoPartitioned: Boolean): Boolean = {
+    if (isCoPartitioned || !conf.v2BucketingAllowJoinKeysSubsetOfPartitionKeys) {
+      partitioning.satisfies(distribution)
+    } else {
+      (partitioning, distribution) match {
+        case (PartitioningCollection(partitionings), c: ClusteredDistribution) =>
+          partitionings.exists(satisfiesDistribution(_, c, isCoPartitioned = false))
+        case (k: KeyGroupedPartitioning, c: ClusteredDistribution) =>
+          // With subset keys enabled, satisfies() can be true even though rows sharing an
+          // operation key occupy different partitions. The multi-child path can regroup join
+          // scans, but a single-child operator needs its clustering before it runs. Without
+          // GroupPartitionsExec on this branch, use a shuffle when a partition expression is not
+          // covered by the operation's keys. Do not regroup a scan through an intervening operator.
+          k.satisfies(c) && k.expressions.forall { e =>
+            c.clustering.exists(_.semanticEquals(e)) ||
+              e.collectLeaves().forall(leaf => c.clustering.exists(_.semanticEquals(leaf)))
+          }
+        case _ => partitioning.satisfies(distribution)
+      }
+    }
   }
 
   private def reorder(

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec
+import org.apache.spark.sql.execution.window.WindowExec
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf._
 import org.apache.spark.sql.types._
@@ -1127,6 +1128,57 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         if (pushDownValues) {
           val scans = collectScans(df.queryExecution.executedPlan)
           assert(scans.forall(_.inputRDD.partitions.length === 3))
+        }
+      }
+    }
+  }
+
+  for (joined <- Seq(false, true)) {
+    test(s"SPARK-58968: establish subset clustering below a window, joined=$joined") {
+      val windowColumns = Array("k", "discard", "v").map(name => Column.create(name, IntegerType))
+      createTable("window_subset", windowColumns, Array(identity("k"), identity("discard")))
+      sql("INSERT INTO testcat.ns.window_subset VALUES (1, 10, 10), (1, 20, 20), (2, 30, 30)")
+      createTable("window_right", Array(Column.create("k", IntegerType)), Array.empty)
+      sql("INSERT INTO testcat.ns.window_right VALUES (1), (2)")
+
+      for {
+        requireAll <- Seq(false, true)
+        fullKey <- Seq(false, true)
+      } {
+        withSQLConf(
+            SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+            SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_DISTRIBUTION.key -> requireAll.toString,
+            SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
+            SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+            SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+            SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "false") {
+          val windowKeys = if (fullKey) "k, discard" else "k"
+          val join = if (joined) "JOIN testcat.ns.window_right r ON w.k = r.k" else ""
+          val hint = if (joined) "/*+ MERGE(w, r) */" else ""
+          val df = sql(
+            s"""SELECT $hint w.k, w.discard, w.rn
+               |FROM (
+               |  SELECT k, discard, ROW_NUMBER() OVER (
+               |    PARTITION BY $windowKeys ORDER BY v) AS rn
+               |  FROM testcat.ns.window_subset
+               |) w $join
+               |""".stripMargin)
+
+          withClue(s"requireAll=$requireAll, fullKey=$fullKey: ") {
+            checkAnswer(df, Seq(Row(1, 10, 1), Row(1, 20, if (fullKey) 1 else 2), Row(2, 30, 1)))
+            val plan = df.queryExecution.executedPlan
+            val Seq(window) = collect(plan) { case w: WindowExec => w }
+            val shuffles = collectAllShuffles(window.child)
+            if (fullKey) {
+              assert(shuffles.isEmpty, "full-key window should retain the scan's clustering")
+            } else {
+              assert(shuffles.size == 1, "the shuffle must be below the window")
+              val partitioning = shuffles.head.outputPartitioning
+                .asInstanceOf[physical.HashPartitioning]
+              assert(partitioning.expressions == window.partitionSpec)
+            }
+            assert(collect(plan) { case j: SortMergeJoinExec => j }.size == (if (joined) 1 else 0))
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/exchange/EnsureRequirementsSuite.scala
@@ -1137,6 +1137,47 @@ class EnsureRequirementsSuite extends SharedSparkSession {
     }
   }
 
+  test("SPARK-58968: single-child clustering respects expressions, collections and counts") {
+    val key = AttributeReference("key", IntegerType)()
+    val extra = AttributeReference("extra", IntegerType)()
+    val transformedKey = bucket(4, key)
+    val subset = KeyGroupedPartitioning(Seq(key, extra), 3)
+    val full = KeyGroupedPartitioning(Seq(key), 3)
+    val required = ClusteredDistribution(Seq(key), requireAllClusterKeys = false,
+      requiredNumPartitions = Some(3))
+
+    val cases = Seq(
+      (subset, required, true),
+      (full, required, false),
+      (KeyGroupedPartitioning(Seq(transformedKey), 3), required, false),
+      (KeyGroupedPartitioning(Seq(transformedKey, extra), 3), required, true),
+      (KeyGroupedPartitioning(Seq(transformedKey), 3),
+        required.copy(clustering = Seq(transformedKey), requireAllClusterKeys = true), false),
+      (PartitioningCollection(Seq(subset, HashPartitioning(Seq(key), 3))), required, false),
+      (PartitioningCollection(Seq(subset, full)), required, false),
+      (PartitioningCollection(Seq(subset, subset)), required, true),
+      (full, required.copy(requiredNumPartitions = Some(4)), true))
+
+    withSQLConf(SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true") {
+      cases.foreach { case (partitioning, distribution, needsShuffle) =>
+        val child = DummySparkPlan(outputPartitioning = partitioning)
+        val parent = DummySparkPlan(children = Seq(child),
+          requiredChildDistribution = Seq(distribution), requiredChildOrdering = Seq(Nil))
+        val result = EnsureRequirements.apply(parent).children.head
+        withClue(s"$partitioning, $distribution: ") {
+          if (needsShuffle) {
+            val shuffle = result.asInstanceOf[ShuffleExchangeExec]
+            assert(shuffle.child == child)
+            assert(shuffle.outputPartitioning ==
+              HashPartitioning(distribution.clustering, distribution.requiredNumPartitions.get))
+          } else {
+            assert(result == child)
+          }
+        }
+      }
+    }
+  }
+
   test("SPARK-42168: FlatMapCoGroupInPandas and Window function with differing key order") {
     val lKey = AttributeReference("key", IntegerType)()
     val lKey2 = AttributeReference("key2", IntegerType)()


### PR DESCRIPTION
JIRA: [SPARK-58968](https://issues.apache.org/jira/browse/SPARK-58968). This is the branch-4.0 adaptation of the existing upstream issue.

Draft: standalone and full-build validation remain pending.

### What changes were proposed in this pull request?

Adapt SPARK-58968 to branch-4.0. The master fix ([#58262](https://github.com/apache/spark/pull/58262)) and its 4.2 backport ([#58469](https://github.com/apache/spark/pull/58469)) use `GroupPartitionsExec`, which branch-4.0 does not have. This adaptation inserts a hash shuffle before a single clustered consumer when its storage partitioning needs a key projection. The multi-child join path is unchanged.

Full-key and derived-expression clustering remain usable. A `PartitioningCollection` is sufficient when any member meets the actual clustering, and required partition counts still apply.

### Why are the changes needed?

With subset keys enabled, a scan partitioned by `(k, discard)` can report that it satisfies a window's `PARTITION BY k`, although equal `k` values are on separate partitions. On rows `(1,10,10)` and `(1,20,20)`, `ROW_NUMBER() OVER (PARTITION BY k ORDER BY v)` can therefore return `1,1` instead of `1,2`. The grouping must be established before the window executes.

### Does this PR introduce _any_ user-facing change?

Yes. Single-child operators requiring clustered input produce correct results when their keys are a strict subset of the storage partition keys.

This is a conservative adaptation, not a literal cherry-pick. Unlike the newer grouping implementation, it can add a hash shuffle even when projecting the reported key values would leave every key distinct. It avoids rewriting a scan beneath an operator that depends on its existing distribution or ordering.

### How was this patch tested?

Added window regressions for standalone and joined queries, both values of `requireAllClusterKeysForDistribution`, and full-key controls. The tests check row numbers and require the subset shuffle to be below `WindowExec`. Added planner coverage for transformed keys, mixed partitioning collections, and required partition counts.

`git diff --check` passed.

Baseline controls returned duplicate row numbers in the standalone case and lacked the required shuffle below the joined window. Both candidate cases passed, including their full-key controls.

Fresh selected-source local validation of a combined branch-4.0 tree containing the separate window, key-routing, scan-ordering and NULL-fixture proposals passed all 11 focused tests. The broader run completed all 244 exact test identities: 237 passed and seven function-based ordering cases in WriteDistributionAndOrderingSuite failed. All seven also failed on the Apache production baseline with matching exception types, messages and first eight stack frames; they remain a limitation of this local setup, not a passing full-suite result. No tests were skipped and no suite aborted; fresh-class origin checks passed.

The separate baseline control reproduced six targeted production regressions, while five expected controls passed. Removing only the two NULL-fixture guards separately reproduced the insertion exception and stale-value result. Candidate tests cover their complete loops; baseline failures stop at the first failing iteration and do not establish later iterations. All nine changed files in the combined 4.0 tree passed Scalastyle with zero errors or warnings.

JDK 17 / Scala 2.13.16 freshly compiled 40 selected Scala production sources, five Java sources and nine test/fixture sources; remaining dependencies were cached and fingerprinted. This is not a complete build, standalone validation of this PR, a whole-source-equivalent Apache runtime, or CI success. Earlier failed setup and audit attempts are retained separately and are not counted as passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (version not exposed in this session).
