### PR TITLE
[SPARK-48701][FOLLOWUP][SQL][PS] Guard nulls nested in collated complex types in mode aggregates

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -70,17 +70,22 @@ private[aggregate] trait ModeCollationAware { self: Expression =>
         childDataType: DataType): Option[AnyRef => _] = {
       childDataType match {
         case _ if UnsafeRowUtils.isBinaryStable(child.dataType) => None
-        // A null key is kept as its own group: PandasMode may store one when `ignoreNA`
-        // is false, and passing null to collationAwareTransform would throw. Mode never
-        // stores a null key, so its behavior is unchanged.
-        case _ => Some((key: AnyRef) =>
-          if (key == null) null else collationAwareTransform(key, childDataType))
+        // PandasMode may store a null key when `ignoreNA` is false, and a collated complex
+        // type may hold nested nulls; collationAwareTransform maps every null to null so it
+        // forms its own group. Mode never stores a null key, so its behavior is unchanged.
+        case _ => Some((key: AnyRef) => collationAwareTransform(key, childDataType))
       }
     }
     determineBufferingFunction(childDataType).map(groupAndReduceBuffer).getOrElse(buffer)
   }
 
   protected[sql] def collationAwareTransform(data: AnyRef, dataType: DataType): AnyRef = {
+    // A null has no collation key. Return it unchanged so that a null -- whether the top-level
+    // key or one nested inside a collated struct/array/map -- folds into its own group instead
+    // of throwing when we would otherwise compute a collation key for it.
+    if (data == null) {
+      return null
+    }
     dataType match {
       case _ if UnsafeRowUtils.isBinaryStable(dataType) => data
       case st: StructType =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/CollationAggregationSuite.scala
@@ -616,6 +616,25 @@ class CollationAggregationSuite
     }
   }
 
+  test("SPARK-48701: pandas_mode handles NULL nested in a collated struct field") {
+    withTable("t") {
+      sql("CREATE TABLE t (c STRUCT<f: STRING COLLATE UTF8_LCASE>) USING parquet")
+      sql(
+        """INSERT INTO t VALUES (named_struct('f', 'a')), (named_struct('f', 'a')),
+          |  (named_struct('f', 'b')), (named_struct('f', 'B')),
+          |  (named_struct('f', CAST(NULL AS STRING))),
+          |  (named_struct('f', CAST(NULL AS STRING))),
+          |  (named_struct('f', CAST(NULL AS STRING)))""".stripMargin)
+      // A NULL string nested inside the collated struct field must fold like any other value
+      // rather than throwing while computing its collation key. {a}=2, {b,B}=2, {NULL}=3, so
+      // the struct whose field is NULL is the sole mode.
+      val modes = pandasMode(spark.table("t").repartition(4), "c", ignoreNA = true)
+        .map(_.asInstanceOf[Row])
+      assert(modes.length == 1)
+      assert(modes.head.isNullAt(0))
+    }
+  }
+
   // `mode` (the public aggregate) is already collation-aware; these tests guard that
   // behavior, which currently has no coverage (the original tests were removed with
   // CollationSQLExpressionsSuite by SPARK-51067). Unlike pandas_mode, `mode` returns a


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-48701. `ModeCollationAware.collationAwareTransform` computes a collation
key for each (nested) string value in `mode`/`pandas_mode` under a non-binary collation. The
top-level buffer key was null-guarded, but the recursion into struct/array/map fields was not,
so a NULL string nested inside a collated complex type reached
`CollationFactory.getCollationKey(null, ...)` and threw an NPE. This adds a single null guard
at the top of `collationAwareTransform` so a null -- top-level or nested -- folds into its own
group, and removes the now-redundant top-level guard in the buffering function.

### Why are the changes needed?

`pandas_mode` (backing pandas-on-Spark `Series.mode()`/`DataFrame.mode()`) with `ignoreNA=False`,
and any `mode` over a collated complex column containing nested nulls, would throw instead of
returning a result.

### Does this PR introduce _any_ user-facing change?

Yes, within the unreleased branch: a `mode`/`pandas_mode` query over a collated complex type with
nested nulls no longer throws. There is no change compared to released versions.

### How was this patch tested?

Added a regression test in `CollationAggregationSuite` ("pandas_mode handles NULL nested in a
collated struct field") that fails (NPE) without the fix. To be verified by the Apache Spark
GitHub Actions CI on this PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

Co-authored-by: Isaac <no-reply@databricks.com>



This pull request and its description were written by Isaac.
