### PR TITLE
[SPARK-55411][SQL][4.0] Drop scan ordering when SPJ regroups input partitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/BatchScanExec.scala
@@ -153,6 +153,17 @@ case class BatchScanExec(
     }
   }
 
+  override def outputOrdering: Seq[SortOrder] = {
+    // The base class checks grouping by the original partition keys. A later projection or
+    // reduction can concatenate separately ordered splits, so that ordering no longer applies.
+    // Check only planning parameters here: inspecting filteredPartitions executes runtime filters.
+    val projectsSubset = spjParams.joinKeyPositions.exists { positions =>
+      spjParams.keyGroupedPartitioning.exists(_.length > positions.length)
+    }
+    val reducesKeys = spjParams.reducers.exists(_.exists(_.isDefined))
+    if (projectsSubset || reducesKeys) Seq.empty else super.outputOrdering
+  }
+
   override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
 
   override lazy val inputRDD: RDD[InternalRow] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
 import org.apache.spark.sql.connector.expressions._
 import org.apache.spark.sql.connector.expressions.Expressions._
-import org.apache.spark.sql.execution.{RDDScanExec, SparkPlan}
+import org.apache.spark.sql.execution.{RDDScanExec, SortExec, SparkPlan}
 import org.apache.spark.sql.execution.datasources.v2.BatchScanExec
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
@@ -238,9 +238,10 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
       table: String,
       columns: Array[Column],
       partitions: Array[Transform],
-      catalog: InMemoryTableCatalog = catalog): Unit = {
+      catalog: InMemoryTableCatalog = catalog,
+      ordering: Array[SortOrder] = Array.empty): Unit = {
     catalog.createTable(Identifier.of(Array("ns"), table),
-      columns, partitions, emptyProps, Distributions.unspecified(), Array.empty, None, None,
+      columns, partitions, emptyProps, Distributions.unspecified(), ordering, None, None,
       numRowsPerSplit = 1)
   }
 
@@ -3106,6 +3107,83 @@ class KeyGroupedPartitioningSuite extends DistributionAndOrderingSuiteBase {
         Row("bbb", 20, 250.0),
         Row("bbb", 20, 350.0),
         Row("ccc", 30, 400.50)))
