### PR TITLE
[MINOR][CORE] Document the JavaUtils.checkArgument format-string contract and fix a concatenating caller

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/RemoteBlockPushResolver.java
@@ -214,7 +214,7 @@ public class RemoteBlockPushResolver implements MergedShuffleFileManager {
     // TODO: [SPARK-33236] Change the message when this service is able to handle NM restart
     AppShuffleInfo appShuffleInfo = appsShuffleInfo.get(appId);
     JavaUtils.checkArgument(appShuffleInfo != null,
-      "application " + appId + " is not registered or NM was restarted.");
+      "application %s is not registered or NM was restarted.", appId);
     return appShuffleInfo;
   }
 

--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -751,8 +751,40 @@ public class JavaUtils {
     .anyMatch(prefix -> osName.regionMatches(true, 0, prefix, 0, prefix.length()));
 
   /**
-   * Throws IllegalArgumentException with the given message if the check is false.
-   * Keep this clone of CommandBuilderUtils.checkArgument synced with the original.
+   * Throws an {@link IllegalArgumentException} with a formatted message if {@code check} is
+   * {@code false}.
+   *
+   * <p>The failure message is produced with {@link String#format(String, Object...)}: {@code msg}
+   * is the format string and every runtime value must be supplied through {@code args} using a
+   * conversion such as {@code %s}. <b>Do not concatenate values into {@code msg}.</b> Passing an
+   * already-interpolated message, for example
+   * <pre>{@code checkArgument(cond, "bad key: " + key)}</pre>
+   * is a mistake for two reasons:
+   * <ul>
+   *   <li><b>It can mask the real failure.</b> If the interpolated value happens to contain a
+   *       {@code %} (a percent-encoded token, a Windows path such as {@code %TEMP%}, a SQL
+   *       {@code LIKE} pattern, a formatted number like {@code "50%"}, and so on) then, on the
+   *       failure path, {@link String#format(String, Object...)} tries to interpret it as a
+   *       conversion and throws an {@link java.util.IllegalFormatException} (for instance
+   *       {@link java.util.UnknownFormatConversionException} or
+   *       {@link java.util.MissingFormatArgumentException}). That formatting error is thrown in
+   *       place of the intended argument-validation error and carries a message about the format
+   *       string rather than the condition that actually failed, so the true cause is lost.</li>
+   *   <li><b>It does needless work on the success path.</b> The message is built eagerly on every
+   *       call, including the common case where {@code check} is {@code true} and the string is
+   *       immediately discarded.</li>
+   * </ul>
+   * Instead, pass the values as trailing arguments, as in
+   * {@code checkArgument(cond, "bad key: %s", key)}, so the message is format-safe (arbitrary
+   * characters in {@code key} are inserted literally) and is built only when the check fails.
+   *
+   * <p>Keep this clone of {@code CommandBuilderUtils.checkArgument} synced with the original.
+   *
+   * @param check the condition that must hold; an exception is thrown when it is {@code false}
+   * @param msg   a {@link String#format(String, Object...)} format string for the failure message;
+   *              do not interpolate runtime values into it, pass them through {@code args}
+   * @param args  the arguments referenced by the format specifiers in {@code msg}
+   * @throws IllegalArgumentException if {@code check} is {@code false}
    */
   public static void checkArgument(boolean check, String msg, Object... args) {
     if (!check) {
@@ -761,8 +793,20 @@ public class JavaUtils {
   }
 
   /**
-   * Throws IllegalStateException with the given message if the check is false.
-   * Keep this clone of CommandBuilderUtils.checkState synced with the original.
+   * Throws an {@link IllegalStateException} with a formatted message if {@code check} is
+   * {@code false}.
+   *
+   * <p>{@code msg} is a {@link String#format(String, Object...)} format string; the same
+   * format-argument contract and caveats described on {@link #checkArgument(boolean, String,
+   * Object...)} apply here.
+   *
+   * <p>Keep this clone of {@code CommandBuilderUtils.checkState} synced with the original.
+   *
+   * @param check the condition that must hold; an exception is thrown when it is {@code false}
+   * @param msg   a {@link String#format(String, Object...)} format string for the failure message;
+   *              do not interpolate runtime values into it, pass them through {@code args}
+   * @param args  the arguments referenced by the format specifiers in {@code msg}
+   * @throws IllegalStateException if {@code check} is {@code false}
    */
   public static void checkState(boolean check, String msg, Object... args) {
     if (!check) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`JavaUtils.checkArgument` and `JavaUtils.checkState` build their failure message with
`String.format(msg, args)`, so `msg` is a format string and callers are meant to pass runtime
values as trailing `args` (e.g. `checkArgument(cond, "bad key: %s", key)`). This was not documented,
and one caller concatenated the value into the message instead. This PR:

- Expands the `checkArgument` / `checkState` JavaDoc to describe the `String.format` contract and
  warn against interpolating values into `msg`, showing the correct `%s` idiom.
- Fixes the concatenating caller in `RemoteBlockPushResolver.validateAndGetAppShuffleInfo`:

  ```java
  // before
  JavaUtils.checkArgument(appShuffleInfo != null,
    "application " + appId + " is not registered or NM was restarted.");
  // after
  JavaUtils.checkArgument(appShuffleInfo != null,
    "application %s is not registered or NM was restarted.", appId);
  ```

### Why are the changes needed?

Concatenating a value into `msg` is unsafe. On the failure path `String.format` treats the
already-interpolated text as the format string, so a stray `%` in the value (a percent-encoded
token, a Windows path such as `%TEMP%`, a SQL `LIKE` pattern, a number like `"50%"`) makes it throw
an `IllegalFormatException` that replaces the intended `IllegalArgumentException` and hides the real
reason the check failed. It also builds the message eagerly on every call, including the common
success path where it is immediately discarded. Documenting the contract and correcting the one
concatenating caller prevents this.

### Does this PR introduce _any_ user-facing change?

No. The message produced by the corrected caller is identical (`%s` is substituted with `appId`),
and the remaining changes are documentation only.

### How was this patch tested?

Existing `RemoteBlockPushResolverSuite` passes (46 tests; the two tests that assert the
"application ... is not registered" message still hold, since the produced text is unchanged).
Checkstyle is clean on both `common-utils-java` and `network-shuffle`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
