### PR TITLE
[SPARK-59412][CORE] Support short class names of built-in plugins in `spark.plugins`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2162,13 +2162,27 @@ package object config {
 
   private[spark] val DEFAULT_PLUGINS_LIST = "spark.plugins.defaultList"
 
+  // A map from the short class names of built-in plugins to their fully-qualified class names.
+  private val BUILTIN_PLUGINS: Map[String, String] = Seq(
+    "org.apache.spark.deploy.DriverTimeoutPlugin",
+    "org.apache.spark.deploy.RedirectConsolePlugin",
+    "org.apache.spark.profiler.ProfilerPlugin",
+    "org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin",
+    "org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin",
+    "org.apache.spark.scheduler.cluster.k8s.ExecutorRollPlugin",
+    "org.apache.spark.sql.connect.SparkConnectPlugin"
+  ).map(name => name.substring(name.lastIndexOf('.') + 1) -> name).toMap
+
   private[spark] val PLUGINS =
     ConfigBuilder("spark.plugins")
       .withPrepended(DEFAULT_PLUGINS_LIST, separator = ",")
       .doc("Comma-separated list of class names implementing " +
-        "org.apache.spark.api.plugin.SparkPlugin to load into the application.")
+        "org.apache.spark.api.plugin.SparkPlugin to load into the application. " +
+        "Built-in plugins can also be specified by their short class names, " +
+        "e.g. `DriverTimeoutPlugin`.")
       .version("3.0.0")
       .stringConf
+      .transform(name => BUILTIN_PLUGINS.getOrElse(name, name))
       .toSequence
       .createWithDefault(Nil)
 

--- a/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/internal/plugin/PluginContainerSuite.scala
@@ -34,6 +34,7 @@ import org.scalatest.concurrent.Eventually.{eventually, interval, timeout}
 import org.apache.spark._
 import org.apache.spark.TestUtils._
 import org.apache.spark.api.plugin._
+import org.apache.spark.deploy.{DriverTimeoutPlugin, RedirectConsolePlugin}
 import org.apache.spark.internal.config._
 import org.apache.spark.launcher.SparkLauncher
 import org.apache.spark.memory.MemoryMode
@@ -130,6 +131,20 @@ class PluginContainerSuite extends SparkFunSuite with LocalSparkContext {
     sc = new SparkContext(conf)
     // Just check plugin is loaded. The plugin code below checks whether a single copy was loaded.
     assert(TestSparkPlugin.driverPlugin != null)
+  }
+
+  test("SPARK-59412: short class names of built-in plugins") {
+    val conf = new SparkConf()
+      .set(DEFAULT_PLUGINS_LIST, "RedirectConsolePlugin")
+      .set(PLUGINS.key, "DriverTimeoutPlugin,org.apache.spark.deploy.DriverTimeoutPlugin," +
+        s"drivertimeoutplugin,${classOf[TestSparkPlugin].getName()}")
+
+    assert(conf.get(PLUGINS) === Seq(
+      classOf[RedirectConsolePlugin].getName(),
+      classOf[DriverTimeoutPlugin].getName(),
+      classOf[DriverTimeoutPlugin].getName(),
+      "drivertimeoutplugin",
+      classOf[TestSparkPlugin].getName()))
   }
 
   test("SPARK-33088: executor tasks trigger plugin calls") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support short class names of built-in plugins in `spark.plugins` and `spark.plugins.defaultList`.

| Short class name | Fully-qualified class name |
| --- | --- |
| `DriverTimeoutPlugin` | `org.apache.spark.deploy.DriverTimeoutPlugin` |
| `RedirectConsolePlugin` | `org.apache.spark.deploy.RedirectConsolePlugin` |
| `ProfilerPlugin` | `org.apache.spark.profiler.ProfilerPlugin` |
| `ExecutorPVCResizePlugin` | `org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin` |
| `ExecutorResizePlugin` | `org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin` |
| `ExecutorRollPlugin` | `org.apache.spark.scheduler.cluster.k8s.ExecutorRollPlugin` |
| `SparkConnectPlugin` | `org.apache.spark.sql.connect.SparkConnectPlugin` |

Each item of the `spark.plugins` config entry is resolved via `transform` after `spark.plugins.defaultList` is prepended.
- A short class name is matched exactly (case-sensitive) and converted to its fully-qualified class name.
- All other values are passed through unchanged.
- Since `PluginContainer` removes duplicates after the resolution, a plugin is loaded only once even if both its short and fully-qualified class names are given.

### Why are the changes needed?

To improve the usability of built-in plugins. Currently, users must specify long fully-qualified class names.

```
--conf spark.plugins=org.apache.spark.scheduler.cluster.k8s.ExecutorResizePlugin,org.apache.spark.scheduler.cluster.k8s.ExecutorPVCResizePlugin
```

After this PR, users can use the following instead.

```
--conf spark.plugins=ExecutorResizePlugin,ExecutorPVCResizePlugin
```

This is consistent with other Spark configurations which accept short names for built-in implementations, such as `spark.shuffle.manager` (`sort`) and `spark.io.compression.codec` (`zstd`).

### Does this PR introduce _any_ user-facing change?

No, there is no behavior change for existing configurations with fully-qualified class names.

### How was this patch tested?

Pass the CIs with the newly added test case in `PluginContainerSuite`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5