### PR TITLE
[SPARK-59430][CORE] Cache UTF8String.hashCode

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -62,6 +62,12 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   private int numBytes;
   private volatile int numChars = -1;
 
+  // Cache the hash code, like java.lang.String. `hash` holds the computed value; `hashIsZero`
+  // records the case where the hash legitimately computed to 0, so it is not recomputed on every
+  // call. Non-volatile: the benign race only ever recomputes the same value.
+  private int hash;
+  private boolean hashIsZero;
+
   /**
    * The validity of the UTF8Strings can be cached to avoid repeated validation checks, because
    * that operation requires full string scan. Valid strings have no illegal UTF-8 byte sequences.
@@ -2276,7 +2282,16 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
 
   @Override
   public int hashCode() {
-    return Murmur3_x86_32.hashUnsafeBytes(base, offset, numBytes, 42);
+    int h = hash;
+    if (h == 0 && !hashIsZero) {
+      h = Murmur3_x86_32.hashUnsafeBytes(base, offset, numBytes, 42);
+      if (h == 0) {
+        hashIsZero = true;
+      } else {
+        hash = h;
+      }
+    }
+    return h;
   }
 
   /**
@@ -2345,6 +2360,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     numBytes = in.readInt();
     base = new byte[numBytes];
     in.readFully((byte[]) base);
+    hash = 0;
+    hashIsZero = false;
   }
 
   @Override
@@ -2360,6 +2377,8 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     this.numBytes = in.readInt();
     this.base = new byte[numBytes];
     in.read((byte[]) base);
+    this.hash = 0;
+    this.hashIsZero = false;
   }
 
   /**

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -17,8 +17,11 @@
 
 package org.apache.spark.unsafe.types;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -1547,5 +1550,32 @@ public class UTF8StringSuite {
       sb.appendCodePoint(i);
       assert(usb.build().equals(UTF8String.fromString(sb.toString())));
     }
+  }
+
+  @Test
+  public void hashCodeIsCachedAndStable() throws Exception {
+    // Repeated calls return the same value (the cache must not change it).
+    UTF8String s = fromString("hashcode-cache-test");
+    int h = s.hashCode();
+    assertEquals(h, s.hashCode());
+    assertEquals(h, s.hashCode());
+    // Equal strings built differently agree (consistency with equals).
+    assertEquals(h, fromBytes("hashcode-cache-test".getBytes(StandardCharsets.UTF_8)).hashCode());
+
+    // A Java-serialization round-trip (which re-points the fields via readExternal) yields the
+    // same hash, even when the source's hash was already cached.
+    UTF8String before = fromString("round-trip");
+    before.hashCode();
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(before);
+    }
+    ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
+    UTF8String after;
+    try (ObjectInputStream ois = new ObjectInputStream(bis)) {
+      after = (UTF8String) ois.readObject();
+    }
+    assertEquals(before, after);
+    assertEquals(before.hashCode(), after.hashCode());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UTF8String.hashCode()` recomputed a Murmur3 hash over **all** of the string's bytes on every call:

```java
public int hashCode() {
  return Murmur3_x86_32.hashUnsafeBytes(base, offset, numBytes, 42);
}
```

This PR caches the result in a non-volatile `int`, using the modern `java.lang.String` technique so a
legitimately zero hash is remembered (via a `hashIsZero` flag) rather than recomputed on every call:

```java
private int hash;
private boolean hashIsZero;

public int hashCode() {
  int h = hash;
  if (h == 0 && !hashIsZero) {
    h = Murmur3_x86_32.hashUnsafeBytes(base, offset, numBytes, 42);
    if (h == 0) {
      hashIsZero = true;
    } else {
      hash = h;
    }
  }
  return h;
}
```

The cache is reset alongside `base`/`offset`/`numBytes` in `readExternal` and `read` (Kryo) — the
only places a `UTF8String` is re-pointed to different memory.

### Why are the changes needed?

For a `UTF8String` hashed more than once — e.g. a key in a Scala `Map`/`Set`, or the repeated
`contains`/`apply`/`update` probes against an aggregation buffer — recomputing an O(length) Murmur3
scan each time is wasteful. Caching the hash (as `java.lang.String` does) removes the repeated scans.

The change is safe for the same reason the class's existing lazily-computed caches (`numChars`,
`isFullAscii`, `isValid`, `numBytesValid`) are safe: a `UTF8String` object's value is stable for its
lifetime — callers `copy()` before retaining a value across a Tungsten buffer reuse (see
`InternalRow.copyValue`). A cached hash relies on the exact same contract, and is reset when the
fields are re-pointed during deserialization.

Memory: one `int` plus one `boolean`, which should largely be absorbed by the object's existing
alignment padding.

### Does this PR introduce _any_ user-facing change?

No. The cached value equals the previously computed hash for every input.

### How was this patch tested?

Added a `UTF8StringSuite` test covering hash stability across repeated calls, equals/hashCode
consistency for equal strings built different ways, and a Java-serialization round-trip (which
exercises the `readExternal` reset). Existing `UTF8StringSuite` passes; checkstyle is clean.

Note: the benefit applies to `UTF8String`s hashed multiple times; ephemeral per-row views hashed once
see no change, and `BytesToBytesMap` (hash aggregate/join) hashes raw bytes directly rather than
through `UTF8String.hashCode`, so it is unaffected.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
