### PR TITLE
[MINOR][CORE][SQL] Inline argument checks and drop the network.util.JavaUtils dependency in ReadAheadInputStream and VectorizedDeltaBinaryPackedReader

### DIFF
--- a/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
+++ b/core/src/main/java/org/apache/spark/io/ReadAheadInputStream.java
@@ -33,7 +33,6 @@ import org.apache.spark.internal.SparkLogger;
 import org.apache.spark.internal.SparkLoggerFactory;
 import org.apache.spark.internal.LogKeys;
 import org.apache.spark.internal.MDC;
-import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.util.ThreadUtils;
 
 /**
@@ -104,8 +103,10 @@ public class ReadAheadInputStream extends InputStream {
    */
   public ReadAheadInputStream(
       InputStream inputStream, int bufferSizeInBytes) {
-    JavaUtils.checkArgument(bufferSizeInBytes > 0,
-        "bufferSizeInBytes should be greater than 0, but the value is " + bufferSizeInBytes);
+    if (bufferSizeInBytes <= 0) {
+      throw new IllegalArgumentException(
+          "bufferSizeInBytes should be greater than 0, but the value is " + bufferSizeInBytes);
+    }
     activeBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     readAheadBuffer = ByteBuffer.allocate(bufferSizeInBytes);
     this.underlyingInputStream = inputStream;

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/VectorizedDeltaBinaryPackedReader.java
@@ -26,7 +26,6 @@ import org.apache.parquet.column.values.bitpacking.BytePackerForLong;
 import org.apache.parquet.column.values.bitpacking.Packer;
 import org.apache.parquet.io.ParquetDecodingException;
 
-import org.apache.spark.network.util.JavaUtils;
 import org.apache.spark.sql.catalyst.util.RebaseDateTime;
 import org.apache.spark.sql.execution.datasources.DataSourceUtils;
 import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
@@ -89,8 +88,10 @@ public class VectorizedDeltaBinaryPackedReader extends VectorizedReaderBase {
 
   @Override
   public void initFromPage(int valueCount, ByteBufferInputStream in) throws IOException {
-    JavaUtils.checkArgument(valueCount >= 1,
-        "Page must have at least one value, but it has " + valueCount);
+    if (valueCount < 1) {
+      throw new IllegalArgumentException(
+          "Page must have at least one value, but it has " + valueCount);
+    }
     this.in = in;
     // Read the header
     this.blockSizeInValues = BytesUtils.readUnsignedVarInt(in);
@@ -105,8 +106,10 @@ public class VectorizedDeltaBinaryPackedReader extends VectorizedReaderBase {
           + miniBlockNumInABlock + " (block size in values: " + blockSizeInValues + ")");
     }
     double miniSize = (double) blockSizeInValues / miniBlockNumInABlock;
-    JavaUtils.checkArgument(miniSize % 8 == 0,
-        "miniBlockSize must be multiple of 8, but it's " + miniSize);
+    if (miniSize % 8 != 0) {
+      throw new IllegalArgumentException(
+          "miniBlockSize must be multiple of 8, but it's " + miniSize);
+    }
     this.miniBlockSizeInValues = (int) miniSize;
     // True value count. May be less than valueCount because of nulls
     this.totalValueCount = BytesUtils.readUnsignedVarInt(in);


### PR DESCRIPTION
### What changes were proposed in this pull request?

`ReadAheadInputStream` (core) and `VectorizedDeltaBinaryPackedReader` (sql/core) validated their
arguments through `org.apache.spark.network.util.JavaUtils.checkArgument(check, msg, args...)`,
passing an already-concatenated message string, e.g.:

```java
JavaUtils.checkArgument(bufferSizeInBytes > 0,
    "bufferSizeInBytes should be greater than 0, but the value is " + bufferSizeInBytes);
```

This PR replaces each of the three call sites with an inline
`if (!cond) { throw new IllegalArgumentException(...); }` and removes the now-unused
`org.apache.spark.network.util.JavaUtils` import from both files. The exception type and message
text are unchanged.

### Why are the changes needed?

The `checkArgument(boolean, String, Object...)` overload is designed for deferred `%s` templating
(`String.format(msg, args)` is evaluated only on failure). Passing an already-concatenated string
misuses it in two ways:

- The failure message is built eagerly on every call and then discarded on the (overwhelmingly
  common) success path — `initFromPage` runs once per Parquet page.
- It pulls in a cross-package dependency on the shuffle/network module's `JavaUtils` purely for a
  one-line precondition, and passes an already-interpolated string as a `String.format` template,
  so a stray `%` in the interpolated value would throw a `FormatFlagsConversionMismatchException`
  (or similar) instead of the intended `IllegalArgumentException`.

The inline form builds the message only on failure, drops the cross-package dependency, and in
`VectorizedDeltaBinaryPackedReader` matches the `if (...) throw new ParquetDecodingException(...)`
style already used throughout that file.

### Does this PR introduce _any_ user-facing change?

No. The same `IllegalArgumentException` with the same message is thrown on the same conditions.

### How was this patch tested?

Existing suites pass: `ReadAheadInputStreamSuite` (8 tests) and `ParquetDeltaEncodingInteger` +
`ParquetDeltaEncodingLong` (32 tests). Checkstyle is clean on both `core` and `sql/core`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
