### PR TITLE
[SPARK-59421][BUILD] Upgrade `zstd-jni` to 1.5.7-16

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -314,4 +314,4 @@ xz/1.12//xz-1.12.jar
 zjsonpatch/7.9.0//zjsonpatch-7.9.0.jar
 zookeeper-jute/3.9.5//zookeeper-jute-3.9.5.jar
 zookeeper/3.9.5//zookeeper-3.9.5.jar
-zstd-jni/1.5.7-13//zstd-jni-1.5.7-13.jar
+zstd-jni/1.5.7-16//zstd-jni-1.5.7-16.jar

--- a/pom.xml
+++ b/pom.xml
@@ -883,7 +883,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.7-13</version>
+        <version>1.5.7-16</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.7-16.

### Why are the changes needed?

To bring the latest bug fixes and improvements. `zstd-jni` 1.5.7-16 was released on 2026-08-29 and includes the following notable changes since 1.5.7-13.

- [v1.5.7-16](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-16) (2026-08-29)
- [v1.5.7-15](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-15) (2026-08-16)
- [v1.5.7-14](https://github.com/luben/zstd-jni/releases/tag/v1.5.7-14) (2026-08-16)

Notable changes:
- Fix cross-object lifetime tracking for dicts and contexts
- Fix dict lifecycle in `ZstdDirectBufferCompressingStream`
- Add more guards for non-null and closed streams
- Add argument validation for `ZstdDictDecompress` constructor
- Fix int overflow
- Simplify loading the native library
- Return `long` from the private natives whose C function returns `size_t`
- Guard against negative frame content sizes

Full changelog: https://github.com/luben/zstd-jni/compare/v1.5.7-13...v1.5.7-16

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5