### PR TITLE
[SPARK-59406][UI] Fix UI display on weird custom log names

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -94,6 +94,7 @@ function getTimeZone() {
  * the scheme. */
 function isHttpOrRelativeUrl(url) {
   if (typeof url !== 'string') return false;
+  /* eslint-disable-next-line no-control-regex */
   var normalized = url.replace(/[\u0000-\u0020]/g, '').toLowerCase();
   return /^https?:\/\//.test(normalized) || !/^[a-z][a-z0-9+.-]*:/.test(normalized);
 }

--- a/core/src/main/resources/org/apache/spark/ui/static/utils.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/utils.js
@@ -88,12 +88,27 @@ function getTimeZone() {
   }
 }
 
+/* Custom log URLs are rendered as links only when they are http(s) or relative
+ * URLs; anything else is shown as plain text. Browsers strip ASCII whitespace
+ * and control characters when parsing URLs, so remove them before checking
+ * the scheme. */
+function isHttpOrRelativeUrl(url) {
+  if (typeof url !== 'string') return false;
+  var normalized = url.replace(/[\u0000-\u0020]/g, '').toLowerCase();
+  return /^https?:\/\//.test(normalized) || !/^[a-z][a-z0-9+.-]*:/.test(normalized);
+}
+
 function formatLogsCells(execLogs, type) {
   if (type !== 'display') return Object.keys(execLogs);
   if (!execLogs) return;
   var result = '';
   $.each(execLogs, function (logName, logUrl) {
-    result += '<div><a href=' + logUrl + '>' + logName + '</a></div>'
+    // Custom log names and URLs can contain markup characters.
+    if (isHttpOrRelativeUrl(logUrl)) {
+      result += '<div><a href="' + escapeHtml(logUrl) + '">' + escapeHtml(logName) + '</a></div>'
+    } else {
+      result += '<div>' + escapeHtml(logName) + '</div>'
+    }
   });
   return result;
 }

--- a/ui-test/tests/utils.test.js
+++ b/ui-test/tests/utils.test.js
@@ -16,6 +16,7 @@
  */
 
 
+import '../../core/src/main/resources/org/apache/spark/ui/static/jquery.min.js';
 import * as utils from '../../core/src/main/resources/org/apache/spark/ui/static/utils.js';
 
 test('ConvertDurationString', function () {
@@ -87,4 +88,25 @@ test('errorMessageCell escapes HTML in error messages', function () {
   const multiLine = utils.errorMessageCell('boom\n' + payload);
   expect(multiLine).not.toContain(payload);
   expect(multiLine).toContain('&lt;img src=x onerror=alert(document.domain)&gt;');
+});
+
+test('formatLogsCells escapes custom log names and URLs', function () {
+  // Names and URLs are escaped, and the href attribute is quoted.
+  const rendered = utils.formatLogsCells(
+    {'<b>stdout</b>': 'http://worker:8081/log?a=1&b="2"'}, 'display');
+  expect(rendered).toBe(
+    '<div><a href="http://worker:8081/log?a=1&amp;b=&quot;2&quot;">&lt;b&gt;stdout&lt;/b&gt;</a></div>');
+
+  // Only http(s) and relative URLs become links; other schemes render as text.
+  ['javascript:alert(1)', 'JAVAS\tCRIPT:alert(1)', 'data:text/html,x'].forEach(function (url) {
+    expect(utils.formatLogsCells({'stdout': url}, 'display')).toBe('<div>stdout</div>');
+  });
+
+  expect(utils.formatLogsCells({'stderr': 'logPage/?self&logType=stderr'}, 'display'))
+    .toBe('<div><a href="logPage/?self&amp;logType=stderr">stderr</a></div>');
+  expect(utils.formatLogsCells({'stdout': 'https://worker:8081/logPage'}, 'display'))
+    .toBe('<div><a href="https://worker:8081/logPage">stdout</a></div>');
+
+  // Non-display rendering returns the log names for sorting and filtering.
+  expect(utils.formatLogsCells({'stdout': 'javascript:alert(1)'}, 'sort')).toEqual(['stdout']);
 });


### PR DESCRIPTION
### What changes were proposed in this pull request?

Better handling for custom log names and URLs


### Why are the changes needed?
Custom log names can be weird, so let's validate that they're displayable before we display them.

### Does this PR introduce _any_ user-facing change?

Invalid log URLs will be replaced with plain text.

### How was this patch tested?

New unit tests

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude (mixture of models) and Cursor (Kimi K3)