### PR TITLE
[SPARK-59311][FOLLOWUP][SQL] Name the map-key property when its Catalyst type overflows the parser

### DIFF
--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSchemaHelperSuite.scala
@@ -33,31 +33,47 @@ class AvroSchemaHelperSuite extends SharedSparkSession {
     assert(SchemaConverters.toSqlType(avroSchema).dataType.isInstanceOf[ArrayType])
   }
 
-  test("a pathologically nested Catalyst type fails as a schema error, not StackOverflowError") {
-    // A backquoted identifier may itself contain '>', so a character scan of the type string
-    // cannot bound the real nesting -- only parsing it can. Parse on a small-stack thread so the
-    // recursive-descent parser overflows deterministically, and assert the overflow surfaces as
-    // an IncompatibleSchemaException instead of escaping as a StackOverflowError.
-    val depth = 6000
-    val deepType = "struct<`>`:" * depth + "int" + ">" * depth
-    val avroSchema = SchemaBuilder.builder().intType()
-    avroSchema.addProp("spark.sql.catalyst.type", deepType)
+  // A type string deep enough to overflow the recursive-descent parser on the small-stack thread
+  // used by the overflow tests below. A backquoted identifier may itself contain '>', so a
+  // character scan of the type string cannot bound the real nesting -- only parsing it can.
+  private def deeplyNestedType(depth: Int): String =
+    "struct<`>`:" * depth + "int" + ">" * depth
 
+  // Runs `f` on a thread with a small (256 KiB) stack so the recursive-descent parser overflows
+  // deterministically, and returns whatever it threw (or null if nothing did).
+  private def runOnSmallStack(f: => Unit): Throwable = {
     @volatile var thrown: Throwable = null
     val runnable = new Runnable {
       override def run(): Unit = {
-        try {
-          SchemaConverters.toSqlType(avroSchema)
-        } catch {
-          case t: Throwable => thrown = t
-        }
+        try f catch { case t: Throwable => thrown = t }
       }
     }
     val t = new Thread(null, runnable, "avro-deep-catalyst-type", 256 * 1024)
     t.start()
     t.join()
+    thrown
+  }
+
+  test("a pathologically nested Catalyst type fails as a schema error, not StackOverflowError") {
+    val avroSchema = SchemaBuilder.builder().intType()
+    avroSchema.addProp("spark.sql.catalyst.type", deeplyNestedType(1000))
+    val thrown = runOnSmallStack(SchemaConverters.toSqlType(avroSchema))
     assert(thrown.isInstanceOf[IncompatibleSchemaException],
       s"expected IncompatibleSchemaException but got: $thrown")
+    // The message names the property the deep type came from.
+    assert(thrown.getMessage.contains("spark.sql.catalyst.type"))
+  }
+
+  test("SPARK-59311: a pathologically nested map-key type names the map-key property on overflow") {
+    // The overflow while parsing the map-key type must be reported against
+    // spark.sql.catalyst.mapKey.type, not the generic spark.sql.catalyst.type property.
+    val mapSchema = SchemaBuilder.builder().map().values(SchemaBuilder.builder().intType())
+    mapSchema.addProp("spark.sql.catalyst.mapKey.type", deeplyNestedType(1000))
+    val thrown = runOnSmallStack(SchemaConverters.toSqlType(mapSchema))
+    assert(thrown.isInstanceOf[IncompatibleSchemaException],
+      s"expected IncompatibleSchemaException but got: $thrown")
+    assert(thrown.getMessage.contains("spark.sql.catalyst.mapKey.type"),
+      s"expected the map-key property name in: ${thrown.getMessage}")
   }
 
   test("ensure schema is a record") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -115,29 +115,34 @@ object SchemaConverters extends Logging {
     mapSchema
   }
 
-  // Parses the Catalyst type carried in the `spark.sql.catalyst.type` Avro property with the
-  // recursive-descent Catalyst parser. A pathologically deep type string can exhaust the stack
-  // while parsing; the parser only converts `ParseException`, so such a `StackOverflowError`
-  // would otherwise escape as an unhandled error. Convert it into an `IncompatibleSchemaException`
-  // so it surfaces as a normal schema error. This runs on both the driver (schema inference) and
+  // Parses a Catalyst type carried in an Avro property (`spark.sql.catalyst.type` or, for map
+  // keys, `spark.sql.catalyst.mapKey.type`) with the recursive-descent Catalyst parser. A
+  // pathologically deep type string can exhaust the stack while parsing; the parser only converts
+  // `ParseException`, so such a `StackOverflowError` would otherwise escape as an unhandled error.
+  // Convert it into an `IncompatibleSchemaException`, naming the property it came from, so it
+  // surfaces as a normal schema error. This runs on both the driver (schema inference) and
   // executors (`AvroDeserializer`).
-  private def parseCatalystType(catalystTypeAttrValue: String): DataType = {
+  private def parseCatalystType(
+      catalystTypeAttrValue: String,
+      propName: String = CATALYST_TYPE_PROP_NAME): DataType = {
     try {
       CatalystSqlParser.parseDataType(catalystTypeAttrValue)
     } catch {
       case e: StackOverflowError =>
         throw new IncompatibleSchemaException(
-          s"Cannot parse the $CATALYST_TYPE_PROP_NAME Avro schema property because it is nested " +
+          s"Cannot parse the $propName Avro schema property because it is nested " +
             "too deeply.", e)
     }
   }
 
-  private def parseStampedStringType(catalystTypeAttrValue: String): StringType = {
-    parseCatalystType(catalystTypeAttrValue) match {
+  private def parseStampedStringType(
+      catalystTypeAttrValue: String,
+      propName: String = CATALYST_TYPE_PROP_NAME): StringType = {
+    parseCatalystType(catalystTypeAttrValue, propName) match {
       case s: StringType => s
       case other =>
         throw new IncompatibleSchemaException(
-          s"Avro $CATALYST_TYPE_PROP_NAME for STRING must be a STRING subtype, got $other")
+          s"Avro $propName for STRING must be a STRING subtype, got $other")
     }
   }
 
@@ -300,7 +305,7 @@ object SchemaConverters extends Logging {
           val keyType = if (keyAttr == null) {
             StringType
           } else {
-            parseStampedStringType(keyAttr)
+            parseStampedStringType(keyAttr, CATALYST_MAP_KEY_TYPE_PROP_NAME)
           }
           SchemaType(
             MapType(keyType, schemaType.dataType, valueContainsNull = schemaType.nullable),


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-59311. `parseCatalystType`/`parseStampedStringType` hardcoded
`spark.sql.catalyst.type` in the overflow (`IncompatibleSchemaException`) message, but they are
also used to parse the map-key type carried in `spark.sql.catalyst.mapKey.type`. A too-deeply
nested map-key type therefore reported the wrong property. This threads the source property name
through both helpers so the message names the property the type actually came from.

Also reduces the overflow regression test's nesting depth from 6000 to 1000 (still overflows the
256 KiB test stack deterministically, but runs much faster) and factors the small-stack runner
into a shared helper.

### Why are the changes needed?

The error message pointed users at the wrong Avro schema property when a map-key Catalyst type was
malformed, making the failure harder to diagnose.

### Does this PR introduce _any_ user-facing change?

Yes, within the unreleased branch: the exception for an over-deep map-key Catalyst type now names
`spark.sql.catalyst.mapKey.type` instead of `spark.sql.catalyst.type`. No change compared to
released versions.

### How was this patch tested?

Added a regression test asserting the map-key property name appears in the overflow message, and
strengthened the existing overflow test to also assert its property name. To be verified by the
Apache Spark GitHub Actions CI on this PR.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

Co-authored-by: Isaac <no-reply@databricks.com>



This pull request and its description were written by Isaac.
