### PR TITLE
[WIP][CORE] Make shuffle tracking storage-aware

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -108,7 +108,8 @@ private[spark] class ExecutorAllocationManager(
     cleaner: Option[ContextCleaner] = None,
     clock: Clock = new SystemClock(),
     resourceProfileManager: ResourceProfileManager,
-    reliableShuffleStorage: Boolean)
+    reliableShuffleStorage: Boolean,
+    isShuffleReliablyStored: Int => Boolean = _ => false)
   extends Logging {
 
   allocationManager =>
@@ -168,7 +169,13 @@ private[spark] class ExecutorAllocationManager(
   val executorAllocationManagerSource = new ExecutorAllocationManagerSource(this)
 
   val executorMonitor =
-    new ExecutorMonitor(conf, client, listenerBus, clock, executorAllocationManagerSource)
+    new ExecutorMonitor(
+      conf,
+      client,
+      listenerBus,
+      clock,
+      executorAllocationManagerSource,
+      isShuffleReliablyStored)
 
   // Whether we are still waiting for the initial set of executors to be allocated.
   // While this is true, we will not cancel outstanding executor requests. This is

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -63,7 +63,8 @@ import org.apache.spark.util.io.{ChunkedByteBuffer, ChunkedByteBufferOutputStrea
 private class ShuffleStatus(
     numPartitions: Int,
     numReducers: Int = -1,
-    bufferRacingMigrations: Boolean = false) extends Logging {
+    bufferRacingMigrations: Boolean = false,
+    val isReliablyStored: Boolean = false) extends Logging {
 
   private val (readLock, writeLock) = {
     val lock = new ReentrantReadWriteLock()
@@ -929,23 +930,37 @@ private[spark] class MapOutputTrackerMaster(
     shuffleStatuses.valuesIterator.count(_.hasCachedSerializedBroadcast)
   }
 
-  def registerShuffle(shuffleId: Int, numMaps: Int, numReduces: Int): Unit = {
+  def registerShuffle(shuffleId: Int, numMaps: Int, numReduces: Int): Unit =
+    registerShuffle(shuffleId, numMaps, numReduces, isReliablyStored = false)
+
+  def registerShuffle(
+      shuffleId: Int,
+      numMaps: Int,
+      numReduces: Int,
+      isReliablyStored: Boolean): Unit = {
     if (pushBasedShuffleEnabled) {
       if (shuffleStatuses.put(shuffleId,
-        new ShuffleStatus(numMaps, numReduces, bufferRacingMigrations)).isDefined) {
+        new ShuffleStatus(numMaps, numReduces, bufferRacingMigrations,
+          isReliablyStored)).isDefined) {
         throw new IllegalArgumentException("Shuffle ID " + shuffleId + " registered twice")
       }
     } else {
       if (shuffleStatuses.put(shuffleId,
-        new ShuffleStatus(numMaps, bufferRacingMigrations = bufferRacingMigrations)).isDefined) {
+        new ShuffleStatus(numMaps, bufferRacingMigrations = bufferRacingMigrations,
+          isReliablyStored = isReliablyStored)).isDefined) {
         throw new IllegalArgumentException("Shuffle ID " + shuffleId + " registered twice")
       }
     }
   }
 
   // ShuffleOutputTrackerMaster: a regular shuffle has no per-job registration, so jobId is ignored.
-  override def registerShuffle(shuffleId: Int, numMaps: Int, numReduces: Int, jobId: Int): Unit =
-    registerShuffle(shuffleId, numMaps, numReduces)
+  override def registerShuffle(
+      shuffleId: Int,
+      numMaps: Int,
+      numReduces: Int,
+      jobId: Int,
+      isReliablyStored: Boolean): Unit =
+    registerShuffle(shuffleId, numMaps, numReduces, isReliablyStored)
 
   def updateMapOutput(shuffleId: Int, mapId: Long, bmAddress: BlockManagerId): Unit = {
     shuffleStatuses.get(shuffleId) match {
@@ -1044,20 +1059,48 @@ private[spark] class MapOutputTrackerMaster(
   /**
    * Removes all shuffle outputs associated with this host. Note that this will also remove
    * outputs which are served by an external shuffle server (if one exists).
+   *
+   * When `skipReliablyStored` is true (executor/worker loss rather than a fetch failure),
+   * shuffles whose output is reliably stored off-executor are left intact, since losing the host
+   * does not lose their output.
    */
-  def removeOutputsOnHost(host: String): Unit = {
-    shuffleStatuses.valuesIterator.foreach { _.removeOutputsOnHost(host) }
-    incrementEpoch()
+  def removeOutputsOnHost(host: String): Unit =
+    removeOutputsOnHost(host, skipReliablyStored = false)
+
+  def removeOutputsOnHost(host: String, skipReliablyStored: Boolean): Unit = {
+    var removedAny = false
+    shuffleStatuses.valuesIterator.foreach { status =>
+      if (!(skipReliablyStored && status.isReliablyStored)) {
+        status.removeOutputsOnHost(host)
+        removedAny = true
+      }
+    }
+    // Skip the epoch bump when nothing was removed (every shuffle was reliably stored): a bump
+    // needlessly invalidates every executor's cached map statuses and forces a re-fetch.
+    if (removedAny) incrementEpoch()
   }
 
   /**
    * Removes all shuffle outputs associated with this executor. Note that this will also remove
    * outputs which are served by an external shuffle server (if one exists), as they are still
    * registered with this execId.
+   *
+   * When `skipReliablyStored` is true (executor loss rather than a fetch failure), shuffles whose
+   * output is reliably stored off-executor are left intact: losing the executor does not lose
+   * their output, so unregistering would force a needless map-stage recompute.
    */
-  def removeOutputsOnExecutor(execId: String): Unit = {
-    shuffleStatuses.valuesIterator.foreach { _.removeOutputsOnExecutor(execId) }
-    incrementEpoch()
+  def removeOutputsOnExecutor(execId: String): Unit =
+    removeOutputsOnExecutor(execId, skipReliablyStored = false)
+
+  def removeOutputsOnExecutor(execId: String, skipReliablyStored: Boolean): Unit = {
+    var removedAny = false
+    shuffleStatuses.valuesIterator.foreach { status =>
+      if (!(skipReliablyStored && status.isReliablyStored)) {
+        status.removeOutputsOnExecutor(execId)
+        removedAny = true
+      }
+    }
+    if (removedAny) incrementEpoch()
   }
 
   /**
@@ -1082,6 +1125,14 @@ private[spark] class MapOutputTrackerMaster(
 
   /** Check if the given shuffle is being tracked */
   override def containsShuffle(shuffleId: Int): Boolean = shuffleStatuses.contains(shuffleId)
+
+  /**
+   * Whether this shuffle's output is reliably stored off-executor, so it is not lost when an
+   * executor or worker holding it is lost. Unknown shuffles default to false.
+   */
+  def isReliablyStored(shuffleId: Int): Boolean = {
+    shuffleStatuses.get(shuffleId).exists(_.isReliablyStored)
+  }
 
   def getNumAvailableOutputs(shuffleId: Int): Int = {
     shuffleStatuses.get(shuffleId).map(_.numAvailableMapOutputs).getOrElse(0)

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1130,7 +1130,7 @@ private[spark] class MapOutputTrackerMaster(
    * Whether this shuffle's output is reliably stored off-executor, so it is not lost when an
    * executor or worker holding it is lost. Unknown shuffles default to false.
    */
-  def isReliablyStored(shuffleId: Int): Boolean = {
+  override def isReliablyStored(shuffleId: Int): Boolean = {
     shuffleStatuses.get(shuffleId).exists(_.isReliablyStored)
   }
 

--- a/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/MapOutputTracker.scala
@@ -1060,17 +1060,17 @@ private[spark] class MapOutputTrackerMaster(
    * Removes all shuffle outputs associated with this host. Note that this will also remove
    * outputs which are served by an external shuffle server (if one exists).
    *
-   * When `skipReliablyStored` is true (executor/worker loss rather than a fetch failure),
+   * When `respectReliablyStored` is true (executor/worker loss rather than a fetch failure),
    * shuffles whose output is reliably stored off-executor are left intact, since losing the host
    * does not lose their output.
    */
   def removeOutputsOnHost(host: String): Unit =
-    removeOutputsOnHost(host, skipReliablyStored = false)
+    removeOutputsOnHost(host, respectReliablyStored = false)
 
-  def removeOutputsOnHost(host: String, skipReliablyStored: Boolean): Unit = {
+  def removeOutputsOnHost(host: String, respectReliablyStored: Boolean): Unit = {
     var removedAny = false
     shuffleStatuses.valuesIterator.foreach { status =>
-      if (!(skipReliablyStored && status.isReliablyStored)) {
+      if (!(respectReliablyStored && status.isReliablyStored)) {
         status.removeOutputsOnHost(host)
         removedAny = true
       }
@@ -1085,17 +1085,17 @@ private[spark] class MapOutputTrackerMaster(
    * outputs which are served by an external shuffle server (if one exists), as they are still
    * registered with this execId.
    *
-   * When `skipReliablyStored` is true (executor loss rather than a fetch failure), shuffles whose
-   * output is reliably stored off-executor are left intact: losing the executor does not lose
+   * When `respectReliablyStored` is true (executor loss rather than a fetch failure), shuffles
+   * whose output is reliably stored off-executor are left intact: losing the executor does not lose
    * their output, so unregistering would force a needless map-stage recompute.
    */
   def removeOutputsOnExecutor(execId: String): Unit =
-    removeOutputsOnExecutor(execId, skipReliablyStored = false)
+    removeOutputsOnExecutor(execId, respectReliablyStored = false)
 
-  def removeOutputsOnExecutor(execId: String, skipReliablyStored: Boolean): Unit = {
+  def removeOutputsOnExecutor(execId: String, respectReliablyStored: Boolean): Unit = {
     var removedAny = false
     shuffleStatuses.valuesIterator.foreach { status =>
-      if (!(skipReliablyStored && status.isReliablyStored)) {
+      if (!(respectReliablyStored && status.isReliablyStored)) {
         status.removeOutputsOnExecutor(execId)
         removedAny = true
       }

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -702,7 +702,8 @@ class SparkContext(config: SparkConf) extends Logging {
             Some(new ExecutorAllocationManager(
               schedulerBackend.asInstanceOf[ExecutorAllocationClient], listenerBus, _conf,
               cleaner = cleaner, resourceProfileManager = resourceProfileManager,
-              reliableShuffleStorage = _shuffleDriverComponents.supportsReliableStorage()))
+              reliableShuffleStorage = _shuffleDriverComponents.supportsReliableStorage(),
+              isShuffleReliablyStored = _dagScheduler.isShuffleReliablyStored))
           case _ =>
             None
         }

--- a/core/src/main/scala/org/apache/spark/StreamingShuffleOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/StreamingShuffleOutputTracker.scala
@@ -38,7 +38,12 @@ import org.apache.spark.util.ThreadUtils
  */
 private[spark] trait ShuffleOutputTrackerMaster {
   /** Register a shuffle so its outputs can be tracked. `jobId` is used by the streaming tracker. */
-  def registerShuffle(shuffleId: Int, numMaps: Int, numReduces: Int, jobId: Int): Unit
+  def registerShuffle(
+      shuffleId: Int,
+      numMaps: Int,
+      numReduces: Int,
+      jobId: Int,
+      isReliablyStored: Boolean = false): Unit
   /** Whether the given shuffle is registered with this tracker. */
   def containsShuffle(shuffleId: Int): Boolean
   /** Unregister a shuffle and release its tracked state. */
@@ -237,7 +242,12 @@ private[spark] class StreamingShuffleOutputTrackerMaster(conf: SparkConf)
     pool
   }
 
-  override def registerShuffle(shuffleId: Int, numMaps: Int, numReduces: Int, jobId: Int): Unit = {
+  override def registerShuffle(
+      shuffleId: Int,
+      numMaps: Int,
+      numReduces: Int,
+      jobId: Int,
+      isReliablyStored: Boolean): Unit = {
     logInfo(log"Registering shuffleId ${MDC(LogKeys.SHUFFLE_ID, shuffleId)} with ${
       MDC(LogKeys.NUM_MAPPERS, numMaps)} mappers and ${
       MDC(LogKeys.NUM_REDUCERS, numReduces)} reducers")

--- a/core/src/main/scala/org/apache/spark/StreamingShuffleOutputTracker.scala
+++ b/core/src/main/scala/org/apache/spark/StreamingShuffleOutputTracker.scala
@@ -46,6 +46,8 @@ private[spark] trait ShuffleOutputTrackerMaster {
       isReliablyStored: Boolean = false): Unit
   /** Whether the given shuffle is registered with this tracker. */
   def containsShuffle(shuffleId: Int): Boolean
+  /** Whether the given shuffle's output is reliably stored off-executor. */
+  def isReliablyStored(shuffleId: Int): Boolean
   /** Unregister a shuffle and release its tracked state. */
   def unregisterShuffle(shuffleId: Int): Unit
 }
@@ -215,7 +217,11 @@ private[spark] abstract class StreamingShuffleOutputTracker(conf: SparkConf) ext
   def getAvailableShuffleWriterTaskLocations(shuffleId: Int): Option[ShuffleLocationResponse]
 }
 
-private[spark] case class StreamingShuffleInfo(numMaps: Int, numReduces: Int, jobId: Int)
+private[spark] case class StreamingShuffleInfo(
+    numMaps: Int,
+    numReduces: Int,
+    jobId: Int,
+    isReliablyStored: Boolean)
 
 private[spark] class StreamingShuffleOutputTrackerMaster(conf: SparkConf)
   extends StreamingShuffleOutputTracker(conf) with ShuffleOutputTrackerMaster {
@@ -252,12 +258,16 @@ private[spark] class StreamingShuffleOutputTrackerMaster(conf: SparkConf)
       MDC(LogKeys.NUM_MAPPERS, numMaps)} mappers and ${
       MDC(LogKeys.NUM_REDUCERS, numReduces)} reducers")
     if (shuffleInfos.putIfAbsent(
-        shuffleId, StreamingShuffleInfo(numMaps, numReduces, jobId)) != null) {
+        shuffleId, StreamingShuffleInfo(numMaps, numReduces, jobId, isReliablyStored)) != null) {
       throw new IllegalArgumentException(s"Shuffle ID $shuffleId registered twice")
     }
   }
 
   override def containsShuffle(shuffleId: Int): Boolean = shuffleInfos.containsKey(shuffleId)
+
+  override def isReliablyStored(shuffleId: Int): Boolean = {
+    Option(shuffleInfos.get(shuffleId)).exists(_.isReliablyStored)
+  }
 
   // for testing purposes
   private[spark] def getShuffleInfo(shuffleId: Int): Option[StreamingShuffleInfo] = {

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -762,7 +762,8 @@ private[spark] class DAGScheduler(
         log"(${MDC(CREATION_SITE, rdd.getCreationSite)}) as input to " +
         log"shuffle ${MDC(SHUFFLE_ID, shuffleDep.shuffleId)}")
       outputTracker.registerShuffle(shuffleDep.shuffleId, rdd.partitions.length,
-        shuffleDep.partitioner.numPartitions, jobId)
+        shuffleDep.partitioner.numPartitions, jobId,
+        isReliablyStored = shuffleDep.shuffleHandle.isReliablyStored)
     }
     stage
   }
@@ -4199,7 +4200,10 @@ private[spark] class DAGScheduler(
       execId = execId,
       fileLost = fileLost,
       hostToUnregisterOutputs = workerHost,
-      maybeEpoch = None)
+      maybeEpoch = None,
+      // Executor loss (not a fetch failure): preserve shuffles whose output is reliably stored
+      // off-executor. Their data survives the executor, so recomputing them would be wasteful.
+      skipReliablyStored = true)
   }
 
   /**
@@ -4267,7 +4271,8 @@ private[spark] class DAGScheduler(
       fileLost: Boolean,
       hostToUnregisterOutputs: Option[String],
       maybeEpoch: Option[Long] = None,
-      ignoreShuffleFileLostEpoch: Boolean = false): Unit = {
+      ignoreShuffleFileLostEpoch: Boolean = false,
+      skipReliablyStored: Boolean = false): Unit = {
     val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
     logDebug(s"Considering removal of executor $execId; " +
       s"fileLost: $fileLost, currentEpoch: $currentEpoch")
@@ -4307,11 +4312,11 @@ private[spark] class DAGScheduler(
           case Some(host) =>
             logInfo(log"Shuffle files lost for host: ${MDC(HOST, host)} (epoch " +
               log"${MDC(EPOCH, currentEpoch)}")
-            mapOutputTracker.removeOutputsOnHost(host)
+            mapOutputTracker.removeOutputsOnHost(host, skipReliablyStored)
           case None =>
               logInfo(log"Shuffle files lost for executor: ${MDC(EXECUTOR_ID, execId)} " +
                 log"(epoch ${MDC(EPOCH, currentEpoch)})")
-            mapOutputTracker.removeOutputsOnExecutor(execId)
+            mapOutputTracker.removeOutputsOnExecutor(execId, skipReliablyStored)
         }
       }
     }
@@ -4334,7 +4339,9 @@ private[spark] class DAGScheduler(
       message: String): Unit = {
     logInfo(log"Shuffle files lost for worker ${MDC(WORKER_ID, workerId)} " +
       log"on host ${MDC(HOST, host)}")
-    mapOutputTracker.removeOutputsOnHost(host)
+    // Worker loss (not a fetch failure): reliably-stored shuffle output lives off the worker and
+    // survives, so leave those outputs registered and only drop the rest.
+    mapOutputTracker.removeOutputsOnHost(host, skipReliablyStored = true)
     clearCacheLocs()
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -763,7 +763,10 @@ private[spark] class DAGScheduler(
         log"shuffle ${MDC(SHUFFLE_ID, shuffleDep.shuffleId)}")
       outputTracker.registerShuffle(shuffleDep.shuffleId, rdd.partitions.length,
         shuffleDep.partitioner.numPartitions, jobId,
-        isReliablyStored = shuffleDep.shuffleHandle.isReliablyStored)
+        // Resolve the per-shuffle reliability signal against the app-global flag once, here: a
+        // handle that sets it is authoritative; None falls back to supportsReliableStorage().
+        isReliablyStored = shuffleDep.shuffleHandle.reliablyStored.getOrElse(
+          sc.shuffleDriverComponents.supportsReliableStorage()))
     }
     stage
   }
@@ -4191,11 +4194,11 @@ private[spark] class DAGScheduler(
   private[scheduler] def handleExecutorLost(
       execId: String,
       workerHost: Option[String]): Unit = {
-    // if the cluster manager explicitly tells us that the entire worker was lost, then
-    // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
-    // from a Standalone cluster, where the shuffle service lives in the Worker.)
-    val fileLost = !sc.shuffleDriverComponents.supportsReliableStorage() &&
-      (workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled)
+    // "worker" specifically refers to the process from a Standalone cluster, where the shuffle
+    // service lives in the Worker. Reliability is decided per shuffle by skipReliablyStored below
+    // (the tracker's per-shuffle value already folds in supportsReliableStorage()), so this only
+    // decides whether outputs on this executor/host are candidates for removal at all.
+    val fileLost = workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled
     removeExecutorAndUnregisterOutputs(
       execId = execId,
       fileLost = fileLost,
@@ -4302,7 +4305,13 @@ private[spark] class DAGScheduler(
         true
       } else if (!shuffleFileLostEpoch.contains(execId) ||
         shuffleFileLostEpoch(execId) < currentEpoch) {
-        shuffleFileLostEpoch(execId) = currentEpoch
+        // A selective cleanup (skipReliablyStored) leaves reliably-stored outputs registered, so
+        // it is not a full cleanup of this executor. Don't stamp shuffleFileLostEpoch in that case:
+        // otherwise a later same-epoch FetchFailed for one of those preserved-but-actually-gone
+        // outputs would be rejected by the strict epoch check here and never cleaned up.
+        if (!skipReliablyStored) {
+          shuffleFileLostEpoch(execId) = currentEpoch
+        }
         true
       } else {
         false

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -763,8 +763,7 @@ private[spark] class DAGScheduler(
         log"shuffle ${MDC(SHUFFLE_ID, shuffleDep.shuffleId)}")
       outputTracker.registerShuffle(shuffleDep.shuffleId, rdd.partitions.length,
         shuffleDep.partitioner.numPartitions, jobId,
-        // Resolve the per-shuffle reliability signal against the app-global flag once, here: a
-        // handle that sets it is authoritative; None falls back to supportsReliableStorage().
+        // Per-shuffle handle wins; None falls back to the app-global flag.
         isReliablyStored = shuffleDep.shuffleHandle.reliablyStored.getOrElse(
           sc.shuffleDriverComponents.supportsReliableStorage()))
     }
@@ -4194,10 +4193,9 @@ private[spark] class DAGScheduler(
   private[scheduler] def handleExecutorLost(
       execId: String,
       workerHost: Option[String]): Unit = {
-    // "worker" specifically refers to the process from a Standalone cluster, where the shuffle
-    // service lives in the Worker. Reliability is decided per shuffle by skipReliablyStored below
-    // (the tracker's per-shuffle value already folds in supportsReliableStorage()), so this only
-    // decides whether outputs on this executor/host are candidates for removal at all.
+    // Whether these outputs are candidates for removal at all; reliability is then decided per
+    // shuffle by skipReliablyStored below. workerHost.isDefined means the whole Standalone worker
+    // (which hosts the shuffle service) is gone.
     val fileLost = workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled
     removeExecutorAndUnregisterOutputs(
       execId = execId,
@@ -4305,10 +4303,8 @@ private[spark] class DAGScheduler(
         true
       } else if (!shuffleFileLostEpoch.contains(execId) ||
         shuffleFileLostEpoch(execId) < currentEpoch) {
-        // A selective cleanup (skipReliablyStored) leaves reliably-stored outputs registered, so
-        // it is not a full cleanup of this executor. Don't stamp shuffleFileLostEpoch in that case:
-        // otherwise a later same-epoch FetchFailed for one of those preserved-but-actually-gone
-        // outputs would be rejected by the strict epoch check here and never cleaned up.
+        // A selective cleanup keeps reliably-stored outputs, so it isn't a full cleanup: don't
+        // stamp the epoch, or a same-epoch FetchFailed for a preserved-but-gone output is skipped.
         if (!skipReliablyStored) {
           shuffleFileLostEpoch(execId) = currentEpoch
         }

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -4193,9 +4193,9 @@ private[spark] class DAGScheduler(
   private[scheduler] def handleExecutorLost(
       execId: String,
       workerHost: Option[String]): Unit = {
-    // Whether these outputs are candidates for removal at all; reliability is then decided per
-    // shuffle by skipReliablyStored below. workerHost.isDefined means the whole Standalone worker
-    // (which hosts the shuffle service) is gone.
+    // Whether these outputs are candidates for removal at all; reliability is then honored per
+    // shuffle via respectReliablyStored below. workerHost.isDefined means the whole Standalone
+    // worker (which hosts the shuffle service) is gone.
     val fileLost = workerHost.isDefined || !env.blockManager.externalShuffleServiceEnabled
     removeExecutorAndUnregisterOutputs(
       execId = execId,
@@ -4204,7 +4204,7 @@ private[spark] class DAGScheduler(
       maybeEpoch = None,
       // Executor loss (not a fetch failure): preserve shuffles whose output is reliably stored
       // off-executor. Their data survives the executor, so recomputing them would be wasteful.
-      skipReliablyStored = true)
+      respectReliablyStored = true)
   }
 
   /**
@@ -4273,7 +4273,7 @@ private[spark] class DAGScheduler(
       hostToUnregisterOutputs: Option[String],
       maybeEpoch: Option[Long] = None,
       ignoreShuffleFileLostEpoch: Boolean = false,
-      skipReliablyStored: Boolean = false): Unit = {
+      respectReliablyStored: Boolean = false): Unit = {
     val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
     logDebug(s"Considering removal of executor $execId; " +
       s"fileLost: $fileLost, currentEpoch: $currentEpoch")
@@ -4305,7 +4305,7 @@ private[spark] class DAGScheduler(
         shuffleFileLostEpoch(execId) < currentEpoch) {
         // A selective cleanup keeps reliably-stored outputs, so it isn't a full cleanup: don't
         // stamp the epoch, or a same-epoch FetchFailed for a preserved-but-gone output is skipped.
-        if (!skipReliablyStored) {
+        if (!respectReliablyStored) {
           shuffleFileLostEpoch(execId) = currentEpoch
         }
         true
@@ -4317,11 +4317,11 @@ private[spark] class DAGScheduler(
           case Some(host) =>
             logInfo(log"Shuffle files lost for host: ${MDC(HOST, host)} (epoch " +
               log"${MDC(EPOCH, currentEpoch)}")
-            mapOutputTracker.removeOutputsOnHost(host, skipReliablyStored)
+            mapOutputTracker.removeOutputsOnHost(host, respectReliablyStored)
           case None =>
               logInfo(log"Shuffle files lost for executor: ${MDC(EXECUTOR_ID, execId)} " +
                 log"(epoch ${MDC(EPOCH, currentEpoch)})")
-            mapOutputTracker.removeOutputsOnExecutor(execId, skipReliablyStored)
+            mapOutputTracker.removeOutputsOnExecutor(execId, respectReliablyStored)
         }
       }
     }
@@ -4346,7 +4346,7 @@ private[spark] class DAGScheduler(
       log"on host ${MDC(HOST, host)}")
     // Worker loss (not a fetch failure): reliably-stored shuffle output lives off the worker and
     // survives, so leave those outputs registered and only drop the rest.
-    mapOutputTracker.removeOutputsOnHost(host, skipReliablyStored = true)
+    mapOutputTracker.removeOutputsOnHost(host, respectReliablyStored = true)
     clearCacheLocs()
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -792,6 +792,20 @@ private[spark] class DAGScheduler(
     }
   }
 
+  private[spark] def isShuffleReliablyStored(shuffleId: Int): Boolean = {
+    if (mapOutputTracker.containsShuffle(shuffleId)) {
+      mapOutputTracker.isReliablyStored(shuffleId)
+    } else {
+      sc.env.streamingShuffleOutputTracker
+        .collect {
+          case tracker: StreamingShuffleOutputTrackerMaster
+              if tracker.containsShuffle(shuffleId) =>
+            tracker.isReliablyStored(shuffleId)
+        }
+        .getOrElse(false)
+    }
+  }
+
   private def pipelinedUnsupportedError(reason: String): PipelinedShuffleUnsupportedException =
     new PipelinedShuffleUnsupportedException(reason)
 

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1228,8 +1228,20 @@ private[spark] class TaskSetManager(
     // pipelined set and aborts the whole group. Note isZombie already skips a fully-complete
     // producer's set; this guard also covers a PARTIALLY-complete producer losing an executor on
     // decommission.
+
+    // OR, not AND: a shuffle reliably stored off-executor (globally, or just this one via a remote
+    // shuffle service) keeps its map output when the executor dies. The per-shuffle bit only ever
+    // adds reliability (defaults to false, set true solely by an opting-in manager), so a false
+    // there means "no info", not "unreliable".
+    val reliablyStored = sched.sc.shuffleDriverComponents.supportsReliableStorage() ||
+      taskSet.shuffleId.exists { shuffleId =>
+        sched.mapOutputTracker match {
+          case master: MapOutputTrackerMaster => master.isReliablyStored(shuffleId)
+          case _ => false
+        }
+      }
     val maybeShuffleMapOutputLoss = isShuffleMapTasks && !taskSet.isPipelined &&
-      !sched.sc.shuffleDriverComponents.supportsReliableStorage() &&
+      !reliablyStored &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)
     if (maybeShuffleMapOutputLoss && !isZombie) {
       val iter1 = taskIdsOnExec.iterator

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1229,17 +1229,10 @@ private[spark] class TaskSetManager(
     // producer's set; this guard also covers a PARTIALLY-complete producer losing an executor on
     // decommission.
 
-    // Per-shuffle reliability wins: the tracker's stored value already folds in the app-global
-    // flag at registration. Use it for a registered shuffle, else fall back to the global flag.
-    val reliablyStored = taskSet.shuffleId match {
-      case Some(shuffleId) =>
-        sched.mapOutputTracker match {
-          case master: MapOutputTrackerMaster if master.containsShuffle(shuffleId) =>
-            master.isReliablyStored(shuffleId)
-          case _ => sched.sc.shuffleDriverComponents.supportsReliableStorage()
-        }
-      case None => sched.sc.shuffleDriverComponents.supportsReliableStorage()
-    }
+    // The tracker's stored value already folds the app-global flag and the per-shuffle handle
+    // together at registration (see DAGScheduler.createShuffleMapStage), and a shuffle map task set
+    // always has its shuffle registered before it is submitted. Read it as the single source.
+    val reliablyStored = taskSet.shuffleId.exists(sched.mapOutputTracker.isReliablyStored)
     val maybeShuffleMapOutputLoss = isShuffleMapTasks && !taskSet.isPipelined &&
       !reliablyStored &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1229,17 +1229,19 @@ private[spark] class TaskSetManager(
     // producer's set; this guard also covers a PARTIALLY-complete producer losing an executor on
     // decommission.
 
-    // OR, not AND: a shuffle reliably stored off-executor (globally, or just this one via a remote
-    // shuffle service) keeps its map output when the executor dies. The per-shuffle bit only ever
-    // adds reliability (defaults to false, set true solely by an opting-in manager), so a false
-    // there means "no info", not "unreliable".
-    val reliablyStored = sched.sc.shuffleDriverComponents.supportsReliableStorage() ||
-      taskSet.shuffleId.exists { shuffleId =>
+    // Per-shuffle reliability is authoritative. The tracker's stored value already folds in the
+    // app-global supportsReliableStorage() at registerShuffle time (a handle that sets
+    // reliablyStored wins, else the global flag), so use it for a registered shuffle and fall back
+    // to the global flag only when the shuffle isn't registered here.
+    val reliablyStored = taskSet.shuffleId match {
+      case Some(shuffleId) =>
         sched.mapOutputTracker match {
-          case master: MapOutputTrackerMaster => master.isReliablyStored(shuffleId)
-          case _ => false
+          case master: MapOutputTrackerMaster if master.containsShuffle(shuffleId) =>
+            master.isReliablyStored(shuffleId)
+          case _ => sched.sc.shuffleDriverComponents.supportsReliableStorage()
         }
-      }
+      case None => sched.sc.shuffleDriverComponents.supportsReliableStorage()
+    }
     val maybeShuffleMapOutputLoss = isShuffleMapTasks && !taskSet.isPipelined &&
       !reliablyStored &&
       (reason.isInstanceOf[ExecutorDecommission] || !env.blockManager.externalShuffleServiceEnabled)

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1229,10 +1229,8 @@ private[spark] class TaskSetManager(
     // producer's set; this guard also covers a PARTIALLY-complete producer losing an executor on
     // decommission.
 
-    // Per-shuffle reliability is authoritative. The tracker's stored value already folds in the
-    // app-global supportsReliableStorage() at registerShuffle time (a handle that sets
-    // reliablyStored wins, else the global flag), so use it for a registered shuffle and fall back
-    // to the global flag only when the shuffle isn't registered here.
+    // Per-shuffle reliability wins: the tracker's stored value already folds in the app-global
+    // flag at registration. Use it for a registered shuffle, else fall back to the global flag.
     val reliablyStored = taskSet.shuffleId match {
       case Some(shuffleId) =>
         sched.mapOutputTracker match {

--- a/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitor.scala
@@ -40,7 +40,8 @@ private[spark] class ExecutorMonitor(
     client: ExecutorAllocationClient,
     listenerBus: LiveListenerBus,
     clock: Clock,
-    metrics: ExecutorAllocationManagerSource = null)
+    metrics: ExecutorAllocationManagerSource = null,
+    isShuffleReliablyStored: Int => Boolean = _ => false)
   extends SparkListener with CleanerListener with Logging {
 
   private val idleTimeoutNs = TimeUnit.SECONDS.toNanos(
@@ -205,7 +206,7 @@ private[spark] class ExecutorMonitor(
     }
 
     val shuffleStages = event.stageInfos.flatMap { s =>
-      s.shuffleDepId.toSeq.map { shuffleId =>
+      s.shuffleDepId.filterNot(isShuffleReliablyStored).toSeq.map { shuffleId =>
         s.stageId -> shuffleId
       }
     }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -25,4 +25,12 @@ import org.apache.spark.annotation.DeveloperApi
  * @param shuffleId ID of the shuffle
  */
 @DeveloperApi
-abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {}
+abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
+  /**
+   * Whether this shuffle's output is stored reliably outside the executors that produced it (e.g.
+   * a remote shuffle service). When true, losing an executor does not lose this shuffle's output,
+   * so its map outputs are not unregistered on executor loss. Defaults to false; a ShuffleManager
+   * that routes a shuffle to reliable storage overrides this on the handle it returns.
+   */
+  def isReliablyStored: Boolean = false
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -27,10 +27,13 @@ import org.apache.spark.annotation.DeveloperApi
 @DeveloperApi
 abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
   /**
-   * Per-shuffle override of the app-global `ShuffleDriverComponents.supportsReliableStorage()`.
-   * `Some(true)`/`Some(false)` is authoritative for this shuffle; `None` (the default) falls back
-   * to the global flag. When reliable, the output survives executor/host loss and is not
-   * unregistered.
+   * Whether this shuffle's output is stored reliably, off the executor that produced it (e.g. a
+   * remote shuffle service or distributed filesystem). When true, losing the executor or its host
+   * does not lose the output, so its map outputs are not unregistered on executor/worker loss.
+   *
+   * Per-shuffle override of the app-global `ShuffleDriverComponents.supportsReliableStorage()`:
+   * `Some(value)` is authoritative for this shuffle; `None` (the default) means "no per-shuffle
+   * information", so the global flag is used and managers that don't set it keep legacy behavior.
    */
   def reliablyStored: Option[Boolean] = None
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -27,16 +27,10 @@ import org.apache.spark.annotation.DeveloperApi
 @DeveloperApi
 abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
   /**
-   * Whether this shuffle's output is stored reliably, independent of the lifecycle of the executor
-   * host that produced it (e.g. a remote shuffle service or a distributed filesystem), matching the
-   * contract of `ShuffleDriverComponents.supportsReliableStorage()`. When true, losing the executor
-   * or its host does not lose this shuffle's output, so its map outputs are not unregistered on
-   * executor/worker loss.
-   *
-   * This is the per-shuffle override of the app-global `supportsReliableStorage()`: `Some(value)`
-   * is authoritative for this shuffle (a ShuffleManager that routes reliability per shuffle sets it
-   * on the handle it returns), while `None` means "no per-shuffle information", in which case the
-   * global flag is used. Defaults to `None` so managers that don't set it keep the global behavior.
+   * Per-shuffle override of the app-global `ShuffleDriverComponents.supportsReliableStorage()`.
+   * `Some(true)`/`Some(false)` is authoritative for this shuffle; `None` (the default) falls back
+   * to the global flag. When reliable, the output survives executor/host loss and is not
+   * unregistered.
    */
   def reliablyStored: Option[Boolean] = None
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleHandle.scala
@@ -27,10 +27,16 @@ import org.apache.spark.annotation.DeveloperApi
 @DeveloperApi
 abstract class ShuffleHandle(val shuffleId: Int) extends Serializable {
   /**
-   * Whether this shuffle's output is stored reliably outside the executors that produced it (e.g.
-   * a remote shuffle service). When true, losing an executor does not lose this shuffle's output,
-   * so its map outputs are not unregistered on executor loss. Defaults to false; a ShuffleManager
-   * that routes a shuffle to reliable storage overrides this on the handle it returns.
+   * Whether this shuffle's output is stored reliably, independent of the lifecycle of the executor
+   * host that produced it (e.g. a remote shuffle service or a distributed filesystem), matching the
+   * contract of `ShuffleDriverComponents.supportsReliableStorage()`. When true, losing the executor
+   * or its host does not lose this shuffle's output, so its map outputs are not unregistered on
+   * executor/worker loss.
+   *
+   * This is the per-shuffle override of the app-global `supportsReliableStorage()`: `Some(value)`
+   * is authoritative for this shuffle (a ShuffleManager that routes reliability per shuffle sets it
+   * on the handle it returns), while `None` means "no per-shuffle information", in which case the
+   * global flag is used. Defaults to `None` so managers that don't set it keep the global behavior.
    */
-  def isReliablyStored: Boolean = false
+  def reliablyStored: Option[Boolean] = None
 }

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -136,6 +136,46 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     rpcEnv.shutdown()
   }
 
+  test("SPARK-59138: executor loss skips reliably-stored shuffles but not local-disk ones") {
+    val rpcEnv = createRpcEnv("test")
+    val tracker = newTrackerMaster()
+    tracker.trackerEndpoint = rpcEnv.setupEndpoint(MapOutputTracker.ENDPOINT_NAME,
+      new MapOutputTrackerMasterEndpoint(rpcEnv, tracker, conf))
+
+    val size = MapStatus.compressSize(1000L)
+    // Shuffle 0: local-disk (not reliably stored). Shuffle 1: reliably stored off-executor.
+    tracker.registerShuffle(0, 1, MergeStatus.SHUFFLE_PUSH_DUMMY_NUM_REDUCES)
+    tracker.registerShuffle(1, 1, MergeStatus.SHUFFLE_PUSH_DUMMY_NUM_REDUCES,
+      isReliablyStored = true)
+    tracker.registerMapOutput(0, 0, MapStatus(BlockManagerId("a", "hostA", 1000), Array(size), 5))
+    tracker.registerMapOutput(1, 0, MapStatus(BlockManagerId("a", "hostA", 1000), Array(size), 6))
+
+    assert(tracker.isReliablyStored(0) === false)
+    assert(tracker.isReliablyStored(1) === true)
+
+    // Executor loss: skip reliably-stored shuffles. Shuffle 0 drops, shuffle 1 stays.
+    tracker.removeOutputsOnExecutor("a", skipReliablyStored = true)
+    assert(tracker.getNumAvailableOutputs(0) === 0)
+    assert(tracker.getNumAvailableOutputs(1) === 1)
+
+    // Losing an executor when only reliably-stored shuffles remain removes nothing, so the
+    // epoch must not bump (a bump would needlessly invalidate every executor's cached statuses).
+    tracker.unregisterShuffle(0)
+    val epochBeforeNoOp = tracker.getEpoch
+    tracker.removeOutputsOnExecutor("a", skipReliablyStored = true)
+    assert(tracker.getEpoch === epochBeforeNoOp)
+
+    // Fetch failure (skip = false): even the reliably-stored shuffle's output is removed, and
+    // because something was removed the epoch bumps.
+    val epochBeforeRemoval = tracker.getEpoch
+    tracker.removeOutputsOnExecutor("a", skipReliablyStored = false)
+    assert(tracker.getNumAvailableOutputs(1) === 0)
+    assert(tracker.getEpoch > epochBeforeRemoval)
+
+    tracker.stop()
+    rpcEnv.shutdown()
+  }
+
   test("remote fetch") {
     val hostname = "localhost"
     val rpcEnv = createRpcEnv("spark", hostname, 0, new SecurityManager(conf))

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -154,7 +154,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     assert(tracker.isReliablyStored(1) === true)
 
     // Executor loss: skip reliably-stored shuffles. Shuffle 0 drops, shuffle 1 stays.
-    tracker.removeOutputsOnExecutor("a", skipReliablyStored = true)
+    tracker.removeOutputsOnExecutor("a", respectReliablyStored = true)
     assert(tracker.getNumAvailableOutputs(0) === 0)
     assert(tracker.getNumAvailableOutputs(1) === 1)
 
@@ -162,13 +162,13 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     // epoch must not bump (a bump would needlessly invalidate every executor's cached statuses).
     tracker.unregisterShuffle(0)
     val epochBeforeNoOp = tracker.getEpoch
-    tracker.removeOutputsOnExecutor("a", skipReliablyStored = true)
+    tracker.removeOutputsOnExecutor("a", respectReliablyStored = true)
     assert(tracker.getEpoch === epochBeforeNoOp)
 
     // Fetch failure (skip = false): even the reliably-stored shuffle's output is removed, and
     // because something was removed the epoch bumps.
     val epochBeforeRemoval = tracker.getEpoch
-    tracker.removeOutputsOnExecutor("a", skipReliablyStored = false)
+    tracker.removeOutputsOnExecutor("a", respectReliablyStored = false)
     assert(tracker.getNumAvailableOutputs(1) === 0)
     assert(tracker.getEpoch > epochBeforeRemoval)
 

--- a/core/src/test/scala/org/apache/spark/StreamingShuffleOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/StreamingShuffleOutputTrackerSuite.scala
@@ -87,6 +87,17 @@ class StreamingShuffleOutputTrackerSuite
       new StreamingShuffleOutputTrackerMasterEndpoint(rpcEnv, tracker, conf))
   }
 
+  test("track reliable storage per shuffle") {
+    val master = newTrackerMaster()
+
+    master.registerShuffle(0, 1, 1, 0, isReliablyStored = true)
+    master.registerShuffle(1, 1, 1, 0, isReliablyStored = false)
+
+    master.isReliablyStored(0) should be(true)
+    master.isReliablyStored(1) should be(false)
+    master.isReliablyStored(2) should be(false)
+  }
+
   test("test tracker workflow") {
     val master = newTrackerMaster()
     val worker = newTrackerWorker()

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -48,7 +48,7 @@ import org.apache.spark.resource.ResourceUtils.{FPGA, GPU}
 import org.apache.spark.rpc.RpcTimeoutException
 import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
 import org.apache.spark.scheduler.local.LocalSchedulerBackend
-import org.apache.spark.shuffle.{FetchFailedException, MetadataFetchFailedException}
+import org.apache.spark.shuffle.{BaseShuffleHandle, FetchFailedException, MetadataFetchFailedException, ShuffleHandle}
 import org.apache.spark.storage.{BlockId, BlockManager, BlockManagerId, BlockManagerMaster}
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, CallSite, Clock, LongAccumulator, SystemClock, ThreadUtils, Utils}
 import org.apache.spark.util.ArrayImplicits._
@@ -152,6 +152,17 @@ class MyRDD(
   }
 
   override def toString: String = "DAGSchedulerSuiteRDD " + id
+}
+
+/** A ShuffleDependency whose handle reports its output as reliably stored off-executor. */
+class ReliablyStoredShuffleDependency(
+    rdd: RDD[_ <: Product2[Int, Int]],
+    partitioner: Partitioner)
+  extends ShuffleDependency[Int, Int, Int](rdd, partitioner) {
+  override val shuffleHandle: ShuffleHandle =
+    new BaseShuffleHandle(shuffleId, this) {
+      override def isReliablyStored: Boolean = true
+    }
 }
 
 class DummyScheduledFuture(
@@ -778,7 +789,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     runEvent(ExecutorLost("hostA-exec", ExecutorExited(-100, false, "Container marked as failed")))
     // Executor is removed but shuffle files are not unregistered
     verify(blockManagerMaster, times(1)).removeExecutorAsync("hostA-exec")
-    verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec")
+    verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec", true)
 
     // The MapOutputTracker has all the shuffle files
     val mapStatuses = mapOutputTracker.shuffleStatuses(shuffleId).mapStatuses
@@ -793,7 +804,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     // blockManagerMaster.removeExecutorAsync is not called again
     // but shuffle files are unregistered
     verify(blockManagerMaster, times(1)).removeExecutorAsync("hostA-exec")
-    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec")
+    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec", false)
 
     // Shuffle files for hostA-exec should be lost
     assert(mapStatuses.count(_ != null) === 1)
@@ -805,7 +816,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     complete(taskSets(1), Seq(
       (FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0L, 1, 0, "ignored"), null)
     ))
-    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec")
+    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec", false)
   }
 
   test("zero split job") {
@@ -1079,15 +1090,15 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
       verify(blockManagerMaster, times(1)).removeExecutorAsync("hostA-exec")
       if (expectFileLoss) {
         if (expectHostFileLoss) {
-          verify(mapOutputTracker, times(1)).removeOutputsOnHost("hostA")
+          verify(mapOutputTracker, times(1)).removeOutputsOnHost("hostA", true)
         } else {
-          verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec")
+          verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec", true)
         }
         intercept[MetadataFetchFailedException] {
           mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0)
         }
       } else {
-        verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec")
+        verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec", true)
         assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
           HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
       }
@@ -1112,9 +1123,36 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     completeShuffleMapStageSuccessfully(0, 0, 1)
     runEvent(ExecutorLost("hostA-exec", event))
     verify(blockManagerMaster, times(1)).removeExecutorAsync("hostA-exec")
-    verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec")
+    verify(mapOutputTracker, times(0)).removeOutputsOnExecutor("hostA-exec", true)
     assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
+  }
+
+  test("SPARK-59138: executor loss keeps a reliably-stored shuffle but drops a local-disk one") {
+    // No external shuffle service, so a plain (local-disk) shuffle's outputs are lost on executor
+    // loss, but a per-shuffle reliably-stored one survives.
+    conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "false")
+
+    val reliableRdd = new MyRDD(sc, 2, Nil)
+    val reliableDep = new ReliablyStoredShuffleDependency(reliableRdd, new HashPartitioner(1))
+    val localRdd = new MyRDD(sc, 2, Nil)
+    val localDep = new ShuffleDependency(localRdd, new HashPartitioner(1))
+    val reduceRdd = new MyRDD(sc, 1, List(reliableDep, localDep), tracker = mapOutputTracker)
+    submit(reduceRdd, Array(0))
+
+    // Two independent map stages, one per shuffle; complete both on hostA / hostB.
+    completeShuffleMapStageSuccessfully(0, 0, 1)
+    completeShuffleMapStageSuccessfully(1, 0, 1)
+
+    runEvent(ExecutorLost("hostA-exec", ExecutorKilled))
+    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec", true)
+
+    // Reliable shuffle keeps hostA's output; local-disk shuffle loses it.
+    assert(mapOutputTracker.getMapSizesByExecutorId(reliableDep.shuffleId, 0).map(_._1).toSet ===
+      HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
+    intercept[MetadataFetchFailedException] {
+      mapOutputTracker.getMapSizesByExecutorId(localDep.shuffleId, 0)
+    }
   }
 
   test("SPARK-28967 properties must be cloned before posting to listener bus for 0 partition") {
@@ -6185,7 +6223,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     verify(blockManagerMaster, times(0))
       .removeExecutorAsync(BlockManagerId.SHUFFLE_MERGER_IDENTIFIER)
     verify(mapOutputTracker,
-      times(0)).removeOutputsOnExecutor(BlockManagerId.SHUFFLE_MERGER_IDENTIFIER)
+      times(0)).removeOutputsOnExecutor(BlockManagerId.SHUFFLE_MERGER_IDENTIFIER, true)
 
     // Now a fetch failure from the lost executor occurs
     complete(taskSets(1), Seq(
@@ -6199,7 +6237,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
       .removeExecutorAsync(BlockManagerId.SHUFFLE_MERGER_IDENTIFIER)
     verify(blockManagerMaster, times(1)).removeShufflePushMergerLocation("hostA")
     verify(mapOutputTracker,
-      times(1)).removeOutputsOnHost("hostA")
+      times(1)).removeOutputsOnHost("hostA", false)
 
     // There should be no map statuses or merge statuses on the host
     val shuffleStatuses = mapOutputTracker.shuffleStatuses(shuffleId)

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1157,9 +1157,7 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   test("SPARK-59138: per-shuffle reliablyStored=false overrides a global supportsReliableStorage") {
-    // Mixed/fallback case: the manager reports the app-global capability as true, but a specific
-    // shuffle fell back to local disk and reports Some(false) on its handle. The per-shuffle value
-    // must win, so that shuffle's outputs are dropped on executor loss.
+    // Global flag true, but one shuffle reports Some(false); the per-shuffle value must win.
     conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "false")
     conf.set(config.SHUFFLE_IO_PLUGIN_CLASS.key,
       classOf[TestShuffleDataIOWithMockedComponents].getName)
@@ -1187,9 +1185,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
   }
 
   test("SPARK-59138: same-epoch FetchFailed after selective executor-loss cleanup is not skipped") {
-    // Selective cleanup on executor loss preserves a reliably-stored shuffle's outputs but must not
-    // record shuffleFileLostEpoch as a full cleanup: a later same-epoch FetchFailed for one of the
-    // preserved-but-actually-gone outputs must still trigger the real removal.
+    // A selective cleanup preserves reliable outputs, so it must not stamp shuffleFileLostEpoch;
+    // a same-epoch FetchFailed for a preserved-but-gone output must still trigger real removal.
     conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "false")
 
     val shuffleMapRdd = new MyRDD(sc, 2, Nil)
@@ -1204,9 +1201,8 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1.host).toSet ===
       HashSet("hostA", "hostB"))
 
-    // A reducer running at the same epoch reports FetchFailed for hostA's output, which is really
-    // gone. The selective cleanup didn't stamp shuffleFileLostEpoch, so the epoch-gated bulk
-    // cleanup proceeds instead of being skipped.
+    // Same-epoch FetchFailed for hostA's (really gone) output: no epoch was stamped, so the
+    // epoch-gated cleanup proceeds instead of being skipped.
     complete(taskSets(1), Seq(
       (Success, 42),
       (FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0L, 0, 1, "ignored"), null)))

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -1171,6 +1171,9 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     val reduceRdd = new MyRDD(sc, 1, List(reliableDep, fallbackDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0))
 
+    assert(scheduler.isShuffleReliablyStored(reliableDep.shuffleId))
+    assert(!scheduler.isShuffleReliablyStored(fallbackDep.shuffleId))
+
     completeShuffleMapStageSuccessfully(0, 0, 1)
     completeShuffleMapStageSuccessfully(1, 0, 1)
 

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -154,14 +154,15 @@ class MyRDD(
   override def toString: String = "DAGSchedulerSuiteRDD " + id
 }
 
-/** A ShuffleDependency whose handle reports its output as reliably stored off-executor. */
+/** A ShuffleDependency whose handle reports a per-shuffle reliable-storage signal. */
 class ReliablyStoredShuffleDependency(
     rdd: RDD[_ <: Product2[Int, Int]],
-    partitioner: Partitioner)
+    partitioner: Partitioner,
+    reliablyStoredSignal: Option[Boolean] = Some(true))
   extends ShuffleDependency[Int, Int, Int](rdd, partitioner) {
   override val shuffleHandle: ShuffleHandle =
     new BaseShuffleHandle(shuffleId, this) {
-      override def isReliablyStored: Boolean = true
+      override def reliablyStored: Option[Boolean] = reliablyStoredSignal
     }
 }
 
@@ -1153,6 +1154,63 @@ class DAGSchedulerSuite extends SparkFunSuite with TempLocalSparkContext with Ti
     intercept[MetadataFetchFailedException] {
       mapOutputTracker.getMapSizesByExecutorId(localDep.shuffleId, 0)
     }
+  }
+
+  test("SPARK-59138: per-shuffle reliablyStored=false overrides a global supportsReliableStorage") {
+    // Mixed/fallback case: the manager reports the app-global capability as true, but a specific
+    // shuffle fell back to local disk and reports Some(false) on its handle. The per-shuffle value
+    // must win, so that shuffle's outputs are dropped on executor loss.
+    conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "false")
+    conf.set(config.SHUFFLE_IO_PLUGIN_CLASS.key,
+      classOf[TestShuffleDataIOWithMockedComponents].getName)
+    when(sc.shuffleDriverComponents.supportsReliableStorage()).thenReturn(true)
+
+    val reliableRdd = new MyRDD(sc, 2, Nil)
+    val reliableDep = new ReliablyStoredShuffleDependency(reliableRdd, new HashPartitioner(1))
+    val fallbackRdd = new MyRDD(sc, 2, Nil)
+    val fallbackDep =
+      new ReliablyStoredShuffleDependency(fallbackRdd, new HashPartitioner(1), Some(false))
+    val reduceRdd = new MyRDD(sc, 1, List(reliableDep, fallbackDep), tracker = mapOutputTracker)
+    submit(reduceRdd, Array(0))
+
+    completeShuffleMapStageSuccessfully(0, 0, 1)
+    completeShuffleMapStageSuccessfully(1, 0, 1)
+
+    runEvent(ExecutorLost("hostA-exec", ExecutorKilled))
+
+    // Some(true) keeps hostA's output despite the global flag; Some(false) loses it despite it.
+    assert(mapOutputTracker.getMapSizesByExecutorId(reliableDep.shuffleId, 0).map(_._1).toSet ===
+      HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
+    intercept[MetadataFetchFailedException] {
+      mapOutputTracker.getMapSizesByExecutorId(fallbackDep.shuffleId, 0)
+    }
+  }
+
+  test("SPARK-59138: same-epoch FetchFailed after selective executor-loss cleanup is not skipped") {
+    // Selective cleanup on executor loss preserves a reliably-stored shuffle's outputs but must not
+    // record shuffleFileLostEpoch as a full cleanup: a later same-epoch FetchFailed for one of the
+    // preserved-but-actually-gone outputs must still trigger the real removal.
+    conf.set(config.SHUFFLE_SERVICE_ENABLED.key, "false")
+
+    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
+    val shuffleDep = new ReliablyStoredShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
+    val shuffleId = shuffleDep.shuffleId
+    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
+    submit(reduceRdd, Array(0, 1))
+    completeShuffleMapStageSuccessfully(0, 0, reduceRdd.partitions.length)
+
+    // Executor loss: reliably-stored shuffle is preserved (selective cleanup), no output removed.
+    runEvent(ExecutorLost("hostA-exec", ExecutorKilled))
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1.host).toSet ===
+      HashSet("hostA", "hostB"))
+
+    // A reducer running at the same epoch reports FetchFailed for hostA's output, which is really
+    // gone. The selective cleanup didn't stamp shuffleFileLostEpoch, so the epoch-gated bulk
+    // cleanup proceeds instead of being skipped.
+    complete(taskSets(1), Seq(
+      (Success, 42),
+      (FetchFailed(makeBlockManagerId("hostA"), shuffleId, 0L, 0, 1, "ignored"), null)))
+    verify(mapOutputTracker, times(1)).removeOutputsOnExecutor("hostA-exec", false)
   }
 
   test("SPARK-28967 properties must be cloned before posting to listener bus for 0 partition") {

--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSetManagerSuite.scala
@@ -760,6 +760,37 @@ class TaskSetManagerSuite
     assert(manager.successful(taskIndex))
   }
 
+  test("SPARK-59138: task doesn't rerun on executor lost for a reliably-stored shuffle") {
+    sc = new SparkContext("local", "test")
+    sched = new FakeTaskScheduler(sc)
+    val backend = mock(classOf[SchedulerBackend])
+    doNothing().when(backend).reviveOffers()
+    sched.initialize(backend)
+
+    sched.addExecutor("exec0", "host0")
+
+    val mapOutputTracker = sc.env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster]
+    mapOutputTracker.registerShuffle(0, 2, 0, isReliablyStored = true)
+
+    val taskSet = FakeTask.createShuffleMapTaskSet(2, 0, 0,
+      Seq(TaskLocation("host0", "exec0")), Seq(TaskLocation("host1", "exec1")))
+    sched.submitTasks(taskSet)
+    val manager = sched.taskSetManagerForAttempt(0, 0).get
+
+    val taskDesc = manager.resourceOffer("exec0", "host0", PROCESS_LOCAL)._1
+    assert(taskDesc.isDefined)
+    val taskIndex = taskDesc.get.index
+    val taskId = taskDesc.get.taskId
+    manager.handleSuccessfulTask(taskId, createTaskResult(taskId.toInt))
+    mapOutputTracker.registerMapOutput(0, taskIndex,
+      MapStatus(BlockManagerId("exec0", "host0", 8848), Array(1024), taskId))
+
+    // The shuffle is reliably stored off-executor, so losing exec0 must not rerun the map task,
+    // even without shuffle migration or an external shuffle service.
+    manager.executorLost("exec0", "host0", ExecutorDecommission())
+    assert(manager.successful(taskIndex))
+  }
+
   test("SPARK-32653: Decommissioned host should not be used to calculate locality levels") {
     sc = new SparkContext("local", "test")
     sched = new FakeTaskScheduler(sc)

--- a/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/dynalloc/ExecutorMonitorSuite.scala
@@ -384,6 +384,39 @@ class ExecutorMonitorSuite extends SparkFunSuite {
     assert(monitor.timedOutExecutors(idleDeadline) === Seq("1"))
   }
 
+  test("shuffle tracking ignores reliably stored shuffles") {
+    val bus = mockListenerBus()
+    conf.set(DYN_ALLOCATION_SHUFFLE_TRACKING_ENABLED, true).set(SHUFFLE_SERVICE_ENABLED, false)
+    monitor = new ExecutorMonitor(
+      conf,
+      client,
+      bus,
+      clock,
+      allocationManagerSource(),
+      isShuffleReliablyStored = _ == 0)
+
+    knownExecs ++= Set("1", "2")
+    monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "1", execInfo))
+    monitor.onExecutorAdded(SparkListenerExecutorAdded(clock.getTimeMillis(), "2", execInfo))
+
+    val reliableStage = stageInfo(1, shuffleId = 0)
+    val localStage = stageInfo(2, shuffleId = 1)
+    monitor.onJobStart(
+      SparkListenerJobStart(1, clock.getTimeMillis(), Seq(reliableStage, localStage)))
+
+    monitor.onTaskStart(SparkListenerTaskStart(1, 0, taskInfo("1", 1)))
+    monitor.onTaskEnd(SparkListenerTaskEnd(
+      1, 0, "foo", Success, taskInfo("1", 1), new ExecutorMetrics, null))
+    monitor.onTaskStart(SparkListenerTaskStart(2, 0, taskInfo("2", 2)))
+    monitor.onTaskEnd(SparkListenerTaskEnd(
+      2, 0, "foo", Success, taskInfo("2", 2), new ExecutorMetrics, null))
+
+    assert(monitor.timedOutExecutors(idleDeadline) === Seq("1"))
+    monitor.onJobEnd(SparkListenerJobEnd(1, clock.getTimeMillis(), JobSucceeded))
+    assert(monitor.timedOutExecutors(idleDeadline) === Seq("1"))
+    assert(monitor.timedOutExecutors(shuffleDeadline).toSet === Set("1", "2"))
+  }
+
 
   test("SPARK-28839: Avoids NPE in context cleaner when shuffle service is on") {
     val bus = mockListenerBus()


### PR DESCRIPTION
Stacked on apache/spark#58437. The final commit is the storage-aware dynamic-allocation change; the preceding commits belong to the dependency. A Spark JIRA ID is still needed before this is marked ready for review.

### What changes were proposed in this pull request?

- Carry the resolved per-shuffle reliable-storage bit through both regular and streaming shuffle output trackers.
- Let `ExecutorMonitor` query that bit when processing `SparkListenerJobStart`.
- Exclude reliably stored shuffles from dynamic-allocation shuffle tracking while retaining existing tracking for local or unknown-storage shuffles.

### Why are the changes needed?

When shuffle tracking and a reliable remote shuffle service are both enabled, Spark currently tracks every shuffle-producing executor without consulting the shuffle storage location. Executors that wrote remotely stored shuffle data therefore remain pinned by `spark.dynamicAllocation.shuffleTracking.timeout`, even though their output survives executor removal.

This is particularly costly for mixed fallback configurations: local fallback shuffles need tracking, while remote shuffles do not. The per-shuffle reliability state introduced by apache/spark#58437 provides the distinction, but `ExecutorMonitor` does not currently consume it.

### Does this PR introduce _any_ user-facing change?

Yes. With shuffle tracking enabled, executors holding only reliably stored shuffle output become eligible for the normal idle timeout. Executors holding local or unknown-storage shuffle output retain the existing active-shuffle and shuffle-timeout protection.

### How was this patch tested?

Added coverage that reliably stored shuffles use the executor idle timeout while local shuffles remain protected by shuffle tracking, plus streaming-tracker coverage for the per-shuffle reliability bit.

```
build/sbt "core/testOnly org.apache.spark.StreamingShuffleOutputTrackerSuite org.apache.spark.scheduler.DAGSchedulerSuite org.apache.spark.scheduler.dynalloc.ExecutorMonitorSuite" core/scalastyle
```

272 tests passed; core scalastyle reported no errors or warnings.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: GitHub Copilot (GPT-5.6 Sol Fast)