### PR TITLE
[SPARK-59525][PYTHON][SQL] Add Arrow support for nanosecond-precision timestamp types in PySpark

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1999,15 +1999,6 @@ class DataFrame(ParentDataFrame):
         return self._to_pandas()
 
     def _to_pandas(self, **kwargs: Any) -> "PandasDataFrameLike":
-        # SPARK-57462: the Arrow-based nanosecond timestamp value path is a pending follow-up.
-        # Connect overrides _to_pandas and goes straight to client.to_pandas, so the guard on the
-        # classic PandasConversionMixin is not reached; reject here too so the behavior is
-        # deterministic (and consistent with classic toPandas and to_arrow_type) rather than
-        # emitting unhandled pandas nanosecond / wrong-time-zone values.
-        from pyspark.sql.pandas.types import _reject_timestamp_nanos_conversion
-
-        _reject_timestamp_nanos_conversion(self.schema)
-
         query = self._plan.to_proto(self._session.client)
         pdf, ei = self._session.client.to_pandas(query, self._plan.observations, **kwargs)
         self._execution_info = ei

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1959,6 +1959,21 @@ class DataFrame(ParentDataFrame):
         attrs.update(self.columns)
         return sorted(attrs)
 
+    def _check_timestamp_nanos_map_key(self, schema: StructType) -> None:
+        # SPARK-57462: a nanosecond timestamp used as a map key collapses to a single microsecond
+        # datetime.datetime when Arrow rows are turned into Python dicts, dropping entries that
+        # differ only below a microsecond. Reject such a schema up front -- matching the classic
+        # DataFrame's guard -- rather than silently dropping map entries.
+        from pyspark.errors import PySparkTypeError
+        from pyspark.sql.types import _first_timestamp_nanos_map_key_type
+
+        key_type = _first_timestamp_nanos_map_key_type(schema)
+        if key_type is not None:
+            raise PySparkTypeError(
+                errorClass="TIMESTAMP_NANOS_PYTHON_MAP_KEY",
+                messageParameters={"type": key_type.simpleString()},
+            )
+
     def collect(self) -> List[Row]:
         table, schema = self._to_table()
 
@@ -1968,6 +1983,8 @@ class DataFrame(ParentDataFrame):
         schema = schema or schema2
 
         assert schema is not None and isinstance(schema, StructType)
+
+        self._check_timestamp_nanos_map_key(schema)
 
         return ArrowTableToRowsConversion.convert(
             table, schema, binary_as_bytes=self._get_binary_as_bytes()
@@ -2222,6 +2239,7 @@ class DataFrame(ParentDataFrame):
         return self.storageLevel != StorageLevel.NONE
 
     def toLocalIterator(self, prefetchPartitions: bool = False) -> Iterator[Row]:
+        self._check_timestamp_nanos_map_key(self.schema)
         query = self._plan.to_proto(self._session.client)
         binary_as_bytes = self._get_binary_as_bytes()
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -517,15 +517,6 @@ class SparkSession:
                 },
             )
 
-        # SPARK-57462: building a DataFrame over Spark Connect goes through Arrow, whose
-        # nanosecond timestamp value conversion is a pending follow-up. Reject an explicit
-        # nanosecond-typed schema here, right after resolution, so the empty-input and NumPy fast
-        # paths (which never build an Arrow converter) fail deterministically too.
-        if _schema is not None:
-            from pyspark.sql.pandas.types import _reject_timestamp_nanos_conversion
-
-            _reject_timestamp_nanos_conversion(_schema)
-
         if isinstance(data, np.ndarray) and data.ndim not in [1, 2]:
             raise PySparkValueError(
                 errorClass="INVALID_NDARRAY_DIMENSION",

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -56,6 +56,8 @@ from pyspark.sql.types import (
     StringType,
     StructField,
     StructType,
+    TimestampLTZNanosType,
+    TimestampNTZNanosType,
     TimestampNTZType,
     TimestampType,
     TimeType,
@@ -540,13 +542,10 @@ class LocalDataToArrowConversion:
             return True
         elif isinstance(dataType, BinaryType):
             return True
-        elif isinstance(dataType, (TimestampType, TimestampNTZType)):
+        elif isinstance(
+            dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)
+        ):
             # Always truncate
-            return True
-        elif isinstance(dataType, AnyTimestampNanoType):
-            # Needs a converter so _create_converter is built (and eagerly rejects) for every
-            # direct caller -- Arrow UDF return values, Python data-source writes -- not only the
-            # LocalDataToArrowConversion.convert path.
             return True
         elif isinstance(dataType, DecimalType):
             # Convert Decimal('NaN') to None
@@ -600,18 +599,6 @@ class LocalDataToArrowConversion:
                 return None
             else:
                 return lambda value: value
-
-        if isinstance(dataType, AnyTimestampNanoType):
-            # SPARK-57462: the Arrow-based value path for the nanosecond timestamp types is a
-            # pending follow-up. Reject eagerly, when the converter is built, so building a
-            # DataFrame from Arrow / returning nanoseconds from an Arrow UDF fails deterministically
-            # rather than mis-encoding the value. Consistent with to_arrow_type.
-            from pyspark.errors import PySparkTypeError
-
-            raise PySparkTypeError(
-                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                messageParameters={"data_type": str(dataType)},
-            )
 
         if isinstance(dataType, NullType):
 
@@ -793,7 +780,7 @@ class LocalDataToArrowConversion:
 
             return convert_binary
 
-        elif isinstance(dataType, TimestampType):
+        elif isinstance(dataType, (TimestampType, TimestampLTZNanosType)):
 
             def convert_timestamp(value: Any) -> Any:
                 if value is None:
@@ -806,7 +793,7 @@ class LocalDataToArrowConversion:
 
             return convert_timestamp
 
-        elif isinstance(dataType, TimestampNTZType):
+        elif isinstance(dataType, (TimestampNTZType, TimestampNTZNanosType)):
 
             def convert_timestamp_ntz(value: Any) -> Any:
                 if value is None:
@@ -1192,13 +1179,10 @@ class ArrowTableToRowsConversion:
             return True
         elif isinstance(dataType, BinaryType):
             return True
-        elif isinstance(dataType, (TimestampType, TimestampNTZType)):
+        elif isinstance(
+            dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)
+        ):
             # Always remove the time zone info for now
