### PR TITLE
[SPARK-59403][CORE] Fix remote fetch of empty deserialized RDD blocks

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1339,11 +1339,13 @@ private[spark] class BlockManager(
       None
     } else {
       val locationsAndStatus = locationsAndStatusOption.get
-      val blockSize = locationsAndStatus.status.diskSize.max(locationsAndStatus.status.memSize)
 
-      locationsAndStatus.localDirs.flatMap { localDirs =>
+      locationsAndStatus.locations.collectFirst {
+        case BlockManagerMessages.BlockLocationAndStatus(_, Some(status), Some(localDirs)) =>
+          (status, localDirs)
+      }.flatMap { case (status, localDirs) =>
         val blockDataOption =
-          readDiskBlockFromSameHostExecutor(blockId, localDirs, locationsAndStatus.status.diskSize)
+          readDiskBlockFromSameHostExecutor(blockId, localDirs, status.diskSize)
         val res = blockDataOption.flatMap { blockData =>
           try {
             Some(bufferTransformer(blockData))
@@ -1358,7 +1360,7 @@ private[spark] class BlockManager(
           log"${MDC(STATUS, if (res.isDefined) "successful." else "failed.")}")
         res
       }.orElse {
-        fetchRemoteManagedBuffer(blockId, blockSize, locationsAndStatus).map(bufferTransformer)
+        fetchRemoteManagedBuffer(blockId, locationsAndStatus).map(bufferTransformer)
       }
     }
   }
@@ -1394,20 +1396,20 @@ private[spark] class BlockManager(
    */
   private def fetchRemoteManagedBuffer(
       blockId: BlockId,
-      blockSize: Long,
       locationsAndStatus: BlockManagerMessages.BlockLocationsAndStatus): Option[ManagedBuffer] = {
     // If the block size is above the threshold, we should pass our FileManger to
     // BlockTransferService, which will leverage it to spill the block; if not, then passed-in
     // null value means the block will be persisted in memory.
-    val tempFileManager = if (blockSize > maxRemoteBlockToMem) {
+    val tempFileManager = if (locationsAndStatus.blockSize > maxRemoteBlockToMem) {
       remoteBlockTempFileManager
     } else {
       null
     }
     var runningFailureCount = 0
     var totalFailureCount = 0
-    val locations = sortLocations(locationsAndStatus.locations)
+    val locations = sortLocations(locationsAndStatus.locations.map(_.blockManagerId))
     val maxFetchFailures = locations.size
+    var currentLocationsAndStatus = Option(locationsAndStatus)
     var locationIterator = locations.iterator
     while (locationIterator.hasNext) {
       val loc = locationIterator.next()
@@ -1415,7 +1417,24 @@ private[spark] class BlockManager(
       val data = try {
         val buf = blockTransferService.fetchBlockSync(loc.host, loc.port, loc.executorId,
           blockId.toString, tempFileManager)
-        if (blockSize > 0 && buf.size() == 0) {
+        // For deserialized blocks, memSize is the estimated size of the JVM objects rather than
+        // the size of their serialized representation. An empty iterator can occupy memory while
+        // serializing to an empty buffer, so this size cannot be used to reject an empty response.
+        // Accept an empty response only from a location whose own status reports a nonempty
+        // deserialized memory block.
+        val locationStatus = currentLocationsAndStatus
+          .flatMap(_.locations.find(_.blockManagerId == loc))
+          .flatMap(_.status)
+        val canServeEmptyDeserializedMemoryBlock = locationStatus.exists { status =>
+          status.storageLevel.useMemory &&
+            status.storageLevel.deserialized &&
+            status.memSize > 0
+        }
+        // A status-less location has no evidence that an empty response is valid.
+        if (!canServeEmptyDeserializedMemoryBlock && locationStatus.forall { status =>
+          status.diskSize.max(status.memSize) > 0
+        } &&
+            buf.size() == 0) {
           throw SparkException.internalError("Empty buffer received for non empty block " +
             s"when fetching remote block $blockId from $loc", category = "STORAGE")
         }
@@ -1443,9 +1462,14 @@ private[spark] class BlockManager(
           // If there is a large number of executors then locations list can contain a
           // large number of stale entries causing a large number of retries that may
           // take a significant amount of time. To get rid of these stale entries
-          // we refresh the block locations after a certain number of fetch failures
+          // we refresh the block locations and status after a certain number of fetch failures.
           if (runningFailureCount >= maxFailuresBeforeLocationRefresh) {
-            locationIterator = sortLocations(master.getLocations(blockId)).iterator
+            currentLocationsAndStatus =
+              master.getLocationsAndStatus(blockId, blockManagerId.host)
+            locationIterator = sortLocations(
+              currentLocationsAndStatus
+                .map(_.locations.map(_.blockManagerId))
+                .getOrElse(master.getLocations(blockId))).iterator
             logDebug(s"Refreshed locations from the driver " +
               s"after ${runningFailureCount} fetch failures.")
             runningFailureCount = 0

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMasterEndpoint.scala
@@ -1019,6 +1019,15 @@ class BlockManagerMasterEndpoint(
       blockId: BlockId,
       requesterHost: String): Option[BlockLocationsAndStatus] = {
     val allLocations = Option(blockLocations.get(blockId)).map(_.toSeq).getOrElse(Seq.empty)
+    val statusesByLocation = allLocations.map { bmId =>
+      val status = if (externalShuffleServiceRddFetchEnabled && blockId.isRDD &&
+          bmId.port == externalShuffleServicePort) {
+        blockStatusByShuffleService.get(bmId).flatMap(_.get(blockId))
+      } else {
+        blockManagerInfo.get(bmId).flatMap(_.getStatus(blockId))
+      }
+      bmId -> status
+    }.toMap
     val blockStatusWithBlockManagerId: Option[(BlockStatus, BlockManagerId)] =
       (if (externalShuffleServiceRddFetchEnabled && blockId.isRDD) {
         // If fetching disk persisted RDD from the external shuffle service is enabled then first
@@ -1030,16 +1039,14 @@ class BlockManagerMasterEndpoint(
         val location = hostLocalLocations
           .orElse(allLocations.find(_.port == externalShuffleServicePort))
         location
-          .flatMap(blockStatusByShuffleService.get(_).flatMap(_.get(blockId)))
+          .flatMap(statusesByLocation.get(_).flatten)
           .zip(location)
       } else {
         // trying to find it in the executors running on the same host and persisted on the disk
         // Implementation detail: using flatMap on iterators makes the transformation lazy.
         allLocations.filter(_.host == requesterHost).iterator
           .flatMap { bmId =>
-            blockManagerInfo.get(bmId).flatMap { blockInfo =>
-              blockInfo.getStatus(blockId).map((_, bmId))
-            }
+            statusesByLocation.get(bmId).flatten.map((_, bmId))
           }
           .find(_._1.storageLevel.useDisk)
       })
@@ -1047,19 +1054,21 @@ class BlockManagerMasterEndpoint(
         // if the block cannot be found in the same host as a disk stored block then extend the
         // search to all active (not killed) executors and to all storage levels
         val location = allLocations.headOption
-        location.flatMap(blockManagerInfo.get(_)).flatMap(_.getStatus(blockId)).zip(location)
+        location.flatMap(statusesByLocation.get(_).flatten).zip(location)
       }
     logDebug(s"Identified block: $blockStatusWithBlockManagerId")
     blockStatusWithBlockManagerId
       .map { case (blockStatus: BlockStatus, bmId: BlockManagerId) =>
-        if (bmId.host == requesterHost && blockStatus.storageLevel.useDisk) {
-          BlockLocationsAndStatus(
-            allLocations,
-            blockStatus,
-            Option(executorIdToLocalDirs.getIfPresent(bmId.executorId)))
-        } else {
-          BlockLocationsAndStatus(allLocations, blockStatus, None)
+        val locations = allLocations.map { location =>
+          val localDirs = if (location == bmId && location.host == requesterHost &&
+              blockStatus.storageLevel.useDisk) {
+            Option(executorIdToLocalDirs.getIfPresent(location.executorId))
+          } else {
+            None
+          }
+          BlockLocationAndStatus(location, statusesByLocation(location), localDirs)
         }
+        BlockLocationsAndStatus(locations, blockStatus.diskSize.max(blockStatus.memSize))
       }
       .orElse(None)
   }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerMessages.scala
@@ -131,16 +131,25 @@ private[spark] object BlockManagerMessages {
     extends ToBlockManagerMaster
 
   /**
+   * A block location and its status.
+   *
+   * @param localDirs if the block is persisted to disk on the same host as the requester executor,
+   *                  the cached data will be in a file in one of these directories.
+   */
+  case class BlockLocationAndStatus(
+      blockManagerId: BlockManagerId,
+      status: Option[BlockStatus],
+      localDirs: Option[Array[String]])
+
+  /**
    * The response message of `GetLocationsAndStatus` request.
    *
-   * @param localDirs if it is persisted-to-disk on the same host as the requester executor is
-   *                  running on then localDirs will be Some and the cached data will be in a file
-   *                  in one of those dirs, otherwise it is None.
+   * @param blockSize the size of a representative block replica, used to decide whether to spill
+   *                  a remote fetch to disk.
    */
   case class BlockLocationsAndStatus(
-      locations: Seq[BlockManagerId],
-      status: BlockStatus,
-      localDirs: Option[Array[String]]) {
+      locations: Seq[BlockLocationAndStatus],
+      blockSize: Long) {
     assert(locations.nonEmpty)
   }
 

--- a/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExternalShuffleServiceSuite.scala
@@ -181,18 +181,18 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with Eventually {
         val locationStatusForLocalHost =
           sc.env.blockManager.master.getLocationsAndStatus(blockId, Utils.localHostName())
         assert(locationStatusForLocalHost.isDefined)
-        assert(locationStatusForLocalHost.get.localDirs.isDefined)
-        assert(locationStatusForLocalHost.get.locations.head.executorId == "0")
-        assert(locationStatusForLocalHost.get.locations.head.host == Utils.localHostName())
+        assert(locationStatusForLocalHost.get.locations.head.localDirs.isDefined)
+        assert(locationStatusForLocalHost.get.locations.head.blockManagerId.executorId == "0")
+        assert(locationStatusForLocalHost.get.locations.head.blockManagerId.host == Utils.localHostName())
       }
 
       eventually(timeout(2.seconds), interval(100.milliseconds)) {
         val locationStatusForRemoteHost =
           sc.env.blockManager.master.getLocationsAndStatus(blockId, "<invalid-host>")
         assert(locationStatusForRemoteHost.isDefined)
-        assert(locationStatusForRemoteHost.get.localDirs.isEmpty)
-        assert(locationStatusForRemoteHost.get.locations.head.executorId == "0")
-        assert(locationStatusForRemoteHost.get.locations.head.host == Utils.localHostName())
+        assert(locationStatusForRemoteHost.get.locations.head.localDirs.isEmpty)
+        assert(locationStatusForRemoteHost.get.locations.head.blockManagerId.executorId == "0")
+        assert(locationStatusForRemoteHost.get.locations.head.blockManagerId.host == Utils.localHostName())
       }
 
       assert(sc.env.blockManager.getRemoteValues(blockId).isDefined)
@@ -202,9 +202,9 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with Eventually {
         val locStatusForMemBroadcast =
           sc.env.blockManager.master.getLocationsAndStatus(broadcastBlockId, Utils.localHostName())
         assert(locStatusForMemBroadcast.isDefined)
-        assert(locStatusForMemBroadcast.get.localDirs.isEmpty)
-        assert(locStatusForMemBroadcast.get.locations.head.executorId == "driver")
-        assert(locStatusForMemBroadcast.get.locations.head.host == Utils.localHostName())
+        assert(locStatusForMemBroadcast.get.locations.head.localDirs.isEmpty)
+        assert(locStatusForMemBroadcast.get.locations.head.blockManagerId.executorId == "driver")
+        assert(locStatusForMemBroadcast.get.locations.head.blockManagerId.host == Utils.localHostName())
       }
 
       val byteBuffer = ByteBuffer.wrap(Array[Byte](7))
@@ -216,18 +216,19 @@ class ExternalShuffleServiceSuite extends ShuffleSuite with Eventually {
         val locStatusForDiskBroadcast =
           sc.env.blockManager.master.getLocationsAndStatus(diskBroadcastId, Utils.localHostName())
         assert(locStatusForDiskBroadcast.isDefined)
-        assert(locStatusForDiskBroadcast.get.localDirs.isDefined)
-        assert(locStatusForDiskBroadcast.get.locations.head.executorId == "driver")
-        assert(locStatusForDiskBroadcast.get.locations.head.host == Utils.localHostName())
+        assert(locStatusForDiskBroadcast.get.locations.head.localDirs.isDefined)
+        assert(locStatusForDiskBroadcast.get.locations.head.blockManagerId.executorId == "driver")
+        assert(locStatusForDiskBroadcast.get.locations.head.blockManagerId.host == Utils.localHostName())
       }
 
       eventually(timeout(2.seconds), interval(100.milliseconds)) {
         val locStatusForDiskBroadcastForFetch =
           sc.env.blockManager.master.getLocationsAndStatus(diskBroadcastId, "<invalid-host>")
         assert(locStatusForDiskBroadcastForFetch.isDefined)
-        assert(locStatusForDiskBroadcastForFetch.get.localDirs.isEmpty)
-        assert(locStatusForDiskBroadcastForFetch.get.locations.head.executorId == "driver")
-        assert(locStatusForDiskBroadcastForFetch.get.locations.head.host == Utils.localHostName())
+        assert(locStatusForDiskBroadcastForFetch.get.locations.head.localDirs.isEmpty)
+        assert(locStatusForDiskBroadcastForFetch.get.locations.head.blockManagerId.executorId == "driver")
+        assert(locStatusForDiskBroadcastForFetch.get.locations.head.blockManagerId.host ==
+          Utils.localHostName())
       }
 
       // test unpersist: as executors are killed the blocks will be removed via the shuffle service

--- a/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/BlockManagerSuite.scala
@@ -99,6 +99,18 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
   implicit def StringToBlockId(value: String): BlockId = new TestBlockId(value)
   def rdd(rddId: Int, splitId: Int): RDDBlockId = RDDBlockId(rddId, splitId)
 
+  private def blockLocationsAndStatus(
+      locations: Seq[BlockManagerId],
+      statuses: Map[BlockManagerId, BlockStatus]): BlockLocationsAndStatus = {
+    val blockSize = statuses.valuesIterator
+      .map(status => status.diskSize.max(status.memSize))
+      .maxOption
+      .getOrElse(0L)
+    BlockLocationsAndStatus(
+      locations.map(location => BlockLocationAndStatus(location, statuses.get(location), None)),
+      blockSize)
+  }
+
   private def init(sparkConf: SparkConf): Unit = {
     sparkConf
       .set("spark.app.id", "test")
@@ -496,6 +508,14 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     store1.putSingle(broadcastId, value, StorageLevel.MEMORY_ONLY, tellMaster = true)
     store2.putSingle(broadcastId, value, StorageLevel.MEMORY_ONLY, tellMaster = true)
     store3.putSingle(broadcastId, value, StorageLevel.DISK_ONLY, tellMaster = true)
+    val locationsAndStatus =
+      master.getLocationsAndStatus(broadcastId, store4.blockManagerId.host).get
+    val statusByLocation = locationsAndStatus.locations.map { locationAndStatus =>
+      locationAndStatus.blockManagerId -> locationAndStatus.status
+    }.toMap
+    assert(statusByLocation(store1.blockManagerId).exists(_.storageLevel == StorageLevel.MEMORY_ONLY))
+    assert(statusByLocation(store2.blockManagerId).exists(_.storageLevel == StorageLevel.MEMORY_ONLY))
+    assert(statusByLocation(store3.blockManagerId).exists(_.storageLevel == StorageLevel.DISK_ONLY))
     store4.getRemoteBytes(broadcastId) match {
       case Some(block) =>
         assert(block.size > 0, "The block size must be greater than 0 for a nonempty block!")
@@ -1832,7 +1852,9 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     val blockManagerIds = (0 to maxFailuresBeforeLocationRefresh)
       .map { i => BlockManagerId(s"id-$i", s"host-$i", i + 1) }
     when(mockBlockManagerMaster.getLocationsAndStatus(mc.any[BlockId], mc.any[String])).thenReturn(
-      Option(BlockLocationsAndStatus(blockManagerIds, BlockStatus.empty, None)))
+      Option(blockLocationsAndStatus(
+        blockManagerIds, blockManagerIds.map(_ -> BlockStatus.empty).toMap)),
+      None)
     when(mockBlockManagerMaster.getLocations(mc.any[BlockId])).thenReturn(
       blockManagerIds)
 
@@ -1841,7 +1863,125 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     val block = store.getRemoteBytes("item")
       .asInstanceOf[Option[ByteBuffer]]
     assert(block.isDefined)
-    verify(mockBlockManagerMaster, times(1))
+    verify(mockBlockManagerMaster, times(2))
+      .getLocationsAndStatus("item", "MockBlockTransferServiceHost")
+    verify(mockBlockManagerMaster, times(1)).getLocations("item")
+  }
+
+  test("refresh status when fetching an empty deserialized memory block") {
+    conf.set(BLOCK_FAILURES_BEFORE_LOCATION_REFRESH.key, "1")
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val staleExecutors = Seq(
+      BlockManagerId("stale-1", "host-1", 1),
+      BlockManagerId("stale-2", "host-2", 2))
+    val healthyExecutor = BlockManagerId("healthy", "host-3", 3)
+    val initialStatus = BlockStatus(StorageLevel.DISK_ONLY, memSize = 0L, diskSize = 1L)
+    val refreshedStatus = BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(staleExecutors, staleExecutors.map(_ -> initialStatus).toMap)),
+      Option(blockLocationsAndStatus(Seq(healthyExecutor), Map(healthyExecutor -> refreshedStatus))))
+    when(mockBlockManagerMaster.getLocations(mc.any[BlockId])).thenReturn(Seq(healthyExecutor))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        if (execId == healthyExecutor.executorId) {
+          new NioManagedBuffer(ByteBuffer.allocate(0))
+        } else {
+          throw new RuntimeException("simulated stale executor fetch failure")
+        }
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isDefined)
+    verify(mockBlockManagerMaster, times(2))
+      .getLocationsAndStatus("item", "MockBlockTransferServiceHost")
+    verify(mockBlockManagerMaster, never()).getLocations("item")
+  }
+
+  test("use refreshed block size when validating an empty response") {
+    conf.set(BLOCK_FAILURES_BEFORE_LOCATION_REFRESH.key, "1")
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val staleExecutors = Seq(
+      BlockManagerId("stale-1", "host-1", 1),
+      BlockManagerId("stale-2", "host-2", 2))
+    val refreshedExecutor = BlockManagerId("refreshed", "host-3", 3)
+    val refreshedStatus = BlockStatus(StorageLevel.DISK_ONLY, memSize = 0L, diskSize = 1L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(
+        staleExecutors, staleExecutors.map(_ -> BlockStatus.empty).toMap)),
+      Option(blockLocationsAndStatus(
+        Seq(refreshedExecutor), Map(refreshedExecutor -> refreshedStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        if (execId == refreshedExecutor.executorId) {
+          new NioManagedBuffer(ByteBuffer.allocate(0))
+        } else {
+          throw new RuntimeException("simulated stale executor fetch failure")
+        }
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isEmpty)
+  }
+
+  test("reject empty response when refreshed block status is unavailable") {
+    conf.set(BLOCK_FAILURES_BEFORE_LOCATION_REFRESH.key, "1")
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val statusExecutor = BlockManagerId("status", "host-1", 1)
+    val staleExecutor = BlockManagerId("stale", "host-2", 2)
+    val deserializedMemoryStatus =
+      BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(
+        Seq(statusExecutor, staleExecutor), Map(statusExecutor -> deserializedMemoryStatus))),
+      None)
+    when(mockBlockManagerMaster.getLocations(mc.any[BlockId])).thenReturn(Seq(statusExecutor))
+    val blockFetcher = new MockBlockTransferService(0) {
+      private var attempts = 0
+
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        attempts += 1
+        if (attempts == 1) {
+          throw new RuntimeException("simulated stale executor fetch failure")
+        }
+        new NioManagedBuffer(ByteBuffer.allocate(0))
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isEmpty)
+    verify(mockBlockManagerMaster, times(2))
       .getLocationsAndStatus("item", "MockBlockTransferServiceHost")
     verify(mockBlockManagerMaster, times(1)).getLocations("item")
   }
@@ -1903,6 +2043,174 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     store.putSingle("item", "value", StorageLevel.DISK_ONLY, tellMaster = true)
     assert(master.getLocations("item").nonEmpty)
     assert(store2.getRemoteBytes("item").isEmpty)
+  }
+
+  test("allow empty executor response for deserialized memory block") {
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val executor = BlockManagerId("executor1", "localhost", 8000)
+    val deserializedMemoryStatus =
+      BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(Seq(executor), Map(executor -> deserializedMemoryStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        new NioManagedBuffer(ByteBuffer.allocate(0))
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor2",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    val remoteBytes = store.getRemoteBytes(rdd(0, 0))
+    assert(remoteBytes.isDefined)
+    assert(remoteBytes.get.size === 0)
+  }
+
+  test("allow empty executor response when its port matches a disabled shuffle service") {
+    conf.set(SHUFFLE_SERVICE_ENABLED.key, "false")
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val externalShuffleServicePort = StorageUtils.externalShuffleServicePort(conf)
+    val executor = BlockManagerId("executor1", "localhost", externalShuffleServicePort)
+    val deserializedMemoryStatus =
+      BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(Seq(executor), Map(executor -> deserializedMemoryStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        new NioManagedBuffer(ByteBuffer.allocate(0))
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor2",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes(rdd(0, 0)).isDefined)
+  }
+
+  test("reject empty shuffle-service response when its status includes memory") {
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val externalShuffleServicePort = StorageUtils.externalShuffleServicePort(conf)
+    val executor = BlockManagerId("executor1", "localhost", 8000)
+    val shuffleService = BlockManagerId("executor2", "localhost", externalShuffleServicePort)
+    // The external shuffle service records the block's storage level, which can include memory,
+    // but its status has no in-memory bytes because it only serves on-disk data.
+    val shuffleServiceStatus =
+      BlockStatus(StorageLevel.MEMORY_AND_DISK, memSize = 0L, diskSize = 1L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(
+        Seq(executor, shuffleService), Map(shuffleService -> shuffleServiceStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        if (port == externalShuffleServicePort) {
+          new NioManagedBuffer(ByteBuffer.allocate(0))
+        } else {
+          throw new RuntimeException("simulated executor fetch failure")
+        }
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor3",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isEmpty)
+  }
+
+  test("allow empty response from another deserialized memory replica") {
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val deserializedMemoryExecutor =
+      BlockManagerId("executor1", "MockBlockTransferServiceHost", 8000)
+    val statusExecutor = BlockManagerId("executor2", "other-host", 8000)
+    val deserializedMemoryStatus =
+      BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(
+        Seq(deserializedMemoryExecutor, statusExecutor),
+        Map(
+          deserializedMemoryExecutor -> deserializedMemoryStatus,
+          statusExecutor -> deserializedMemoryStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        if (execId == deserializedMemoryExecutor.executorId) {
+          new NioManagedBuffer(ByteBuffer.allocate(0))
+        } else {
+          throw new RuntimeException("simulated status executor fetch failure")
+        }
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor3",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isDefined)
+  }
+
+  test("reject empty response from a disk replica when another replica is deserialized memory") {
+    val mockBlockManagerMaster = mock(classOf[BlockManagerMaster])
+    val diskExecutor = BlockManagerId("executor1", "MockBlockTransferServiceHost", 8000)
+    val deserializedMemoryExecutor = BlockManagerId("executor2", "other-host", 8000)
+    val diskStatus = BlockStatus(StorageLevel.DISK_ONLY, memSize = 0L, diskSize = 1L)
+    val deserializedMemoryStatus =
+      BlockStatus(StorageLevel.MEMORY_ONLY, memSize = 1L, diskSize = 0L)
+    when(mockBlockManagerMaster.getLocationsAndStatus(
+      mc.any[BlockId], mc.any[String])).thenReturn(
+      Option(blockLocationsAndStatus(
+        Seq(diskExecutor, deserializedMemoryExecutor),
+        Map(
+          diskExecutor -> diskStatus,
+          deserializedMemoryExecutor -> deserializedMemoryStatus))))
+    val blockFetcher = new MockBlockTransferService(0) {
+      override def fetchBlockSync(
+          host: String,
+          port: Int,
+          execId: String,
+          blockId: String,
+          tempFileManager: DownloadFileManager): ManagedBuffer = {
+        if (execId == diskExecutor.executorId) {
+          new NioManagedBuffer(ByteBuffer.allocate(0))
+        } else {
+          throw new RuntimeException("simulated deserialized-memory executor fetch failure")
+        }
+      }
+    }
+    val store = makeBlockManager(
+      8000,
+      "executor3",
+      mockBlockManagerMaster,
+      transferService = Some(blockFetcher))
+
+    assert(store.getRemoteBytes("item").isEmpty)
   }
 
   test("test sorting of block locations") {
@@ -2022,7 +2330,7 @@ class BlockManagerSuite extends SparkFunSuite with Matchers with PrivateMethodTe
     val blockStatus = BlockStatus(StorageLevel.DISK_ONLY, 0L, 2000L)
 
     when(mockBlockManagerMaster.getLocationsAndStatus(mc.any[BlockId], mc.any[String])).thenReturn(
-      Option(BlockLocationsAndStatus(blockLocations, blockStatus, None)))
+      Option(blockLocationsAndStatus(blockLocations, Map(blockLocations.head -> blockStatus))))
     when(mockBlockManagerMaster.getLocations(mc.any[BlockId])).thenReturn(blockLocations)
 
     val store = makeBlockManager(8000, "executor1", mockBlockManagerMaster,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR returns status metadata for every candidate block location in
`BlockLocationsAndStatus`, rather than returning one representative
`BlockStatus` for all locations.

`BlockManager` now accepts an empty remote response only when the fetched
location itself reports a nonempty deserialized in-memory block. Empty
responses from disk-backed replicas, external shuffle service replicas, and
locations without status metadata continue to be treated as fetch failures.

The representative block size is retained for the existing remote-fetch spill
decision. The local disk directories are associated with their corresponding
location. When block locations are refreshed after fetch failures, Spark also
refreshes the per-location status metadata; a status-less fallback remains
fail-closed for empty responses.

The PR adds regression tests for valid empty deserialized-memory responses,
another deserialized-memory replica, disk and external shuffle service
responses, missing status metadata, and refreshed locations.

### Why are the changes needed?

For deserialized in-memory blocks, `memSize` is an estimated size of JVM
objects, not the size of the serialized data sent over the network. Therefore,
an empty iterator can have a positive `memSize` while its serialized response
is empty.

Previously, every empty response for a positive representative block size was
interpreted as a failed fetch. Allowing empty responses based only on that
representative status would be unsafe because the fetched replica can have a
different storage level. This PR evaluates the status of the actual fetched
location, allowing the valid deserialized-memory case while preserving failure
detection for disk replicas, external shuffle services, and unknown locations.

### Does this PR introduce _any_ user-facing change?

Yes. Remote reads of affected empty deserialized RDD cache blocks can now
succeed instead of being incorrectly reported as unavailable. There are no
public API or configuration changes.

### How was this patch tested?

```bash
build/sbt 'core/testOnly org.apache.spark.storage.BlockManagerSuite'
build/sbt 'core/testOnly org.apache.spark.ExternalShuffleServiceSuite'
```
The suites completed successfully with 138 and 25 tests passed, respectively.

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex