### PR TITLE
[SPARK-59400][ML] Reuse TreeEnsembleModel prediction helper

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -369,7 +369,7 @@ class GBTClassificationModel private[ml](
       }).apply(features)
     } else {
       udf((features: Vector) => {
-        val margin = TreeEnsembleModel.predict(features, localRootNodes, localTreeWeights)
+        val margin = TreeEnsembleModel.predictRaw(features, localRootNodes, localTreeWeights)
         if (margin > 0.0) 1.0 else 0.0
       }).apply(features)
     }
@@ -380,13 +380,13 @@ class GBTClassificationModel private[ml](
     if (isDefined(thresholds)) {
       super.predict(features)
     } else {
-      if (TreeEnsembleModel.predict(features, _trees, _treeWeights) > 0.0) 1.0 else 0.0
+      if (TreeEnsembleModel.predictRaw(features, _trees, _treeWeights) > 0.0) 1.0 else 0.0
     }
   }
 
   @Since("3.0.0")
   override def predictRaw(features: Vector): Vector = {
-    val prediction = TreeEnsembleModel.predict(features, _trees, _treeWeights)
+    val prediction = TreeEnsembleModel.predictRaw(features, _trees, _treeWeights)
     Vectors.dense(Array(-prediction, prediction))
   }
 
