### PR TITLE
[SPARK-59154][FOLLOWUP][ML] Clean up DecisionTreeRegressionModel transform

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/regression/DecisionTreeRegressor.scala
@@ -198,11 +198,6 @@ class DecisionTreeRegressionModel private[ml] (
     rootNode.predictImpl(features).prediction
   }
 
-  /** We need to update this function if we ever add other impurity measures. */
-  protected def predictVariance(features: Vector): Double = {
-    rootNode.predictImpl(features).impurityStats.calculate()
-  }
-
   @Since("1.4.0")
   override def transformSchema(schema: StructType): StructType = {
     var outputSchema = super.transformSchema(schema)
@@ -220,24 +215,24 @@ class DecisionTreeRegressionModel private[ml] (
     val outputSchema = transformSchema(dataset.schema, logging = true)
     val localRootNode = rootNode
 
-    var predictionColNames = Seq.empty[String]
-    var predictionColumns = Seq.empty[Column]
+    var predColNames = Seq.empty[String]
+    var predCols = Seq.empty[Column]
 
     if ($(predictionCol).nonEmpty) {
-      val predictUDF = udf { features: Vector =>
+      val predUDF = udf { features: Vector =>
         localRootNode.predictImpl(features).prediction
       }
-      predictionColNames :+= $(predictionCol)
-      predictionColumns :+= predictUDF(col($(featuresCol)))
+      predColNames :+= $(predictionCol)
+      predCols :+= predUDF(col($(featuresCol)))
         .as($(predictionCol), outputSchema($(predictionCol)).metadata)
     }
 
     if (isDefined(varianceCol) && $(varianceCol).nonEmpty) {
-      val predictVarianceUDF = udf { features: Vector =>
+      val varianceUDF = udf { features: Vector =>
         localRootNode.predictImpl(features).impurityStats.calculate()
       }
-      predictionColNames :+= $(varianceCol)
-      predictionColumns :+= predictVarianceUDF(col($(featuresCol)))
+      predColNames :+= $(varianceCol)
+      predCols :+= varianceUDF(col($(featuresCol)))
         .as($(varianceCol), outputSchema($(varianceCol)).metadata)
     }
 
@@ -245,13 +240,13 @@ class DecisionTreeRegressionModel private[ml] (
       val leafUDF = udf { features: Vector =>
         DecisionTreeModel.predictLeaf(features, localRootNode)
       }
-      predictionColNames :+= $(leafCol)
-      predictionColumns :+= leafUDF(col($(featuresCol)))
+      predColNames :+= $(leafCol)
+      predCols :+= leafUDF(col($(featuresCol)))
         .as($(leafCol), outputSchema($(leafCol)).metadata)
     }
 
-    if (predictionColNames.nonEmpty) {
-      dataset.withColumns(predictionColNames, predictionColumns)
+    if (predColNames.nonEmpty) {
+      dataset.withColumns(predColNames, predCols)
     } else {
       this.logWarning(log"${MDC(LogKeys.UUID, uid)}: DecisionTreeRegressionModel.transform() " +
         log"does nothing because no output columns were set.")

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -43,7 +43,10 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.classification.DecisionTreeClassificationModel.numLeave"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave")
+      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave"),
+    // [SPARK-59154] Remove unused prediction variance helper after inlining its implementation.
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.predictVariance")
   )
 
   // Exclude rules for 4.3.x from 4.2.0 (add 4.3-specific filters below as needed).

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -43,7 +43,11 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.classification.DecisionTreeClassificationModel.numLeave"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave"),
+      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave")
+  )
+
+  // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
+  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes ++ Seq(
     // [SPARK-59154] Remove unused prediction variance helper after inlining its implementation.
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.regression.DecisionTreeRegressionModel.predictVariance")

--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -43,11 +43,7 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.classification.DecisionTreeClassificationModel.numLeave"),
     ProblemFilters.exclude[DirectMissingMethodProblem](
-      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave")
-  )
-
-  // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
-  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes ++ Seq(
+      "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave"),
     // [SPARK-59154] Remove unused prediction variance helper after inlining its implementation.
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.regression.DecisionTreeRegressionModel.predictVariance")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #58454.

This pull request aligns the local column and UDF names in
`DecisionTreeRegressionModel.transform` with the other tree regression models and removes the
unused `predictVariance` method. The variance prediction logic was moved directly into the
transform UDF by #58454. It also adds a narrow Spark 4.4 MiMa exclusion for the removed method.

### Why are the changes needed?

The old helper became unused after the transform closure optimization, and consistent local names
make the related tree regression transform implementations easier to compare and maintain.

`predictVariance` is protected on a model whose constructors are `private[ml]`, so it is not a
supported external extension point.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks passed:

```
build/sbt mllib/compile
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./dev/mima
git diff --check upstream/master...HEAD
```

Changed-file line-length and non-ASCII checks also passed.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
