### PR TITLE
[MINOR][CORE] Simplify the next-page index computation in BytesToBytesMap.MapIterator

### DIFF
--- a/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
+++ b/core/src/main/java/org/apache/spark/unsafe/map/BytesToBytesMap.java
@@ -323,11 +323,14 @@ public final class BytesToBytesMap extends MemoryConsumer {
 
       try {
         synchronized (this) {
-          int nextIdx = dataPages.indexOf(currentPage) + 1;
-          if (destructive && currentPage != null) {
-            dataPages.remove(currentPage);
+          final int idx = dataPages.indexOf(currentPage);
+          final int nextIdx;
+          if (destructive && idx >= 0) {
+            dataPages.remove(idx);
             pageToFree = currentPage;
-            nextIdx--;
+            nextIdx = idx;
+          } else {
+            nextIdx = idx + 1;
           }
           if (dataPages.size() > nextIdx) {
             currentPage = dataPages.get(nextIdx);


### PR DESCRIPTION
### What changes were proposed in this pull request?

`MapIterator.advanceToNextPage()` in `BytesToBytesMap` computed the next-page index as
`int nextIdx = dataPages.indexOf(currentPage) + 1;` and then decremented it (`nextIdx--`) inside a
conditional. This reuses the `indexOf` result and sets `nextIdx` once in an `if`/`else` so it can be
`final`:

```java
final int idx = dataPages.indexOf(currentPage);
final int nextIdx;
if (destructive && idx >= 0) {
  dataPages.remove(idx);
  pageToFree = currentPage;
  nextIdx = idx;
} else {
  nextIdx = idx + 1;
}
```

### Why are the changes needed?

Minor readability/consistency cleanup: `nextIdx` becomes `final` and is assigned exactly once per
branch instead of being mutated. `idx >= 0` is equivalent to the previous `currentPage != null`
guard — whenever `currentPage` is non-null it is an element of `dataPages` (assigned from
`dataPages.get(...)` and only removed here), and `indexOf(null)` is `-1`. Reusing `idx` for
`remove(idx)` also avoids the redundant second linear scan that `remove(Object)` performs. No lock or
I/O behavior is changed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing `BytesToBytesMapOnHeapSuite` and `BytesToBytesMapOffHeapSuite` pass (34 tests, covering
destructive iteration, spill, reset, and free); checkstyle is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