-            return True
-        elif isinstance(dataType, AnyTimestampNanoType):
-            # Needs a converter so _create_converter is built (and eagerly rejects) for every
-            # direct caller -- Connect collect, batched Arrow UDF inputs, foreachPartition, and
-            # Python data-source reads -- not only the ArrowTableToRowsConversion.convert path.
             return True
         elif isinstance(dataType, UserDefinedType):
             return True
@@ -1234,19 +1218,6 @@ class ArrowTableToRowsConversion:
                 return None
             else:
                 return lambda value: value
-
-        if isinstance(dataType, AnyTimestampNanoType):
-            # SPARK-57462: the Arrow-based value path for the nanosecond timestamp types is a
-            # pending follow-up. Reject eagerly, when the converter is built (all callers build
-            # converters up front), so it is not data-dependent and cannot leak a raw
-            # Arrow-derived value (a nanosecond-precision, possibly timezone-aware
-            # pandas.Timestamp). Consistent with to_arrow_type, which already rejects these types.
-            from pyspark.errors import PySparkTypeError
-
-            raise PySparkTypeError(
-                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                messageParameters={"data_type": str(dataType)},
-            )
 
         if isinstance(dataType, NullType):
             return lambda value: None
@@ -1361,7 +1332,7 @@ class ArrowTableToRowsConversion:
 
             return convert_binary
 
-        elif isinstance(dataType, TimestampType):
+        elif isinstance(dataType, (TimestampType, TimestampLTZNanosType)):
 
             def convert_timestamp(value: Any) -> Any:
                 if value is None:
@@ -1372,7 +1343,7 @@ class ArrowTableToRowsConversion:
 
             return convert_timestamp
 
-        elif isinstance(dataType, TimestampNTZType):
+        elif isinstance(dataType, (TimestampNTZType, TimestampNTZNanosType)):
 
             def convert_timestamp_ntz(value: Any) -> Any:
                 if value is None:

--- a/python/pyspark/sql/conversion.py
+++ b/python/pyspark/sql/conversion.py
@@ -542,9 +542,7 @@ class LocalDataToArrowConversion:
             return True
         elif isinstance(dataType, BinaryType):
             return True
-        elif isinstance(
-            dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)
-        ):
+        elif isinstance(dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)):
             # Always truncate
             return True
         elif isinstance(dataType, DecimalType):
@@ -1179,9 +1177,7 @@ class ArrowTableToRowsConversion:
             return True
         elif isinstance(dataType, BinaryType):
             return True
-        elif isinstance(
-            dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)
-        ):
+        elif isinstance(dataType, (TimestampType, TimestampNTZType, AnyTimestampNanoType)):
             # Always remove the time zone info for now
             return True
         elif isinstance(dataType, UserDefinedType):
@@ -1339,6 +1335,11 @@ class ArrowTableToRowsConversion:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
+                    # A timestamp[ns] value materializes as a pandas.Timestamp; collect()'s
+                    # datetime.datetime boundary is microsecond resolution (toPandas is the
+                    # lossless path), so drop any sub-microsecond digits to match classic collect().
+                    if hasattr(value, "to_pydatetime"):
+                        value = value.to_pydatetime(warn=False)
                     return value.astimezone().replace(tzinfo=None)
 
             return convert_timestamp
@@ -1350,6 +1351,10 @@ class ArrowTableToRowsConversion:
                     return None
                 else:
                     assert isinstance(value, datetime.datetime)
+                    # See convert_timestamp: reduce a nanosecond pandas.Timestamp to a microsecond
+                    # datetime.datetime so collect() matches the classic path.
+                    if hasattr(value, "to_pydatetime"):
+                        value = value.to_pydatetime(warn=False)
                     return value
 
             return convert_timestamp_ntz

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -320,17 +320,10 @@ class PandasConversionMixin:
 
         assert isinstance(self, DataFrame)
 
-        from pyspark.sql.pandas.types import (
-            _create_converter_to_pandas,
-            _reject_timestamp_nanos_conversion,
-        )
+        from pyspark.sql.pandas.types import _create_converter_to_pandas
         from pyspark.sql.pandas.utils import require_minimum_pandas_version
 
         require_minimum_pandas_version()
-
-        # Arrow/pandas value conversion for the nanosecond timestamp types is a pending follow-up;
-        # fail deterministically here rather than fall back to a lossy / wrong-timezone result.
-        _reject_timestamp_nanos_conversion(self.schema)
 
         import pandas as pd
 
@@ -638,18 +631,6 @@ class SparkConversionMixin:
         arrow_batch_size = int(arrowMaxRecordsPerBatch)
         selfcheck = arrowSafeTypeConversion == "true"
         infer_pandas_dict_as_map = inferPandasDictAsMap == "true"
