### PR TITLE
[SPARK-55411][SQL][TEST] Preserve null bucket keys in test fixtures

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryBaseTable.scala
@@ -307,6 +307,7 @@ abstract class InMemoryBaseTable(
       case BucketTransform(numBuckets, cols, _) =>
         val hash: Long = cols.foldLeft(0L) { (acc, col) =>
           val valueHash = extractor(col.fieldNames, cleanedSchema, row) match {
+            case (null, _) => 0L
             case (value: Byte, _: ByteType) => value.toLong
             case (value: Short, _: ShortType) => value.toLong
             case (value: Int, _: IntegerType) => value.toLong

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/KeyGroupedPartitioningSuite.scala
@@ -23,11 +23,11 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.rdd.SortedMergeCoalescedRDD
 import org.apache.spark.sql.{DataFrame, ExplainSuiteHelper, Row}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Ascending, AttributeReference, ExprId, Literal, TransformExpression}
+import org.apache.spark.sql.catalyst.expressions.{ApplyFunctionExpression, Ascending, AttributeReference, BoundReference, ExprId, Literal, TransformExpression}
 import org.apache.spark.sql.catalyst.plans.{Cross, ExistenceJoin, Inner, JoinType, LeftAnti, LeftSemi, LeftSingle}
 import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.catalyst.plans.physical.KeyedPartitioning
-import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryCatalystRuntimeFilterCatalog, InMemoryTableCatalog}
+import org.apache.spark.sql.connector.catalog.{Column, Identifier, InMemoryBaseTable, InMemoryCatalystRuntimeFilterCatalog, InMemoryTableCatalog}
 import org.apache.spark.sql.connector.catalog.functions._
 import org.apache.spark.sql.connector.distributions.Distributions
 import org.apache.spark.sql.connector.expressions._
@@ -478,6 +478,32 @@ class KeyGroupedPartitioningSuite
     val partitionKeys = Seq(0).map(v => InternalRow.fromSeq(Seq(v)))
     checkQueryPlan(df, distribution,
       physical.KeyedPartitioning(distribution.clustering, partitionKeys))
+  }
+
+  test("SPARK-55411: bucket transform preserves null keys") {
+    Seq("TINYINT", "SMALLINT", "INT", "BIGINT", "TIMESTAMP", "TIMESTAMP_NTZ", "STRING", "BINARY")
+      .foreach { dataType =>
+        withTable("testcat.ns.null_bucket") {
+          sql(s"CREATE TABLE testcat.ns.null_bucket (k $dataType) PARTITIONED BY (bucket(4, k))")
+          sql("INSERT INTO testcat.ns.null_bucket VALUES (NULL)")
+          checkAnswer(sql("SELECT k FROM testcat.ns.null_bucket"), Seq(Row(null)))
+
+          val storedTable = catalog.loadTable(Identifier.of(Array("ns"), "null_bucket"))
+            .asInstanceOf[InMemoryBaseTable]
+          assert(storedTable.dataMap.keySet == Set(Seq(0)))
+        }
+      }
+  }
+
+  test("SPARK-55411: bucket function handles null after a non-null key") {
+    val expression = ApplyFunctionExpression(
+      BucketFunction, Seq(Literal(4), BoundReference(0, LongType, nullable = true)))
+
+    // Reuse the expression so its SpecificInternalRow retains the preceding non-null value.
+    assert(expression.eval(InternalRow(5L)) == 1)
+    assert(expression.eval(InternalRow(null)) == 0)
+    assert(expression.eval(InternalRow(-5L)) == 3)
+    assert(expression.eval(InternalRow(null)) == 0)
   }
 
   test("non-clustered distribution: no V2 catalog") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/catalog/functions/transformFunctions.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/catalog/functions/transformFunctions.scala
@@ -209,7 +209,8 @@ object BucketFunction extends ScalarFunction[Int] with ReducibleFunction[Int, In
   override def canonicalName(): String = name()
   override def toString: String = name()
   override def produceResult(input: InternalRow): Int = {
-    Math.floorMod(input.getLong(1), input.getInt(0))
+    val value = if (input.isNullAt(1)) 0L else input.getLong(1)
+    Math.floorMod(value, input.getInt(0))
   }
 
   override def reducer(


### PR DESCRIPTION
Related JIRA: [SPARK-55411](https://issues.apache.org/jira/browse/SPARK-55411), which introduced the affected behavior. A separate follow-up JIRA for this specific bug is pending creation; this draft currently uses the originating issue key.

Draft: master-branch native validation remains pending.

### What changes were proposed in this pull request?

Preserve nullable bucket keys in the in-memory test catalog. A null field contributes zero to the fixture's additive bucket hash, and `BucketFunction` explicitly uses zero for a null key before reading the primitive value. This keeps the two test helpers consistent for nulls.

Add regression coverage for nullable inserts and readback across the fixture's supported input types, including the resulting bucket key. Add a repeated-expression check that evaluates a non-null key followed by null, exercising the reused `SpecificInternalRow`.

### Why are the changes needed?

SPARK-55411 ([#54182](https://github.com/apache/spark/pull/54182), with the 4.0 backport in [#54260](https://github.com/apache/spark/pull/54260)) replaced the fixture's hash calculation with a typed match. The old calculation skipped null values, but the replacement omitted a null case. As a result, inserting null into a bucketed test table throws `IllegalArgumentException` in `InMemoryBaseTable.getKey`.

The paired `BucketFunction` also reads `getLong(1)` without checking the null flag. When the expression reuses a `SpecificInternalRow`, a null key can read the preceding key's primitive payload. An explicit null check avoids that stale-value result.

### Does this PR introduce _any_ user-facing change?

No. The changes are confined to test fixtures and regression tests.

### How was this patch tested?

Added two tests in `KeyGroupedPartitioningSuite`:

- `SPARK-55411: bucket transform preserves null keys`: inserts and reads null for TINYINT, SMALLINT, INT, BIGINT, TIMESTAMP, TIMESTAMP_NTZ, STRING, and BINARY, and checks that each null is assigned bucket zero.
- `SPARK-55411: bucket function handles null after a non-null key`: evaluates the same bound expression for `5L`, null, `-5L`, and null, expecting `1`, `0`, `3`, and `0` with four buckets.

`git diff --check` and a static changed-source line-length check passed. **This master-branch proposal has not been compiled or run natively.** The identical new test block and bucket-guard logic passed both cases in a selected-source branch-4.0 adaptation with cached dependencies. Removing only the two guards reproduced `(null, ByteType)` during the first TINYINT insertion and `1 did not equal 0` at the first NULL-after-5 assertion; exact identities and loaded fresh-class origins were checked. The failing controls do not establish later loop iterations. The guarded positive cases cover all listed types and the full expression sequence.

The combined 4.0 broad run completed 244 cases with 237 passes and seven function-ordering failures also reproduced on its production baseline. Its nine changed files passed Scalastyle with zero errors or warnings. This does not validate master's different toolchain or execution architecture, and is not standalone validation, a full build or CI result. A prior NULL-control audit incorrectly required a reader on a pre-read failure path; that rejected attempt is preserved separately, and the final control run used a separately reviewed phase-appropriate requirement.

Planned focused validation:

```text
build/sbt "sql/testOnly *KeyGroupedPartitioningSuite -- -z SPARK-55411"
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (version not exposed in this session).
