### PR TITLE
[SPARK-59061][FOLLOWUP][CORE] List all eight StandaloneAppClientListener callbacks in its doc

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClientListener.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/client/StandaloneAppClientListener.scala
@@ -22,10 +22,11 @@ import scala.concurrent.Future
 import org.apache.spark.scheduler.ExecutorDecommissionInfo
 
 /**
- * Callbacks invoked by deploy client when various events happen. There are currently six events:
- * connecting to the cluster, disconnecting, being given an executor, having an executor removed
- * (either due to failure or due to revocation), having a worker removed, and being asked by the
- * Master to hold or resume the application.
+ * Callbacks invoked by deploy client when various events happen. There are currently eight
+ * events: connecting to the cluster, disconnecting, an application death, being given an
+ * executor, having an executor removed (either due to failure or due to revocation), having an
+ * executor decommissioned, having a worker removed, and being asked by the Master to hold or
+ * resume the application.
  *
  * Users of this API should *not* block inside the callback methods.
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow-up to SPARK-59061. The `StandaloneAppClientListener` trait overview said there were "six
events" and enumerated six callbacks, but the trait declares eight: the summary omitted the
pre-existing `dead` (application death) and `executorDecommissioned` callbacks. This corrects the
count and lists all eight.

### Why are the changes needed?

The doc under-counted the callbacks a listener must handle, which is misleading for implementers.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only change to an internal (`private[spark]`) trait.

### How was this patch tested?

N/A (comment-only change).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Isaac

Co-authored-by: Isaac <no-reply@databricks.com>



This pull request and its description were written by Isaac.