@@ -459,7 +459,7 @@ object GBTClassificationModel extends MLReadable[GBTClassificationModel] {
       features: Vector,
       rootNodes: Array[Node],
       treeWeights: Array[Double]): Vector = {
-    val prediction = TreeEnsembleModel.predict(features, rootNodes, treeWeights)
+    val prediction = TreeEnsembleModel.predictRaw(features, rootNodes, treeWeights)
     Vectors.dense(-prediction, prediction)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -380,13 +380,13 @@ class GBTClassificationModel private[ml](
     if (isDefined(thresholds)) {
       super.predict(features)
     } else {
-      if (margin(features) > 0.0) 1.0 else 0.0
+      if (TreeEnsembleModel.predict(features, _trees, _treeWeights) > 0.0) 1.0 else 0.0
     }
   }
 
   @Since("3.0.0")
   override def predictRaw(features: Vector): Vector = {
-    val prediction: Double = margin(features)
+    val prediction = TreeEnsembleModel.predict(features, _trees, _treeWeights)
     Vectors.dense(Array(-prediction, prediction))
   }
 
@@ -427,10 +427,6 @@ class GBTClassificationModel private[ml](
   @Since("2.0.0")
   lazy val featureImportances: Vector =
     TreeEnsembleModel.featureImportances(trees, numFeatures, perTreeNormalization = false)
-
-  /** Raw prediction for the positive class. */
-  private def margin(features: Vector): Double =
-    TreeEnsembleModel.predict(features, _trees, _treeWeights)
 
   /** (private[ml]) Convert to a model in the old API */
   private[ml] def toOld: OldGBTModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/GBTClassifier.scala
@@ -429,15 +429,8 @@ class GBTClassificationModel private[ml](
     TreeEnsembleModel.featureImportances(trees, numFeatures, perTreeNormalization = false)
 
   /** Raw prediction for the positive class. */
-  private def margin(features: Vector): Double = {
-    var prediction = 0.0
-    var i = 0
-    while (i < _trees.length) {
-      prediction += _trees(i).rootNode.predictImpl(features).prediction * _treeWeights(i)
-      i += 1
-    }
-    prediction
-  }
+  private def margin(features: Vector): Double =
+    TreeEnsembleModel.predict(features, _trees, _treeWeights)
 
   /** (private[ml]) Convert to a model in the old API */
   private[ml] def toOld: OldGBTModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -372,24 +372,8 @@ class RandomForestClassificationModel private[ml] (
   }
 
   @Since("3.0.0")
-  override def predictRaw(features: Vector): Vector = {
-    // TODO: When we add a generic Bagging class, handle transform there: SPARK-7128
-    // Classifies using majority votes.
-    // Ignore the tree weights since all are 1.0 for now.
-    val votes = Array.ofDim[Double](numClasses)
-    _trees.foreach { tree =>
-      val classCounts = tree.rootNode.predictImpl(features).impurityStats.stats
-      val total = classCounts.sum
-      if (total != 0) {
-        var i = 0
-        while (i < numClasses) {
-          votes(i) += classCounts(i) / total
-          i += 1
-        }
-      }
-    }
-    Vectors.dense(votes)
-  }
+  override def predictRaw(features: Vector): Vector =
+    RandomForestClassificationModel.predictRaw(features, _trees, numClasses)
 
   override protected def raw2probabilityInPlace(rawPrediction: Vector): Vector = {
     rawPrediction match {
@@ -468,6 +452,28 @@ class RandomForestClassificationModel private[ml] (
 
 @Since("2.0.0")
 object RandomForestClassificationModel extends MLReadable[RandomForestClassificationModel] {
+
+  private def predictRaw(
+      features: Vector,
+      trees: Array[DecisionTreeClassificationModel],
+      numClasses: Int): Vector = {
+    // TODO: When we add a generic Bagging class, handle transform there: SPARK-7128
+    // Classifies using majority votes.
+    // Ignore the tree weights since all are 1.0 for now.
+    val votes = Array.ofDim[Double](numClasses)
+    trees.foreach { tree =>
+      val classCounts = tree.rootNode.predictImpl(features).impurityStats.stats
+      val total = classCounts.sum
+      if (total != 0) {
+        var i = 0
+        while (i < numClasses) {
+          votes(i) += classCounts(i) / total
+          i += 1
+        }
+      }
+    }
+    Vectors.dense(votes)
+  }
 
   private def predictRaw(
       features: Vector,

--- a/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/classification/RandomForestClassifier.scala
@@ -457,9 +457,6 @@ object RandomForestClassificationModel extends MLReadable[RandomForestClassifica
       features: Vector,
       trees: Array[DecisionTreeClassificationModel],
       numClasses: Int): Vector = {
-    // TODO: When we add a generic Bagging class, handle transform there: SPARK-7128
-    // Classifies using majority votes.
-    // Ignore the tree weights since all are 1.0 for now.
     val votes = Array.ofDim[Double](numClasses)
     trees.foreach { tree =>
       val classCounts = tree.rootNode.predictImpl(features).impurityStats.stats
@@ -479,9 +476,6 @@ object RandomForestClassificationModel extends MLReadable[RandomForestClassifica
       features: Vector,
       rootNodes: Array[Node],
       numClasses: Int): Vector = {
-    // TODO: When we add a generic Bagging class, handle transform there: SPARK-7128
-    // Classifies using majority votes.
-    // Ignore the tree weights since all are 1.0 for now.
     val votes = Array.ofDim[Double](numClasses)
     rootNodes.foreach { rootNode =>
       val classCounts = rootNode.predictImpl(features).impurityStats.stats

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -307,13 +307,7 @@ class GBTRegressionModel private[ml](
   override def predict(features: Vector): Double = {
     // TODO: When we add a generic Boosting class, handle transform there?  SPARK-7129
     // Classifies by thresholding sum of weighted tree predictions
-    var prediction = 0.0
-    var i = 0
-    while (i < _trees.length) {
-      prediction += _trees(i).rootNode.predictImpl(features).prediction * _treeWeights(i)
-      i += 1
-    }
-    prediction
+    TreeEnsembleModel.predict(features, _trees, _treeWeights)
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -305,8 +305,6 @@ class GBTRegressionModel private[ml](
   }
 
   override def predict(features: Vector): Double = {
-    // TODO: When we add a generic Boosting class, handle transform there?  SPARK-7129
-    // Classifies by thresholding sum of weighted tree predictions
     TreeEnsembleModel.predict(features, _trees, _treeWeights)
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -280,7 +280,7 @@ class GBTRegressionModel private[ml](
       if ($(predictionCol).nonEmpty) {
         val predUDF = udf { features: Vector =>
           val (rootNodes, treeWeights) = bcTreeData.value
-          TreeEnsembleModel.predict(features, rootNodes, treeWeights)
+          TreeEnsembleModel.predictRaw(features, rootNodes, treeWeights)
         }
         predColNames :+= $(predictionCol)
         predCols :+= predUDF(col($(featuresCol)))
@@ -305,7 +305,7 @@ class GBTRegressionModel private[ml](
   }
 
   override def predict(features: Vector): Double = {
-    TreeEnsembleModel.predict(features, _trees, _treeWeights)
+    TreeEnsembleModel.predictRaw(features, _trees, _treeWeights)
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/GBTRegressor.scala
@@ -304,9 +304,8 @@ class GBTRegressionModel private[ml](
     }
   }
 
-  override def predict(features: Vector): Double = {
+  override def predict(features: Vector): Double =
     TreeEnsembleModel.predictRaw(features, _trees, _treeWeights)
-  }
 
   @Since("1.4.0")
   override def copy(extra: ParamMap): GBTRegressionModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -266,7 +266,7 @@ class RandomForestRegressionModel private[ml] (
     // TODO: When we add a generic Bagging class, handle transform there.  SPARK-7128
     // Predict average of tree predictions.
     // Ignore the weights since all are 1.0 for now.
-    _trees.map(_.rootNode.predictImpl(features).prediction).sum / getNumTrees
+    TreeEnsembleModel.predict(features, _trees) / getNumTrees
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -263,7 +263,7 @@ class RandomForestRegressionModel private[ml] (
   }
 
   override def predict(features: Vector): Double = {
-    TreeEnsembleModel.predict(features, _trees) / getNumTrees
+    TreeEnsembleModel.predictRaw(features, _trees) / getNumTrees
   }
 
   @Since("1.4.0")

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -262,9 +262,8 @@ class RandomForestRegressionModel private[ml] (
     }
   }
 
-  override def predict(features: Vector): Double = {
+  override def predict(features: Vector): Double =
     TreeEnsembleModel.predictRaw(features, _trees) / getNumTrees
-  }
 
   @Since("1.4.0")
   override def copy(extra: ParamMap): RandomForestRegressionModel = {

--- a/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/RandomForestRegressor.scala
@@ -263,9 +263,6 @@ class RandomForestRegressionModel private[ml] (
   }
 
   override def predict(features: Vector): Double = {
-    // TODO: When we add a generic Bagging class, handle transform there.  SPARK-7128
-    // Predict average of tree predictions.
-    // Ignore the weights since all are 1.0 for now.
     TreeEnsembleModel.predict(features, _trees) / getNumTrees
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -169,6 +169,31 @@ private[spark] trait TreeEnsembleModel[M <: DecisionTreeModel] {
 
 private[ml] object TreeEnsembleModel {
 
+  private[ml] def predict[M <: DecisionTreeModel](
+      features: Vector,
+      trees: Array[M],
+      treeWeights: Array[Double]): Double = {
+    var prediction = 0.0
+    var i = 0
+    while (i < trees.length) {
+      prediction += trees(i).rootNode.predictImpl(features).prediction * treeWeights(i)
+      i += 1
+    }
+    prediction
+  }
+
+  private[ml] def predict[M <: DecisionTreeModel](
+      features: Vector,
+      trees: Array[M]): Double = {
+    var prediction = 0.0
+    var i = 0
+    while (i < trees.length) {
+      prediction += trees(i).rootNode.predictImpl(features).prediction
+      i += 1
+    }
+    prediction
+  }
+
   private[ml] def predict(
       features: Vector,
       rootNodes: Array[Node],

--- a/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/tree/treeModels.scala
@@ -169,7 +169,7 @@ private[spark] trait TreeEnsembleModel[M <: DecisionTreeModel] {
 
 private[ml] object TreeEnsembleModel {
 
-  private[ml] def predict[M <: DecisionTreeModel](
+  private[ml] def predictRaw[M <: DecisionTreeModel](
       features: Vector,
       trees: Array[M],
       treeWeights: Array[Double]): Double = {
@@ -182,7 +182,7 @@ private[ml] object TreeEnsembleModel {
     prediction
   }
 
-  private[ml] def predict[M <: DecisionTreeModel](
+  private[ml] def predictRaw[M <: DecisionTreeModel](
       features: Vector,
       trees: Array[M]): Double = {
     var prediction = 0.0
@@ -194,7 +194,7 @@ private[ml] object TreeEnsembleModel {
     prediction
   }
 
-  private[ml] def predict(
+  private[ml] def predictRaw(
       features: Vector,
       rootNodes: Array[Node],
       treeWeights: Array[Double]): Double = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request centralizes tree ensemble prediction logic in companion objects:

- Add weighted and unweighted `TreeEnsembleModel.predictRaw` overloads that accept tree models.
- Rename the existing root-node helper to `predictRaw` for consistent naming.
- Reuse these helpers in GBT classification, GBT regression, and random forest regression.
- Move random forest classification's tree-based `predictRaw` implementation to its companion
  object and delegate to it from the model.


### Why are the changes needed?

The model classes duplicated tree traversal and aggregation loops. Keeping the implementations in
companion-object helpers makes the direct model prediction paths consistent with the optimized
column prediction paths. The unweighted overload also avoids allocating an intermediate array when
random forest regression sums tree predictions.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

No new tests were added because this is a behavior-preserving refactor of prediction paths already
covered by the existing GBT and random forest suites.

The patch passed `git diff --check`, changed-file line-length checks, and changed-file non-ASCII
checks. Unit tests were not run locally.


### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
