### PR TITLE
[SPARK-59419][K8S] Use nested builders for volume sources in `MountVolumesFeatureStep`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -72,7 +72,10 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
       val volumeBuilder = spec.volumeConf match {
         case KubernetesHostPathVolumeConf(hostPath, volumeType) =>
           new VolumeBuilder()
-            .withHostPath(new HostPathVolumeSource(hostPath, volumeType))
+            .withNewHostPath()
+              .withPath(hostPath)
+              .withType(volumeType)
+            .endHostPath()
 
         case KubernetesPVCVolumeConf(claimNameTemplate, storageClass, size, labels, annotations) =>
           val claimName = conf match {
@@ -113,20 +116,24 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
           }
 
           new VolumeBuilder()
-            .withPersistentVolumeClaim(
-              new PersistentVolumeClaimVolumeSource(claimName, spec.mountReadOnly))
+            .withNewPersistentVolumeClaim()
+              .withClaimName(claimName)
+              .withReadOnly(spec.mountReadOnly)
+            .endPersistentVolumeClaim()
 
         case KubernetesEmptyDirVolumeConf(medium, sizeLimit) =>
           new VolumeBuilder()
-            .withEmptyDir(
-              new EmptyDirVolumeSourceBuilder()
-                .withMedium(medium.getOrElse(""))
-                .withSizeLimit(sizeLimit.map(new Quantity(_)).orNull)
-                .build())
+            .withNewEmptyDir()
+              .withMedium(medium.getOrElse(""))
+              .withSizeLimit(sizeLimit.map(new Quantity(_)).orNull)
+            .endEmptyDir()
 
         case KubernetesNFSVolumeConf(path, server) =>
           new VolumeBuilder()
-            .withNfs(new NFSVolumeSource(path, null, server))
+            .withNewNfs()
+              .withPath(path)
+              .withServer(server)
+            .endNfs()
       }
 
       val volume = volumeBuilder.withName(spec.volumeName).build()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the nested builders of `VolumeBuilder` for all volume sources in `MountVolumesFeatureStep`, instead of positional constructors and a standalone builder.

| Volume | Before | After |
|---|---|---|
| `hostPath` | `new HostPathVolumeSource(hostPath, volumeType)` | `withNewHostPath()` ... `endHostPath()` |
| `persistentVolumeClaim` | `new PersistentVolumeClaimVolumeSource(claimName, spec.mountReadOnly)` | `withNewPersistentVolumeClaim()` ... `endPersistentVolumeClaim()` |
| `emptyDir` | `new EmptyDirVolumeSourceBuilder()` ... `build()` | `withNewEmptyDir()` ... `endEmptyDir()` |
| `nfs` | `new NFSVolumeSource(path, null, server)` | `withNewNfs()` ... `endNfs()` |

### Why are the changes needed?

Positional constructors of `fabric8` model classes break whenever a new Kubernetes version adds a field. For example, `kubernetes-client` 7.9.0 added the `mode` field to `EmptyDirVolumeSource`, so SPARK-59384 (#58671) had to replace its constructor call with `EmptyDirVolumeSourceBuilder`.

Nested builders set each field by name, so future field additions don't affect this code. They also make the four cases consistent with each other. The same style is already used in the module, e.g., `withNewEmptyDir()` in `LocalDirsFeatureStep`.

### Does this PR introduce _any_ user-facing change?

No. Each nested builder extends the fluent class of its volume source, so the generated volumes are the same as before. The `readOnly` field of the `nfs` volume source stays `null` because it isn't set.

### How was this patch tested?

Pass the CIs with the existing test coverage.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5