### PR TITLE
[SPARK-58896][FOLLOWUP][ML] Apply decision tree MiMa exclusions from Spark 4.4

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -34,7 +34,10 @@ import com.typesafe.tools.mima.core.*
 object MimaExcludes {
 
   // Exclude rules for 5.0.x from 4.4.0 (add 5.0-specific filters below as needed).
-  lazy val v50excludes: Seq[Problem => Boolean] = v44excludes ++ Seq(
+  lazy val v50excludes: Seq[Problem => Boolean] = v44excludes
+
+  // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
+  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes ++ Seq(
     // [SPARK-58896] Decision tree leaf counts moved behind NodeStats. The old package-private
     // numLeave accessors are removed from concrete models.
     ProblemFilters.exclude[DirectMissingMethodProblem](
@@ -42,9 +45,6 @@ object MimaExcludes {
     ProblemFilters.exclude[DirectMissingMethodProblem](
       "org.apache.spark.ml.regression.DecisionTreeRegressionModel.numLeave")
   )
-
-  // Exclude rules for 4.4.x from 4.3.0 (add 4.4-specific filters below as needed).
-  lazy val v44excludes: Seq[Problem => Boolean] = v43excludes
 
   // Exclude rules for 4.3.x from 4.2.0 (add 4.3-specific filters below as needed).
   lazy val v43excludes: Seq[Problem => Boolean] = v42excludes ++ Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to #58147 and its `branch-4.x` backport #58184.

This pull request moves the two SPARK-58896 decision-tree `numLeave` MiMa exclusions from
`v50excludes` to `v44excludes`.

### Why are the changes needed?

SPARK-58896 was also merged into `branch-4.x` by #58184. Its binary-compatibility exclusions
therefore apply starting with Spark 4.4 and should be inherited by Spark 5.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The following checks passed:

```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./dev/mima
git diff --check upstream/master...HEAD
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
