### PR TITLE
[MINOR][CORE] Add verbatim-message overloads for JavaUtils.checkArgument and checkState

### DIFF
--- a/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/util/JavaUtilsSuite.java
@@ -90,4 +90,25 @@ public class JavaUtilsSuite {
     assertEquals(1, JavaUtils.listFiles(symlink).size());
     assertEquals(1, JavaUtils.listPaths(symlink).size());
   }
+
+  @Test
+  public void testCheckArgumentUsesMessageVerbatim() {
+    // The no-varargs overload must not run the message through String.format: a '%' in the
+    // message is preserved rather than interpreted as a (here invalid) format conversion, which
+    // would otherwise throw an IllegalFormatException and mask the intended error.
+    String msg = "invalid value: 100% done, %d unparsed";
+    assertDoesNotThrow(() -> JavaUtils.checkArgument(true, msg));
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+      () -> JavaUtils.checkArgument(false, msg));
+    assertEquals(msg, e.getMessage());
+  }
+
+  @Test
+  public void testCheckStateUsesMessageVerbatim() {
+    String msg = "bad state: 50% done, %s missing";
+    assertDoesNotThrow(() -> JavaUtils.checkState(true, msg));
+    IllegalStateException e = assertThrows(IllegalStateException.class,
+      () -> JavaUtils.checkState(false, msg));
+    assertEquals(msg, e.getMessage());
+  }
 }

--- a/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils-java/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -761,12 +761,53 @@ public class JavaUtils {
   }
 
   /**
+   * Throws an {@link IllegalArgumentException} with the given message if {@code check} is
+   * {@code false}.
+   *
+   * <p>Unlike {@link #checkArgument(boolean, String, Object...)}, {@code msg} is used verbatim and
+   * is <b>not</b> passed through {@link String#format(String, Object...)}. Prefer this overload
+   * whenever the message is a fixed string or is assembled by the caller (for example by
+   * concatenation): the message may then contain {@code %} characters without risking a
+   * {@link java.util.IllegalFormatException} that would mask the intended error, and no format
+   * arguments array is allocated. Use the varargs overload only when there are values to
+   * interpolate, passing them as arguments (e.g. {@code checkArgument(cond, "bad key: %s", key)})
+   * rather than concatenating them into {@code msg}.
+   *
+   * @param check the condition that must hold; an exception is thrown when it is {@code false}
+   * @param msg   the failure message, used exactly as given
+   * @throws IllegalArgumentException if {@code check} is {@code false}
+   */
+  public static void checkArgument(boolean check, String msg) {
+    if (!check) {
+      throw new IllegalArgumentException(msg);
+    }
+  }
+
+  /**
    * Throws IllegalStateException with the given message if the check is false.
    * Keep this clone of CommandBuilderUtils.checkState synced with the original.
    */
   public static void checkState(boolean check, String msg, Object... args) {
     if (!check) {
       throw new IllegalStateException(String.format(msg, args));
+    }
+  }
+
+  /**
+   * Throws an {@link IllegalStateException} with the given message if {@code check} is
+   * {@code false}.
+   *
+   * <p>Unlike {@link #checkState(boolean, String, Object...)}, {@code msg} is used verbatim and is
+   * <b>not</b> passed through {@link String#format(String, Object...)}; see
+   * {@link #checkArgument(boolean, String)} for when to prefer this form over the varargs one.
+   *
+   * @param check the condition that must hold; an exception is thrown when it is {@code false}
+   * @param msg   the failure message, used exactly as given
+   * @throws IllegalStateException if {@code check} is {@code false}
+   */
+  public static void checkState(boolean check, String msg) {
+    if (!check) {
+      throw new IllegalStateException(msg);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add two overloads to `JavaUtils` that throw the failure message verbatim:

```java
public static void checkArgument(boolean check, String msg) { ... }
public static void checkState(boolean check, String msg) { ... }
```

Unlike the existing `checkArgument`/`checkState(boolean, String, Object...)` methods, these do
**not** route the message through `String.format`. The existing varargs methods (and their
"keep synced with `CommandBuilderUtils`" bodies) are left unchanged.

### Why are the changes needed?

`checkArgument`/`checkState` build the message with `String.format(msg, args)`, so `msg` is a
format string. When a caller has no values to interpolate and passes a plain or
already-concatenated message, that message is still treated as a format template: a stray `%` in
it (a percent-encoded token, a Windows path such as `%TEMP%`, a SQL `LIKE` pattern, a number like
`"50%"`) makes `String.format` throw an `IllegalFormatException` that replaces the intended
`IllegalArgumentException` / `IllegalStateException` and hides the real reason the check failed.

The new overloads make the no-argument case format-safe: the message is used exactly as given, and
no empty varargs array is allocated. Existing two-argument call sites bind to these overloads
automatically on recompile — a two-argument call is never ambiguous with the varargs form — so they
gain this safety with no source changes. Callers that do have values to interpolate keep using the
varargs overload and should pass the values as arguments (`"bad key: %s", key`) rather than
concatenating them.

### Does this PR introduce _any_ user-facing change?

No. For the plain messages used by existing callers (none of which contain a `%`), the exception
type and message are unchanged; the overloads only change behavior for a message that contains a
`%` and no arguments, which previously threw a formatting error.

### How was this patch tested?

Added `testCheckArgumentUsesMessageVerbatim` / `testCheckStateUsesMessageVerbatim` to
`JavaUtilsSuite`, asserting that a message containing `%` (which would otherwise make
`String.format` throw) is preserved verbatim in the thrown exception. `JavaUtilsSuite` passes (4
tests). `common-utils-java`, `network-common`, `network-shuffle`, and `kvstore` compile cleanly
(confirming existing two-argument callers rebind without ambiguity), and checkstyle is clean.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8

This pull request and its description were written by Isaac.