-
-        # Building a DataFrame from pandas/PyArrow data goes through Arrow, whose nanosecond
-        # timestamp value conversion is a pending follow-up; fail deterministically for an explicit
-        # nanosecond-typed schema rather than silently mis-handle the values. createDataFrame has
-        # already parsed a DDL-string schema into a DataType by this point, so this guard covers
-        # both an explicit DataType and a DDL string (bare atomic or StructType). Only a plain list
-        # of column names carries no type information -- and so cannot name these types -- and is
-        # left to the server to gate.
-        if isinstance(schema, DataType):
-            from pyspark.sql.pandas.types import _reject_timestamp_nanos_conversion
-
-            _reject_timestamp_nanos_conversion(schema)
 
         if type(data).__name__ == "Table":
             # `data` is a PyArrow Table

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional,
 from pyspark.errors import PySparkTypeError, PySparkValueError, UnsupportedOperationException
 from pyspark.loose_version import LooseVersion
 from pyspark.sql.types import (
+    AnyTimestampNanoType,
     ArrayType,
     BinaryType,
     BooleanType,
@@ -53,6 +54,8 @@ from pyspark.sql.types import (
     StringType,
     StructField,
     StructType,
+    TimestampLTZNanosType,
+    TimestampNTZNanosType,
     TimestampNTZType,
     TimestampType,
     TimeType,
@@ -75,26 +78,6 @@ if TYPE_CHECKING:
 
 # Should keep in line with org.apache.spark.sql.util.ArrowUtils.metadataKey
 metadata_key = b"SPARK::metadata::json"
-
-
-def _reject_timestamp_nanos_conversion(schema: DataType) -> None:
-    """Raise if ``schema`` involves a nanosecond timestamp type, for Arrow/pandas value paths.
-
-    The Arrow / pandas value conversion for :class:`TimestampNTZNanosType` /
-    :class:`TimestampLTZNanosType` is not implemented yet (planned follow-up). Rather than let these
-    paths silently mis-handle the value (wrong time zone for LTZ, or a leaked ``pandas.Timestamp``),
-    fail deterministically here, consistent with :func:`to_arrow_type`, which already rejects these
-    types with the same error condition and reports the offending leaf type.
-    """
-    from pyspark.errors import PySparkTypeError
-    from pyspark.sql.types import _first_timestamp_nanos_type
-
-    offending = _first_timestamp_nanos_type(schema)
-    if offending is not None:
-        raise PySparkTypeError(
-            errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-            messageParameters={"data_type": str(offending)},
-        )
 
 
 def to_arrow_metadata(metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[bytes, bytes]]:
@@ -164,6 +147,15 @@ def to_arrow_type(
         arrow_type = pa.timestamp("us", tz=timezone)
     elif isinstance(dt, TimestampNTZType):
         arrow_type = pa.timestamp("us", tz=None)
+    elif isinstance(dt, TimestampLTZNanosType):
+        # Nanosecond-precision timestamps interchange as Arrow Timestamp(NANOSECOND), matching the
+        # JVM ArrowUtils mapping. This is the LTZ (timezone-aware) variant, so the session timezone
+        # is attached exactly like TimestampType. The precision (7-9) is carried out of band by the
+        # Spark schema; the Arrow unit is always nanoseconds.
+        assert timezone is not None
+        arrow_type = pa.timestamp("ns", tz=timezone)
+    elif isinstance(dt, TimestampNTZNanosType):
+        arrow_type = pa.timestamp("ns", tz=None)
     elif isinstance(dt, DayTimeIntervalType):
         arrow_type = pa.duration("us")
     elif isinstance(dt, TimeType):
@@ -570,7 +562,14 @@ def _check_arrow_array_timestamps_localize(
             ]
         )
 
-    if types.is_timestamp(a.type) and truncate and a.type.unit == "ns":
+    if (
+        types.is_timestamp(a.type)
+        and truncate
+        and a.type.unit == "ns"
+        and not isinstance(dt, AnyTimestampNanoType)
+    ):
+        # Nanosecond timestamps are floored to microseconds for the microsecond-precision Spark
+        # types, but a nanosecond-precision target type keeps its full resolution.
         a = pc.floor_temporal(a, unit="microsecond")
 
     if types.is_timestamp(a.type) and a.type.tz is None and isinstance(dt, TimestampType):
@@ -919,6 +918,10 @@ def _to_corrected_pandas_type(dt: DataType) -> Optional[Any]:
             return np.dtype("datetime64[ns]")
         else:
             return np.dtype("datetime64[us]")
+    elif isinstance(dt, AnyTimestampNanoType):
+        # Nanosecond-precision timestamps always map to datetime64[ns] regardless of pandas
+        # version -- it is the only pandas resolution that preserves the sub-microsecond digits.
+        return np.dtype("datetime64[ns]")
     elif isinstance(dt, DayTimeIntervalType):
         if LooseVersion(pd.__version__) < "3.0.0":
             return np.dtype("timedelta64[ns]")
@@ -1034,7 +1037,10 @@ def _create_converter_to_pandas(
                 else:
                     return pser.astype(pandas_type, copy=False)
 
-        elif isinstance(data_type, TimestampType):
+        elif isinstance(data_type, (TimestampType, TimestampLTZNanosType)):
+            # TimestampLTZNanosType is the nanosecond-precision, timezone-aware timestamp; it is
+            # localized to the session timezone exactly like TimestampType. Its pandas_type is
+            # datetime64[ns] (see _to_corrected_pandas_type), so full resolution is preserved.
             assert timezone is not None
 
             def correct_dtype(pser: pd.Series) -> pd.Series:
@@ -1220,7 +1226,7 @@ def _create_converter_to_pandas(
                     messageParameters={"var": str(_struct_in_pandas)},
                 )
 
-        elif isinstance(dt, TimestampType):
+        elif isinstance(dt, (TimestampType, TimestampLTZNanosType)):
             assert timezone is not None
 
             local_tz: Union[datetime.tzinfo, str] = (
@@ -1236,7 +1242,7 @@ def _create_converter_to_pandas(
 
             return convert_timestamp
 
-        elif isinstance(dt, TimestampNTZType):
+        elif isinstance(dt, (TimestampNTZType, TimestampNTZNanosType)):
 
             def convert_timestamp_ntz(value: Any) -> Any:
                 return pd.Timestamp(value)
@@ -1367,7 +1373,9 @@ def _create_converter_from_pandas(
     """
     import pandas as pd
 
-    if isinstance(data_type, TimestampType):
+    if isinstance(data_type, (TimestampType, TimestampLTZNanosType)):
+        # TimestampLTZNanosType is timezone-aware like TimestampType; the vectorized internal
+        # conversion preserves the datetime64[ns] resolution, so nanoseconds survive to Arrow.
         assert timezone is not None
 
         def correct_timestamp(pser: pd.Series) -> pd.Series:
@@ -1566,7 +1574,7 @@ def _create_converter_from_pandas(
 
             return convert_struct
 
-        elif isinstance(dt, TimestampType):
+        elif isinstance(dt, (TimestampType, TimestampLTZNanosType)):
             assert timezone is not None
 
             def convert_timestamp(value: Any) -> Any:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -79,6 +79,29 @@ if TYPE_CHECKING:
 # Should keep in line with org.apache.spark.sql.util.ArrowUtils.metadataKey
 metadata_key = b"SPARK::metadata::json"
 
+# Should keep in line with org.apache.spark.sql.util.ArrowUtils.timestampNanosPrecisionKey. The
+# nanosecond timestamp types map to an Arrow Timestamp(NANOSECOND) field whose declared precision
+# (7-9) cannot be recovered from the Arrow type alone; the JVM ArrowUtils.fromArrowField reads the
+# precision from this field-metadata key (defaulting to the maximum when it is absent). Tagging it
+# here keeps the precision through a Python -> Arrow -> JVM round trip (e.g. createDataFrame over
+# Spark Connect, which reconstructs the schema from the Arrow field rather than a passed schema).
+timestamp_nanos_precision_key = b"SPARK::timestampNanos::precision"
+
+
+def _with_timestamp_nanos_precision(
+    dt: DataType, metadata: Optional[Dict[bytes, bytes]]
+) -> Optional[Dict[bytes, bytes]]:
+    """Merge the nanosecond-precision tag into an Arrow field's metadata for a nanosecond
+    timestamp type, mirroring the JVM's ``toPrecisionTaggedArrowField``; other types are
+    unchanged."""
+    from pyspark.sql.types import AnyTimestampNanoType
+
+    if isinstance(dt, AnyTimestampNanoType):
+        merged = dict(metadata) if metadata else {}
+        merged[timestamp_nanos_precision_key] = str(dt.precision).encode("utf-8")
+        return merged
+    return metadata
+
 
 def to_arrow_metadata(metadata: Optional[Dict[str, Any]] = None) -> Optional[Dict[bytes, bytes]]:
     if metadata is not None and len(metadata) > 0:
@@ -170,6 +193,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=dt.containsNull,
+            metadata=_with_timestamp_nanos_precision(dt.elementType, None),
         )
         arrow_type = pa.list_(field)
     elif isinstance(dt, MapType):
@@ -182,6 +206,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=False,
+            metadata=_with_timestamp_nanos_precision(dt.keyType, None),
         )
         value_field = pa.field(
             "value",
@@ -192,6 +217,7 @@ def to_arrow_type(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=dt.valueContainsNull,
+            metadata=_with_timestamp_nanos_precision(dt.valueType, None),
         )
         arrow_type = pa.map_(key_field, value_field)
     elif isinstance(dt, StructType):
@@ -211,7 +237,9 @@ def to_arrow_type(
                     prefers_large_types=prefers_large_types,
                 ),
                 nullable=field.nullable,
-                metadata=to_arrow_metadata(field.metadata),
+                metadata=_with_timestamp_nanos_precision(
+                    field.dataType, to_arrow_metadata(field.metadata)
+                ),
             )
             for field in dt
         ]
@@ -299,7 +327,9 @@ def to_arrow_schema(
                 prefers_large_types=prefers_large_types,
             ),
             nullable=field.nullable,
-            metadata=to_arrow_metadata(field.metadata),
+            metadata=_with_timestamp_nanos_precision(
+                field.dataType, to_arrow_metadata(field.metadata)
+            ),
         )
         for field in schema
     ]

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -572,11 +572,15 @@ def _check_arrow_array_timestamps_localize(
         # types, but a nanosecond-precision target type keeps its full resolution.
         a = pc.floor_temporal(a, unit="microsecond")
 
-    if types.is_timestamp(a.type) and a.type.tz is None and isinstance(dt, TimestampType):
+    if (
+        types.is_timestamp(a.type)
+        and a.type.tz is None
+        and isinstance(dt, (TimestampType, TimestampLTZNanosType))
+    ):
         assert timezone is not None
 
-        # Only localize timestamps that will become Spark TimestampType columns.
-        # Do not localize timestamps that will become Spark TimestampNTZType columns.
+        # Localize naive Arrow timestamps whose target is a Spark local-time-zone timestamp
+        # (TimestampType or the nanosecond LTZ type); leave NTZ / NTZ-nanos targets naive.
         return pc.assume_timezone(a, timezone)
     if types.is_list(a.type):
         # Return the ListArray as-is if it contains no nested fields or timestamps
@@ -1574,7 +1578,22 @@ def _create_converter_from_pandas(
 
             return convert_struct
 
-        elif isinstance(dt, (TimestampType, TimestampLTZNanosType)):
+        elif isinstance(dt, TimestampLTZNanosType):
+            assert timezone is not None
+
+            def convert_timestamp_ltz_nanos(value: Any) -> Any:
+                if isinstance(value, datetime.datetime) and value.tzinfo is not None:
+                    ts = pd.Timestamp(value)
+                else:
+                    ts = pd.Timestamp(value).tz_localize(timezone)
+                # Keep the tz-aware pandas.Timestamp so a nested LTZ nanosecond value retains its
+                # sub-microsecond digits through the Arrow build (mirrors the nested NTZ path,
+                # which is identity). to_pydatetime() would truncate to microseconds.
+                return ts
+
+            return convert_timestamp_ltz_nanos
+
+        elif isinstance(dt, TimestampType):
             assert timezone is not None
 
             def convert_timestamp(value: Any) -> Any:

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -94,8 +94,6 @@ def _with_timestamp_nanos_precision(
     """Merge the nanosecond-precision tag into an Arrow field's metadata for a nanosecond
     timestamp type, mirroring the JVM's ``toPrecisionTaggedArrowField``; other types are
     unchanged."""
-    from pyspark.sql.types import AnyTimestampNanoType
-
     if isinstance(dt, AnyTimestampNanoType):
         merged = dict(metadata) if metadata else {}
         merged[timestamp_nanos_precision_key] = str(dt.precision).encode("utf-8")

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -25,17 +25,12 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     # SPARK-57462 follow-up: the nanosecond timestamp value path now works over Spark Connect,
     # whose data path goes through Arrow (to_arrow_type / ArrowTableToRowsConversion). The
-    # data-path tests -- test_timestamp_nanos_type, test_timestamp_nanos_type_preview_flag_off and
-    # test_timestamp_nanos_type_arrow_conversion -- are therefore inherited and run here. The
-    # nanosecond tests below exercise classic-only mechanisms that do not apply to Connect: the
-    # Py4J (useArrow=False) UDF path and the classic collect map-key guard in classic/dataframe.py.
+    # data-path tests -- and the collect map-key collision guard, now mirrored onto the Connect
+    # DataFrame -- are therefore inherited and run here. The nanosecond tests still skipped below
+    # exercise the classic-only Py4J (useArrow=False) UDF path, which does not apply to Connect.
     @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF path, not Connect.")
     def test_timestamp_nanos_type_python_udf(self):
         super().test_timestamp_nanos_type_python_udf()
-
-    @unittest.skip("SPARK-57462: classic-only collect map-key guard (classic/dataframe.py).")
-    def test_timestamp_nanos_type_map_key_collision(self):
-        super().test_timestamp_nanos_type_map_key_collision()
 
     @unittest.skip("SPARK-57462: classic-only Py4J UDF input path (useArrow=False), not Connect.")
     def test_timestamp_nanos_type_python_udf_input(self):

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -33,15 +33,15 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
     def test_timestamp_nanos_type_python_udf(self):
         super().test_timestamp_nanos_type_python_udf()
 
-    @unittest.skip("SPARK-57462: the collect map-key guard is classic-only (classic/dataframe.py).")
+    @unittest.skip("SPARK-57462: classic-only collect map-key guard (classic/dataframe.py).")
     def test_timestamp_nanos_type_map_key_collision(self):
         super().test_timestamp_nanos_type_map_key_collision()
 
-    @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF input path, not Connect.")
+    @unittest.skip("SPARK-57462: classic-only Py4J UDF input path (useArrow=False), not Connect.")
     def test_timestamp_nanos_type_python_udf_input(self):
         super().test_timestamp_nanos_type_python_udf_input()
 
-    @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF input path, not Connect.")
+    @unittest.skip("SPARK-57462: classic-only Py4J map-key UDF input path, not Connect.")
     def test_timestamp_nanos_type_map_key_python_udf_input(self):
         super().test_timestamp_nanos_type_map_key_python_udf_input()
 

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -55,12 +55,8 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
             df = self.spark.sql(
                 "SELECT CAST('2020-01-02 03:04:05.123456789' AS TIMESTAMP_NTZ(9)) AS ts"
             )
-            self.assertEqual(
-                datetime.datetime(2020, 1, 2, 3, 4, 5, 123456), df.collect()[0].ts
-            )
-            self.assertEqual(
-                pd.Timestamp("2020-01-02 03:04:05.123456789"), df.toPandas()["ts"][0]
-            )
+            self.assertEqual(datetime.datetime(2020, 1, 2, 3, 4, 5, 123456), df.collect()[0].ts)
+            self.assertEqual(pd.Timestamp("2020-01-02 03:04:05.123456789"), df.toPandas()["ts"][0])
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_apply_schema(self):

--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import datetime
 import unittest
 
 from pyspark.sql.tests.test_types import TypesTestsMixin
@@ -22,53 +23,44 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
-    # SPARK-57462: nanosecond timestamp types are not yet supported over Spark Connect, whose
-    # data path goes through Arrow (to_arrow_type / ArrowTableToRowsConversion). These inherited
-    # tests build or collect nanosecond data and are covered by the classic (non-Connect) suite;
-    # pending the Arrow follow-up they are skipped here.
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
-    def test_timestamp_nanos_type(self):
-        super().test_timestamp_nanos_type()
-
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
-    def test_timestamp_nanos_type_preview_flag_off(self):
-        super().test_timestamp_nanos_type_preview_flag_off()
-
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
+    # SPARK-57462 follow-up: the nanosecond timestamp value path now works over Spark Connect,
+    # whose data path goes through Arrow (to_arrow_type / ArrowTableToRowsConversion). The
+    # data-path tests -- test_timestamp_nanos_type, test_timestamp_nanos_type_preview_flag_off and
+    # test_timestamp_nanos_type_arrow_conversion -- are therefore inherited and run here. The
+    # nanosecond tests below exercise classic-only mechanisms that do not apply to Connect: the
+    # Py4J (useArrow=False) UDF path and the classic collect map-key guard in classic/dataframe.py.
+    @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF path, not Connect.")
     def test_timestamp_nanos_type_python_udf(self):
         super().test_timestamp_nanos_type_python_udf()
 
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
+    @unittest.skip("SPARK-57462: the collect map-key guard is classic-only (classic/dataframe.py).")
     def test_timestamp_nanos_type_map_key_collision(self):
         super().test_timestamp_nanos_type_map_key_collision()
 
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
+    @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF input path, not Connect.")
     def test_timestamp_nanos_type_python_udf_input(self):
         super().test_timestamp_nanos_type_python_udf_input()
 
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
+    @unittest.skip("SPARK-57462: uses the classic Py4J (useArrow=False) UDF input path, not Connect.")
     def test_timestamp_nanos_type_map_key_python_udf_input(self):
         super().test_timestamp_nanos_type_map_key_python_udf_input()
 
-    # The classic Arrow-rejection test asserts the classic PySparkTypeError / message parameters;
-    # Connect's data path rejects at a different layer, so it is covered by the Connect-specific
-    # test below rather than by inheriting the classic one.
-    @unittest.skip("SPARK-57462: nanosecond timestamp types are pending Connect/Arrow support.")
-    def test_timestamp_nanos_type_arrow_conversion_unsupported(self):
-        super().test_timestamp_nanos_type_arrow_conversion_unsupported()
+    def test_timestamp_nanos_type_connect_data_path(self):
+        # SPARK-57462 follow-up: the Spark Connect data path goes through Arrow, so collecting a
+        # nanosecond value now succeeds. collect() yields microsecond-resolution datetime.datetime
+        # (the Python boundary), while toPandas keeps full nanosecond precision (datetime64[ns]).
+        import pandas as pd
 
-    def test_timestamp_nanos_type_connect_data_path_unsupported(self):
-        # SPARK-57462: the Spark Connect data path goes through Arrow (to_arrow_type /
-        # ArrowTableToRowsConversion), so collecting a nanosecond value must raise the documented
-        # UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION rather than mis-handle it. Connect collect is
-        # otherwise safe only because to_table supplies the Spark schema; this locks that in.
         with self.sql_conf({"spark.sql.timestampNanosTypes.enabled": True}):
             df = self.spark.sql(
                 "SELECT CAST('2020-01-02 03:04:05.123456789' AS TIMESTAMP_NTZ(9)) AS ts"
             )
-            with self.assertRaises(Exception) as pe:
-                df.collect()
-            self.assertIn("UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION", str(pe.exception))
+            self.assertEqual(
+                datetime.datetime(2020, 1, 2, 3, 4, 5, 123456), df.collect()[0].ts
+            )
+            self.assertEqual(
+                pd.Timestamp("2020-01-02 03:04:05.123456789"), df.toPandas()["ts"][0]
+            )
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_apply_schema(self):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2396,6 +2396,36 @@ class TypesTestsMixin:
                 # ... and a full pandas -> Spark -> pandas round-trip is lossless.
                 self.assertEqual(pd.Timestamp(ns_string), df.toPandas()["ts"][0])
 
+    def test_timestamp_nanos_type_arrow_conversion_non_utc(self):
+        # SPARK-57462 follow-up: a naive Arrow timestamp[ns] column ingested as the timezone-aware
+        # LTZ nanosecond type under a non-UTC session time zone must be localized to that zone
+        # (assume_timezone), exactly like TimestampType -- otherwise it is silently read as UTC and
+        # the instant is off by the session offset. This exercises the createDataFrame from a
+        # pyarrow.Table path (createDataFrame from a pandas DataFrame uses a different, already
+        # covered converter). NTZ is the control: it stays a naive wall clock either way.
+        import pandas as pd
+        import pyarrow as pa
+
+        ns_string = "2020-06-15 12:30:00.123456789"
+        with self.sql_conf(
+            {
+                "spark.sql.timestampNanosTypes.enabled": True,
+                "spark.sql.session.timeZone": "America/New_York",
+                "spark.sql.execution.arrow.pyspark.enabled": True,
+            }
+        ):
+            table = pa.table({"ts": pa.array([pd.Timestamp(ns_string)], type=pa.timestamp("ns"))})
+            for nanos_type in (TimestampNTZNanosType(9), TimestampLTZNanosType(9)):
+                schema = StructType([StructField("ts", nanos_type)])
+                df = self.spark.createDataFrame(table, schema)
+                self.assertEqual(schema, df.schema)
+                # Rendered in the session time zone the wall clock is unchanged: NTZ carries no
+                # zone, and LTZ interpreted the naive input in the session zone (not UTC -- which
+                # would shift it by the session offset).
+                self.assertEqual(ns_string, df.select(F.col("ts").cast("string")).first()[0])
+                # Nanoseconds survive the Arrow round-trip.
+                self.assertEqual(789, df.toPandas()["ts"][0].nanosecond)
+
     def test_yearmonth_interval_type_constructor(self):
         self.assertEqual(YearMonthIntervalType().simpleString(), "interval year to month")
         self.assertEqual(

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2354,36 +2354,47 @@ class TypesTestsMixin:
             # SparkRuntimeException); assert that condition rather than any failure.
             self.assertIn("TIMESTAMP_NANOS_PYTHON_MAP_KEY", str(pe.exception))
 
-    def test_timestamp_nanos_type_arrow_conversion_unsupported(self):
-        # SPARK-57462: Arrow/pandas value conversion for the nanosecond timestamp types is a pending
-        # follow-up; until then the classic read (toPandas) and write (createDataFrame from a pandas
-        # DataFrame) paths must reject an explicit nanosecond schema deterministically, naming the
-        # offending leaf type, rather than silently mis-handle the value. (The Connect data path is
-        # asserted separately in the parity suite.)
+    def test_timestamp_nanos_type_arrow_conversion(self):
+        # SPARK-57462 follow-up: the Arrow / pandas value path carries the nanosecond timestamp
+        # types as an Arrow timestamp[ns], so -- unlike the microsecond-resolution
+        # datetime.datetime boundary used by collect() / Python UDFs -- DataFrame.toPandas and
+        # createDataFrame from a pandas DataFrame preserve full nanosecond precision (pandas
+        # datetime64[ns]). The session time zone is pinned so the timezone-aware LTZ value is
+        # deterministic.
         import pandas as pd
 
-        with self.sql_conf({"spark.sql.timestampNanosTypes.enabled": True}):
-            schema = StructType([StructField("ts", TimestampNTZNanosType(9))])
-            value = datetime.datetime(2020, 1, 2, 3, 4, 5, 123456)
+        with self.sql_conf(
+            {
+                "spark.sql.timestampNanosTypes.enabled": True,
+                "spark.sql.session.timeZone": "UTC",
+                "spark.sql.execution.arrow.pyspark.enabled": True,
+            }
+        ):
+            # Read path: toPandas keeps the sub-microsecond digits.
+            pdf = self.spark.sql(
+                "SELECT CAST('2020-01-02 03:04:05.123456789' AS TIMESTAMP_NTZ(9)) AS ts"
+            ).toPandas()
+            self.assertEqual("datetime64[ns]", str(pdf["ts"].dtype))
+            self.assertEqual(pd.Timestamp("2020-01-02 03:04:05.123456789"), pdf["ts"][0])
+            # The sub-microsecond digits survive; datetime.datetime could not carry them.
+            self.assertEqual(789, pdf["ts"][0].nanosecond)
 
-            # Read path: DataFrame.toPandas().
-            df = self.spark.createDataFrame([(value,)], schema)
-            with self.assertRaises(PySparkTypeError) as pe:
-                df.toPandas()
-            self.check_error(
-                exception=pe.exception,
-                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                messageParameters={"data_type": "TimestampNTZNanosType(9)"},
-            )
-
-            # Write path: createDataFrame from a pandas DataFrame with an explicit nanos schema.
-            with self.assertRaises(PySparkTypeError) as pe:
-                self.spark.createDataFrame(pd.DataFrame({"ts": [value]}), schema)
-            self.check_error(
-                exception=pe.exception,
-                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                messageParameters={"data_type": "TimestampNTZNanosType(9)"},
-            )
+            # Write path: a datetime64[ns] pandas column round-trips its nanoseconds back to Spark,
+            # for both the NTZ and the timezone-aware LTZ nanosecond types.
+            ns_string = "2020-01-02 03:04:05.123456789"
+            in_pdf = pd.DataFrame({"ts": pd.to_datetime(pd.Series([ns_string]))})
+            self.assertEqual("datetime64[ns]", str(in_pdf["ts"].dtype))
+            for nanos_type in (TimestampNTZNanosType(9), TimestampLTZNanosType(9)):
+                schema = StructType([StructField("ts", nanos_type)])
+                df = self.spark.createDataFrame(in_pdf, schema)
+                self.assertEqual(schema, df.schema)
+                # The stored value keeps all nine fractional digits (checked server-side).
+                self.assertEqual(
+                    ns_string,
+                    df.select(F.col("ts").cast("string")).first()[0],
+                )
+                # ... and a full pandas -> Spark -> pandas round-trip is lossless.
+                self.assertEqual(pd.Timestamp(ns_string), df.toPandas()["ts"][0])
 
     def test_yearmonth_interval_type_constructor(self):
         self.assertEqual(YearMonthIntervalType().simpleString(), "interval year to month")

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2277,8 +2277,9 @@ class TypesTestsMixin:
 
     def test_timestamp_nanos_type_python_udf(self):
         # SPARK-57462: a Python UDF with a nanosecond return type exercises makeFromJava
-        # (Python -> JVM). useArrow=False forces the classic Py4J path; the Arrow-based UDF path
-        # is not yet implemented for these types. The value round-trips at microsecond resolution.
+        # (Python -> JVM). useArrow=False forces the classic Py4J path; the Arrow-based UDF path is
+        # covered by test_timestamp_nanos_type_arrow_udf. The value round-trips at microsecond
+        # resolution.
         from pyspark.sql.functions import udf
 
         with self.sql_conf({"spark.sql.timestampNanosTypes.enabled": True}):
@@ -2425,6 +2426,76 @@ class TypesTestsMixin:
                 self.assertEqual(ns_string, df.select(F.col("ts").cast("string")).first()[0])
                 # Nanoseconds survive the Arrow round-trip.
                 self.assertEqual(789, df.toPandas()["ts"][0].nanosecond)
+
+    def test_timestamp_nanos_type_nested_arrow_conversion(self):
+        # SPARK-57462 follow-up: to_arrow_type carries the nanosecond precision tag on nested Arrow
+        # fields (array element, struct field, map value), so a nested nanosecond value ingested
+        # through the Arrow value path keeps its declared (non-9) precision rather than being
+        # silently reconstructed at a different precision (e.g. a dropped tag on a nested
+        # map<_, NTZNanos(7)> -> precision 9). Exercises createDataFrame from a pyarrow.Table -- the
+        # Spark Connect createDataFrame path -- for both the NTZ and the timezone-aware LTZ
+        # nanosecond types at a non-9 precision.
+        import pandas as pd
+        import pyarrow as pa
+
+        ns_string = "2020-01-02 03:04:05.123456789"
+        ts = pd.Timestamp(ns_string)
+        with self.sql_conf(
+            {
+                "spark.sql.timestampNanosTypes.enabled": True,
+                "spark.sql.session.timeZone": "UTC",
+                "spark.sql.execution.arrow.pyspark.enabled": True,
+            }
+        ):
+            for nanos_type in (TimestampNTZNanosType(7), TimestampLTZNanosType(8)):
+                arrow_ns = pa.timestamp("ns")
+                table = pa.table(
+                    {
+                        "arr": pa.array([[ts, ts]], type=pa.list_(arrow_ns)),
+                        "st": pa.array([{"a": ts}], type=pa.struct([("a", arrow_ns)])),
+                        "mp": pa.array([[("k", ts)]], type=pa.map_(pa.string(), arrow_ns)),
+                    }
+                )
+                schema = StructType(
+                    [
+                        StructField("arr", ArrayType(nanos_type)),
+                        StructField("st", StructType([StructField("a", nanos_type)])),
+                        StructField("mp", MapType(StringType(), nanos_type)),
+                    ]
+                )
+                df = self.spark.createDataFrame(table, schema)
+                # The declared non-9 precision survives on every nested field -- the precision tag
+                # is not dropped, so nothing (including the map value) is silently widened to
+                # precision 9.
+                self.assertEqual(schema, df.schema)
+                # The value round-trips to the declared nanosecond type without corruption. The
+                # first seven fractional digits are shared by precisions 7/8/9, so this holds
+                # regardless of how the reader floors the sub-microsecond remainder.
+                row = df.selectExpr(
+                    "cast(arr[0] as string) as a0",
+                    "cast(st.a as string) as sa",
+                    "cast(mp['k'] as string) as mv",
+                ).first()
+                self.assertTrue(row.a0.startswith("2020-01-02 03:04:05.1234567"), row.a0)
+                self.assertTrue(row.sa.startswith("2020-01-02 03:04:05.1234567"), row.sa)
+                self.assertTrue(row.mv.startswith("2020-01-02 03:04:05.1234567"), row.mv)
+
+    def test_timestamp_nanos_type_arrow_udf(self):
+        # SPARK-57462 follow-up: with the eager Arrow-conversion reject removed, an Arrow-optimized
+        # Python UDF (useArrow=True) can take and return the nanosecond timestamp types through the
+        # Arrow value path (the reject previously blocked returning nanoseconds from an Arrow UDF).
+        # A microsecond-precision value round-trips: the Arrow encoding carries nanoseconds, but the
+        # datetime.datetime Python boundary is microsecond-resolution.
+        from pyspark.sql.functions import udf
+
+        with self.sql_conf({"spark.sql.timestampNanosTypes.enabled": True}):
+            value = datetime.datetime(2021, 6, 7, 8, 9, 10, 123456)
+            df = self.spark.createDataFrame(
+                [(value,)], StructType([StructField("ts", TimestampNTZNanosType(9))])
+            )
+            identity_udf = udf(lambda x: x, returnType=TimestampNTZNanosType(9), useArrow=True)
+            row = df.select(identity_udf("ts").alias("out")).first()
+            self.assertEqual(value, row.out)
 
     def test_yearmonth_interval_type_constructor(self):
         self.assertEqual(YearMonthIntervalType().simpleString(), "interval year to month")

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -573,10 +573,12 @@ class TimestampNTZNanosType(AnyTimestampNanoType):
     with keys of this type that differ only below a microsecond would collapse to one entry, so
     that conversion raises rather than silently dropping an entry.
 
-    Arrow- and pandas-based conversion for these types -- :meth:`DataFrame.toPandas`,
-    :meth:`SparkSession.createDataFrame` from a pandas ``DataFrame``, Arrow-based UDFs, and the
-    Spark Connect data path -- is not yet supported and raises
-    ``UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION``; it is planned as a follow-up.
+    Arrow- and pandas-based conversion -- :meth:`DataFrame.toPandas`,
+    :meth:`SparkSession.createDataFrame` from a pandas ``DataFrame``, and the Spark Connect data
+    path -- carries the value as an Arrow ``timestamp[ns]`` and preserves full nanosecond
+    precision (pandas ``datetime64[ns]``). Because that Arrow encoding counts nanoseconds since
+    the epoch in a 64-bit integer, values outside the ``datetime64[ns]`` range (roughly the years
+    1677 to 2262) cannot be carried on this path.
 
     .. versionadded:: 4.4.0
     """
@@ -3080,34 +3082,6 @@ def _first_timestamp_nanos_map_key_type(dt: DataType) -> Optional["DataType"]:
         return None
     elif isinstance(dt, UserDefinedType):
         return _first_timestamp_nanos_map_key_type(dt.sqlType())
-    else:
-        return None
-
-
-def _first_timestamp_nanos_type(dt: DataType) -> Optional["DataType"]:
-    """Return the first nanosecond-capable timestamp type (depth-first) that ``dt`` is or contains,
-    or ``None`` if it contains none.
-
-    The Arrow / pandas / Connect value conversion for :class:`TimestampNTZNanosType` /
-    :class:`TimestampLTZNanosType` is not implemented yet (planned follow-up). Callers reject such a
-    schema up front rather than mis-handle the value; the returned leaf type feeds the error
-    message, consistent with :func:`~pyspark.sql.pandas.types.to_arrow_type`, which reports the
-    offending leaf. This is the "find the node" companion to the ``_has_type`` boolean check.
-    """
-    if isinstance(dt, AnyTimestampNanoType):
-        return dt
-    elif isinstance(dt, ArrayType):
-        return _first_timestamp_nanos_type(dt.elementType)
-    elif isinstance(dt, MapType):
-        return _first_timestamp_nanos_type(dt.keyType) or _first_timestamp_nanos_type(dt.valueType)
-    elif isinstance(dt, StructType):
-        for field in dt.fields:
-            found = _first_timestamp_nanos_type(field.dataType)
-            if found is not None:
-                return found
-        return None
-    elif isinstance(dt, UserDefinedType):
-        return _first_timestamp_nanos_type(dt.sqlType())
     else:
         return None
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -573,12 +573,14 @@ class TimestampNTZNanosType(AnyTimestampNanoType):
     with keys of this type that differ only below a microsecond would collapse to one entry, so
     that conversion raises rather than silently dropping an entry.
 
-    Arrow- and pandas-based conversion -- :meth:`DataFrame.toPandas`,
-    :meth:`SparkSession.createDataFrame` from a pandas ``DataFrame``, and the Spark Connect data
-    path -- carries the value as an Arrow ``timestamp[ns]`` and preserves full nanosecond
-    precision (pandas ``datetime64[ns]``). Because that Arrow encoding counts nanoseconds since
-    the epoch in a 64-bit integer, values outside the ``datetime64[ns]`` range (roughly the years
-    1677 to 2262) cannot be carried on this path.
+    Arrow-based conversion -- :meth:`DataFrame.toPandas` and
+    :meth:`SparkSession.createDataFrame` from a pandas ``DataFrame`` with Arrow enabled
+    (``spark.sql.execution.arrow.pyspark.enabled``), including the Spark Connect data path --
+    carries the value as an Arrow ``timestamp[ns]`` and preserves full nanosecond precision
+    (pandas ``datetime64[ns]``). Because that Arrow encoding counts nanoseconds since the epoch in
+    a 64-bit integer, values outside the ``datetime64[ns]`` range (roughly the years 1677 to 2262)
+    cannot be carried on this path. With Arrow disabled, :meth:`DataFrame.toPandas` falls back to
+    :meth:`DataFrame.collect` and, like it, truncates to microseconds.
 
     .. versionadded:: 4.4.0
     """

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -567,11 +567,13 @@ class TimestampNTZNanosType(AnyTimestampNanoType):
 
     ``datetime.datetime`` is microsecond-resolution, so values crossing the Python boundary as
     ``datetime.datetime`` -- :meth:`DataFrame.collect`, :meth:`DataFrame.toLocalIterator`, and
-    Python UDF arguments -- are truncated to microseconds, as are ``datetime.datetime`` values
-    supplied to :meth:`SparkSession.createDataFrame` from Python lists/rows. The value stored by
-    Spark keeps full precision; only this Python boundary is microsecond-resolution. A ``map``
-    with keys of this type that differ only below a microsecond would collapse to one entry, so
-    that conversion raises rather than silently dropping an entry.
+    classic (``useArrow=False``) Python UDF arguments -- are truncated to microseconds, as are
+    ``datetime.datetime`` values supplied to :meth:`SparkSession.createDataFrame` from Python
+    lists/rows. Arrow-optimized Python UDFs (``useArrow=True``) instead carry the value on the
+    Arrow path described below. The value stored by Spark keeps full precision; only this Python
+    boundary is microsecond-resolution. A ``map`` with keys of this type that differ only below a
+    microsecond would collapse to one entry, so that conversion raises rather than silently
+    dropping an entry.
 
     Arrow-based conversion -- :meth:`DataFrame.toPandas` and
     :meth:`SparkSession.createDataFrame` from a pandas ``DataFrame`` with Arrow enabled


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-57462, which added the PySpark `TimestampNTZNanosType` / `TimestampLTZNanosType` classes and the classic (Py4J) value path but deliberately deferred the Arrow / pandas value path: `to_arrow_type` rejected these types, and `DataFrame.toPandas`, `SparkSession.createDataFrame` from a pandas `DataFrame`, and the whole Spark Connect data path raised `UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION`.

This change wires the two types through the Python Arrow path. The JVM side already supports them (`ArrowUtils` maps them to an Arrow `Timestamp(NANOSECOND)` field plus a `SPARK::timestampNanos::precision` metadata tag, with native `ArrowWriter` writers and `ArrowColumnVector` accessors).

The values are carried as an Arrow `timestamp[ns]` (a 64-bit count of nanoseconds since the epoch), so full nanosecond precision is preserved (pandas `datetime64[ns]`); values outside the `datetime64[ns]` range are out of range for this path, consistent with the JVM `ArrowWriter`, which throws on overflow.

### Why are the changes needed?

Without this, a nanosecond-typed column cannot be read into pandas (`toPandas`) or written from a pandas `DataFrame`, and because the Spark Connect data path is entirely Arrow-based, cannot be collected at all over Spark Connect.

### Does this PR introduce _any_ user-facing change?

Yes, when the `spark.sql.timestampNanosTypes.enabled` preview flag is on (it is off by default). `DataFrame.toPandas`, `SparkSession.createDataFrame` from a pandas `DataFrame`, and the Spark Connect data path now accept `TimestampNTZNanosType` / `TimestampLTZNanosType` and preserve full nanosecond precision, where they previously raised `UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION`.

### How was this patch tested?

- Rewrote the classic `test_timestamp_nanos_type_arrow_conversion_unsupported` test into a positive round-trip `test_timestamp_nanos_type_arrow_conversion` that asserts a value with nine fractional-second digits survives `toPandas` (pandas `Timestamp.nanosecond == 789`) and a pandas -> `createDataFrame` -> Spark -> pandas round-trip, for both the NTZ and LTZ types.
- Un-skipped the now-supported nanosecond data-path tests in the Spark Connect parity suite (`connect/test_parity_types.py`) and replaced the "unsupported" Connect test with a positive `test_timestamp_nanos_type_connect_data_path`; the classic-only Py4J-UDF and map-key tests remain skipped there.
- Ran the new test against a live `SparkSession` and confirmed it passes, and confirmed the existing `TimestampType` / `TimestampNTZType` / `TimeType` Arrow round-trips are unchanged.

### Was this patch authored or co-authored using generative AI tooling?

Co-Authored-By: Claude Opus 4.8
