### PR TITLE
[SPARK-59428][SQL] Remove a dead emptiness guard in CollectFrequentItems.add

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/FrequentItems.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/stat/FrequentItems.scala
@@ -95,7 +95,8 @@ case class CollectFrequentItems(
       if (map.size < size) {
         map += key -> count
       } else {
-        val minCount = if (map.values.isEmpty) 0 else map.values.min
+        // Non-empty here: this branch runs only when map.size >= size, and size > 0.
+        val minCount = map.values.min
         val remainder = count - minCount
         if (remainder >= 0) {
           map += key -> count // something will get kicked out, so we can add this


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `CollectFrequentItems.add` (the `collect_frequent_items` aggregate behind
`DataFrame.stat.freqItems`), the eviction branch computed:

```scala
val minCount = if (map.values.isEmpty) 0 else map.values.min
```

The `map.values.isEmpty` guard is dead: this line runs only inside the branch where the buffer is
full (`map.size >= size`), and the class enforces `require(size > 0)`, so the map always has at least
one entry there. This PR drops the guard:

```scala
// Non-empty here: this branch runs only when map.size >= size, and size > 0.
val minCount = map.values.min
```

### Why are the changes needed?

The guard is unreachable-true and not free. `scalac` does not eliminate it (it cannot prove the map
is non-empty — that is a runtime invariant), so at runtime `map.values` is evaluated and allocates a
fresh `Iterable` view wrapper on every call. This runs on the eviction path (buffer full + key miss),
the steady state for a high-cardinality column. Removing it drops the dead branch and one of the two
`map.values` allocations on that path. (HotSpot escape analysis may already scalar-replace the
short-lived wrapper in hot compiled code, but that is not guaranteed; removing it at the source level
does not rely on the JIT.)

### Does this PR introduce _any_ user-facing change?

No. The map is provably non-empty at this point, so the removed branch never executed; results are
identical.

### How was this patch tested?

Existing `DataFrameStatSuite` tests pass (including "Frequent Items" and "Frequent Items 2");
scalastyle is clean. Behavior-preserving cleanup, so no new test was added.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
