### PR TITLE
[SPARK-59439][CORE] Release the HistoryServerDiskManager lease reservation exactly once on a failed commit

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerDiskManager.scala
@@ -332,6 +332,19 @@ private class HistoryServerDiskManager(
 
   private[history] class Lease(val tmpPath: File, private val leased: Long) {
 
+    // The leased (reserved, uncommitted) usage must be returned exactly once, whether the lease
+    // is committed or rolled back. commit() releases it before moving the store into place, so a
+    // failure after that point (e.g. a failed rename) sends the caller through rollback(); guard
+    // against releasing it a second time there, which would drive the usage tracker negative.
+    private var released = false
+
+    private def releaseLease(): Unit = {
+      if (!released) {
+        updateUsage(-leased)
+        released = true
+      }
+    }
+
     /**
      * Commits a lease to its final location, and update accounting information. This method
      * marks the application as active, so its store is not available for eviction.
@@ -357,7 +370,7 @@ private class HistoryServerDiskManager(
         }
       }
 
-      updateUsage(-leased)
+      releaseLease()
 
       val newSize = sizeOf(tmpPath)
       makeRoom(newSize)
@@ -385,7 +398,7 @@ private class HistoryServerDiskManager(
 
     /** Deletes the temporary directory created for the lease. */
     def rollback(): Unit = {
-      updateUsage(-leased)
+      releaseLease()
       Utils.deleteRecursively(tmpPath)
     }
 

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.deploy.history
 
-import java.io.File
+import java.io.{File, IOException}
 import java.util.concurrent.{CountDownLatch, FutureTask, TimeUnit}
 
 import scala.concurrent.duration._
@@ -409,6 +409,35 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
     assert(!dst.exists())
     manager.release("app1", None, delete = true)
     assert(manager.committed() === 0)
+  }
+
+  test("SPARK-59439: a failed commit rename does not double-release the lease") {
+    val manager = mockManager()
+
+    // Reserve space for a store, then make the rename in commit() fail by removing the source
+    // directory. commit() releases the lease reservation before the rename, so a failure there
+    // must not let the caller's rollback() deduct the reservation a second time.
+    val lease = manager.lease(2)
+    doReturn(2L).when(manager).sizeOf(meq(lease.tmpPath))
+    Utils.deleteRecursively(lease.tmpPath)
+
+    intercept[IOException] {
+      lease.commit("app1", None)
+    }
+    // The caller rolls the lease back after the failed commit, as FsHistoryProvider does.
+    lease.rollback()
+
+    // The reservation was returned exactly once: usage is back to zero (not negative) and the
+    // full capacity is free again.
+    assert(manager.committed() === 0)
+    assert(manager.free() === MAX_USAGE)
+
+    // Accounting is intact, so a subsequent lease and commit still succeed.
+    val lease2 = manager.lease(2)
+    doReturn(2L).when(manager).sizeOf(meq(lease2.tmpPath))
+    val dst = lease2.commit("app1", None)
+    assert(dst.isDirectory())
+    assert(manager.committed() === 2)
   }
 
   test("SPARK-38095: appStorePath should use backend extensions") {

--- a/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/history/HistoryServerDiskManagerSuite.scala
@@ -427,9 +427,8 @@ abstract class HistoryServerDiskManagerSuite extends SparkFunSuite with BeforeAn
     // The caller rolls the lease back after the failed commit, as FsHistoryProvider does.
     lease.rollback()
 
-    // The reservation was returned exactly once: usage is back to zero (not negative) and the
-    // full capacity is free again.
-    assert(manager.committed() === 0)
+    // The leased reservation was returned exactly once: the current (leased) usage is back to
+    // zero, not negative, so the full capacity is free again. committed() is untouched here.
     assert(manager.free() === MAX_USAGE)
 
     // Accounting is intact, so a subsequent lease and commit still succeed.


### PR DESCRIPTION
### What changes were proposed in this pull request?

`HistoryServerDiskManager.Lease` now releases its reserved (uncommitted) usage exactly once, whether the lease is committed, fails to commit, or is rolled back. The two `updateUsage(-leased)` calls in `commit()` and `rollback()` are replaced by an idempotent `releaseLease()` helper guarded by a `released` flag.

A regression test forces the rename in `commit()` to fail, then calls `rollback()` (as the caller does) and asserts the usage tracker returns to zero rather than going negative, and that a subsequent lease/commit still succeeds.

### Why are the changes needed?

`Lease.commit()` releases the reservation with `updateUsage(-leased)` before renaming the temporary store into place. SPARK-58985 made that rename throw an `IOException` on failure, which happens *after* the reservation has already been released. The caller then rolls the lease back -- e.g. `FsHistoryProvider.createDiskStore()` calls `lease.rollback()` on `IOException` -- and `rollback()` releases the reservation a second time.

The reservation is added once (in `lease()`) but subtracted twice, so the current-usage tracker is under-counted by the leased amount and can go negative, throwing:

```
java.lang.IllegalStateException: Disk usage tracker went negative (now = ..., delta = ...)
```

This is the same crash SPARK-58985 aimed to prevent; it is reachable whenever `renameTo` fails (I/O error, full disk, destination parent removed out of band). In `createDiskStore()`'s retry loop the exception also escapes the loop, so the store is never rebuilt.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New unit test in `HistoryServerDiskManagerSuite` (runs for both the LevelDB and RocksDB backends). It fails on the current code with `IllegalStateException: Disk usage tracker went negative` and passes with this change.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8