+    }
+  }
+
+  for (fullKey <- Seq(false, true)) {
+    test(s"SPARK-55411: scan ordering after SPJ key projection, fullKey=$fullKey") {
+      val orderedColumns = Array("discard", "k", "id")
+        .map(name => Column.create(name, IntegerType))
+      val partitionKeys = if (fullKey) Array("k", "id") else Array("discard", "k")
+      val ordering = Array("k", "id").map(name => Expressions.sort(
+        Expressions.column(name), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST))
+      createTable("ordered", orderedColumns, partitionKeys.map(identity), ordering = ordering)
+      // Each split has one row and truthfully reports (k, id) ordering. Grouping on k concatenates
+      // the discard=0 and discard=1 partitions into ids 5, 1, which requires sorting before SMJ.
+      sql("INSERT INTO testcat.ns.ordered VALUES (0, 1, 5), (1, 1, 1)")
+      createTable("unordered", orderedColumns.drop(1), Array.empty)
+      sql("INSERT INTO testcat.ns.unordered VALUES (1, 1), (1, 5)")
+
+      withSQLConf(
+          SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+          SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
+          SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "true",
+          SQLConf.V2_BUCKETING_SHUFFLE_ENABLED.key -> "true",
+          SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "false") {
+        val df = sql(
+          """SELECT /*+ MERGE(l, r) */ l.discard, l.k, l.id, r.id
+            |FROM testcat.ns.ordered l JOIN testcat.ns.unordered r
+            |ON l.k = r.k AND l.id = r.id
+            |""".stripMargin)
+        checkAnswer(df, Seq(Row(0, 1, 5, 5), Row(1, 1, 1, 1)))
+        val Seq(join) = collect(df.queryExecution.executedPlan) { case j: SortMergeJoinExec => j }
+        val Seq(scan) = collectScans(join.left)
+        assert(scan.partitions.size == 2 && scan.partitions.forall(_.size == 1))
+        assert(scan.ordering.exists(_.nonEmpty))
+        assert(scan.spjParams.joinKeyPositions ==
+          Some(if (fullKey) Seq(0, 1) else Seq(1)))
+        assert(scan.inputRDD.partitions.length == (if (fullKey) 2 else 1))
+        assert(scan.outputOrdering.isEmpty == !fullKey)
+        assert(collect(join.left) { case s: SortExec => s }.size == (if (fullKey) 0 else 1))
+        assert(collectAllShuffles(join.left).isEmpty)
+        assert(collectAllShuffles(join.right).size == 1)
+      }
+    }
+  }
+
+  test("SPARK-55411: scan ordering after SPJ partition-key reduction") {
+    val bucketColumns = Array(Column.create("k", LongType))
+    val ordering = Array(Expressions.sort(
+      Expressions.column("k"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST))
+    createTable("ordered_buckets", bucketColumns, Array(bucket(8, "k")), ordering = ordering)
+    createTable("coarse_buckets", bucketColumns, Array(bucket(4, "k")), ordering = ordering)
+    // The test bucket function maps 9 to bucket 1 and 5 to bucket 5. Each fine bucket has one
+    // ordered split, but reducing both to bucket 1 concatenates rows into the order 9, 5.
+    sql("INSERT INTO testcat.ns.ordered_buckets VALUES (9), (5)")
+    sql("INSERT INTO testcat.ns.coarse_buckets VALUES (9), (5)")
+
+    withSQLConf(
+        SQLConf.ADAPTIVE_EXECUTION_ENABLED.key -> "false",
+        SQLConf.REQUIRE_ALL_CLUSTER_KEYS_FOR_CO_PARTITION.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_JOIN_KEYS_SUBSET_OF_PARTITION_KEYS.key -> "false",
+        SQLConf.V2_BUCKETING_ALLOW_COMPATIBLE_TRANSFORMS.key -> "true",
+        SQLConf.V2_BUCKETING_PUSH_PART_VALUES_ENABLED.key -> "true",
+        SQLConf.V2_BUCKETING_PARTIALLY_CLUSTERED_DISTRIBUTION_ENABLED.key -> "false") {
+      val df = sql(
+        """SELECT /*+ MERGE(l, r) */ l.k, r.k
+          |FROM testcat.ns.ordered_buckets l JOIN testcat.ns.coarse_buckets r ON l.k = r.k
+          |""".stripMargin)
+      checkAnswer(df, Seq(Row(5L, 5L), Row(9L, 9L)))
+      val Seq(join) = collect(df.queryExecution.executedPlan) { case j: SortMergeJoinExec => j }
+      val Seq(scan) = collectScans(join.left)
+      assert(scan.partitions.size == 2 && scan.partitions.forall(_.size == 1))
+      assert(scan.ordering.exists(_.nonEmpty))
+      assert(scan.spjParams.joinKeyPositions.isEmpty)
+      assert(scan.spjParams.reducers.exists(_.exists(_.isDefined)))
+      assert(scan.inputRDD.partitions.length == 1)
+      assert(scan.outputOrdering.isEmpty)
+      assert(collect(join.left) { case s: SortExec => s }.size == 1)
+      assert(collectAllShuffles(join).isEmpty)
     }
   }
 


### PR DESCRIPTION
Related JIRA: [SPARK-55411](https://issues.apache.org/jira/browse/SPARK-55411), which introduced the affected behavior. A separate follow-up JIRA for this specific bug is pending creation; this draft currently uses the originating issue key.

Draft: standalone and full-build validation remain pending.

### What changes were proposed in this pull request?

Stop reporting the original scan ordering when storage-partitioned join planning drops partition-key positions or applies partition-key reducers. These operations can concatenate separately ordered input splits. `EnsureRequirements` can then insert the sort required by a downstream sort-merge join. Full-key identity projections retain the existing ordering check.

This is a focused branch-4.0 follow-up. The newer grouping implementation introduced by [#54330](https://github.com/apache/spark/pull/54330) already checks ordering against the final groups; its optional sorted-merge optimization in [#55116](https://github.com/apache/spark/pull/55116) is not backported here.

### Why are the changes needed?

`DataSourceV2ScanExecBase.outputOrdering` checks only the original groups. `BatchScanExec.inputRDD` can subsequently project or reduce the keys and concatenate several of those groups into one partition.

For example, two singleton splits ordered by `(k, id)` contain `(1, 5)` and `(1, 1)` under different discarded partition keys. Grouping them by `k` produces ids `5,1`, but the scan still advertises ascending `(k,id)` ordering. A sort-merge join can skip a matching row because its input is not sorted.

### Does this PR introduce _any_ user-facing change?

Yes. Joins over scans whose input partitions are regrouped produce correct results by sorting when necessary. The check is conservative: a key-dropping projection or reducer can discard ordering even when its particular partition values do not merge. Full-key identity projections preserve ordering.

### How was this patch tested?

Added native `KeyGroupedPartitioningSuite` regressions using the existing in-memory catalog's `SupportsReportOrdering` scan. Singleton splits make the reported input ordering truthful. The tests cover subset projection, full-key identity projection, and bucket reduction, checking complete join results and the required sort while preserving the storage-partitioned join.

`git diff --check` passed.

Both baseline regrouping cases lost one sort-merge join match. The full-key identity-projection control passed on both baseline and candidate.

Fresh selected-source local validation of a combined branch-4.0 tree containing the separate window, key-routing, scan-ordering and NULL-fixture proposals passed all 11 focused tests. The broader run completed all 244 exact test identities: 237 passed and seven function-based ordering cases in WriteDistributionAndOrderingSuite failed. All seven also failed on the Apache production baseline with matching exception types, messages and first eight stack frames; they remain a limitation of this local setup, not a passing full-suite result. No tests were skipped and no suite aborted; fresh-class origin checks passed.

The separate baseline control reproduced six targeted production regressions, while five expected controls passed. Removing only the two NULL-fixture guards separately reproduced the insertion exception and stale-value result. Candidate tests cover their complete loops; baseline failures stop at the first failing iteration and do not establish later iterations. All nine changed files in the combined 4.0 tree passed Scalastyle with zero errors or warnings.

JDK 17 / Scala 2.13.16 freshly compiled 40 selected Scala production sources, five Java sources and nine test/fixture sources; remaining dependencies were cached and fingerprinted. This is not a complete build, standalone validation of this PR, a whole-source-equivalent Apache runtime, or CI success. Earlier failed setup and audit attempts are retained separately and are not counted as passes.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
