### PR TITLE
[SPARK-59419][K8S][4.x] Use nested builders for volume sources in `MountVolumesFeatureStep`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/MountVolumesFeatureStep.scala
@@ -72,7 +72,10 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
       val volumeBuilder = spec.volumeConf match {
         case KubernetesHostPathVolumeConf(hostPath, volumeType) =>
           new VolumeBuilder()
-            .withHostPath(new HostPathVolumeSource(hostPath, volumeType))
+            .withNewHostPath()
+              .withPath(hostPath)
+              .withType(volumeType)
+            .endHostPath()
 
         case KubernetesPVCVolumeConf(claimNameTemplate, storageClass, size, labels, annotations) =>
           val claimName = conf match {
@@ -113,18 +116,24 @@ private[spark] class MountVolumesFeatureStep(conf: KubernetesConf)
           }
 
           new VolumeBuilder()
-            .withPersistentVolumeClaim(
-              new PersistentVolumeClaimVolumeSource(claimName, spec.mountReadOnly))
+            .withNewPersistentVolumeClaim()
+              .withClaimName(claimName)
+              .withReadOnly(spec.mountReadOnly)
+            .endPersistentVolumeClaim()
 
         case KubernetesEmptyDirVolumeConf(medium, sizeLimit) =>
           new VolumeBuilder()
-            .withEmptyDir(
-              new EmptyDirVolumeSource(medium.getOrElse(""),
-                sizeLimit.map(new Quantity(_)).orNull))
+            .withNewEmptyDir()
+              .withMedium(medium.getOrElse(""))
+              .withSizeLimit(sizeLimit.map(new Quantity(_)).orNull)
+            .endEmptyDir()
 
         case KubernetesNFSVolumeConf(path, server) =>
           new VolumeBuilder()
-            .withNfs(new NFSVolumeSource(path, null, server))
+            .withNewNfs()
+              .withPath(path)
+              .withServer(server)
+            .endNfs()
       }
 
       val volume = volumeBuilder.withName(spec.volumeName).build()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a backport of #58716 to `branch-4.x`.

This PR aims to use the nested builders of `VolumeBuilder` for all volume sources in `MountVolumesFeatureStep`, instead of positional constructors.

| Volume | Before | After |
|---|---|---|
| `hostPath` | `new HostPathVolumeSource(hostPath, volumeType)` | `withNewHostPath()` ... `endHostPath()` |
| `persistentVolumeClaim` | `new PersistentVolumeClaimVolumeSource(claimName, spec.mountReadOnly)` | `withNewPersistentVolumeClaim()` ... `endPersistentVolumeClaim()` |
| `emptyDir` | `new EmptyDirVolumeSource(medium.getOrElse(""), sizeLimit.map(new Quantity(_)).orNull)` | `withNewEmptyDir()` ... `endEmptyDir()` |
| `nfs` | `new NFSVolumeSource(path, null, server)` | `withNewNfs()` ... `endNfs()` |

Unlike `master`, `branch-4.x` still uses the positional constructor of `EmptyDirVolumeSource` because SPARK-59384 (#58671) is not in `branch-4.x`. After this PR, `MountVolumesFeatureStep` in `branch-4.x` is the same as in `master`.

### Why are the changes needed?

Positional constructors of `fabric8` model classes break whenever a new Kubernetes version adds a field. For example, `kubernetes-client` 7.9.0 added the `mode` field to `EmptyDirVolumeSource`, so SPARK-59384 (#58671) had to replace its constructor call in `master`.

Nested builders set each field by name, so future field additions don't affect this code. The same style is already used in the module, e.g., `withNewEmptyDir()` in `LocalDirsFeatureStep`.

For `branch-4.x`, this also keeps `MountVolumesFeatureStep` the same as in `master`, so future backports to this file apply cleanly. The nested builders are available in `kubernetes-client` 7.6.1, which `branch-4.x` uses.

### Does this PR introduce _any_ user-facing change?

No. Each nested builder extends the fluent class of its volume source, so the generated volumes are the same as before. The `readOnly` field of the `nfs` volume source stays `null` because it isn't set.

### How was this patch tested?

Pass the CIs with the existing test coverage.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5