### PR TITLE
[SPARK-59441][PYTHON] Simplify the UDF/UDTF runner contract to (func, serializer)

### DIFF
--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -2186,7 +2186,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
             yield from map(ArrowBatchTransformer.wrap_struct, verified_iter)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
@@ -2219,7 +2218,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 verify_scalar_result(output_batch, batch.num_rows)
                 yield output_batch
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
@@ -2279,7 +2277,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             # Verify iterator consumed
             verify_iterator_exhausted(args_iter)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
@@ -2319,7 +2316,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
@@ -2350,7 +2346,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 batch = pa.RecordBatch.from_arrays([pa.array([result])], ["_0"])
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_PARTIAL_UDF:
@@ -2469,7 +2464,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for start in range(0, len(entries), cap):
                     yield make_batch(entries[start : start + cap])
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_FINAL_UDF:
@@ -2516,7 +2510,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF:
@@ -2560,7 +2553,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF:
@@ -2606,7 +2598,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
@@ -2674,7 +2665,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_INCREMENTAL_UDF:
@@ -2769,7 +2759,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 batch = pa.RecordBatch.from_arrays(result_arrays, col_names)
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF:
@@ -2857,7 +2846,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF:
@@ -2918,7 +2906,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for batch in result.to_batches():
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_ITER_UDF:
@@ -2982,7 +2969,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for _ in value_batches:
                     pass
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
@@ -3053,7 +3039,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
                 del result
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_ITER_UDF:
@@ -3129,7 +3114,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for _ in group_iter:
                     pass
 
-        # profiling is not supported for UDF
         return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF:
@@ -3182,7 +3166,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for batch in result.to_batches():
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
-        # profiling is not supported for UDF
         return cogrouped_func, ser
 
     if eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
@@ -3259,7 +3242,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF:
@@ -3328,7 +3310,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
                 del result
 
-        # profiling is not supported for UDF
         return cogrouped_func, ser
 
     if (
@@ -3421,7 +3402,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if (
@@ -3511,7 +3491,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_ARROW_ELEMENTWISE_UDF:
@@ -3641,7 +3620,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type in (
@@ -3767,7 +3745,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type in (
@@ -3932,7 +3909,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
 
             yield from process_results()
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
@@ -4004,7 +3980,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     int_to_decimal_coercion_enabled=runner_conf.int_to_decimal_coercion_enabled,
                 )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF:
@@ -4081,7 +4056,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             # Verify iterator consumed
             verify_iterator_exhausted(args_iter)
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_UDF:
@@ -4224,7 +4198,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
             )
 
-        # profiling is not supported for UDF
         return transform_with_state_func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF:
@@ -4437,7 +4410,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
             )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
@@ -4771,7 +4743,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     pdfs, pdf_data_cnt, return_type, state_pdfs, state_data_cnt
                 )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF:
@@ -4873,7 +4844,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
             )
 
-        # profiling is not supported for UDF
         return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF:
@@ -5054,7 +5024,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
             )
 
-        # profiling is not supported for UDF
         return func, ser
 
     elif eval_type == PythonEvalType.SQL_BATCHED_UDF:
@@ -5072,7 +5041,6 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 for row in data
             )
 
-        # profiling is not supported for UDF
         return func, ser
 
     else:

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1522,7 +1522,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, None, ser, ser
+        return func, ser, ser
 
     elif (
         eval_type == PythonEvalType.SQL_ARROW_TABLE_UDF
@@ -1686,7 +1686,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, None, ser, ser
+        return func, ser, ser
 
     elif eval_type == PythonEvalType.SQL_ARROW_UDTF:
         import pyarrow as pa
@@ -1794,7 +1794,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, None, ser, ser
+        return func, ser, ser
 
     else:
 
@@ -1896,7 +1896,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return mapper, None, ser, ser
+        return mapper, ser, ser
 
 
 def _elementwise_renest(flat_values, shape_lengths, is_large):
@@ -2187,7 +2187,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from map(ArrowBatchTransformer.wrap_struct, verified_iter)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
@@ -2220,7 +2220,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield output_batch
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2280,7 +2280,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
         import pyarrow as pa
@@ -2320,7 +2320,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2351,7 +2351,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_PARTIAL_UDF:
         import pyarrow as pa
@@ -2470,7 +2470,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield make_batch(entries[start : start + cap])
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_FINAL_UDF:
         import pyarrow as pa
@@ -2517,7 +2517,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF:
         import pandas as pd
@@ -2561,7 +2561,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF:
         import pandas as pd
@@ -2607,7 +2607,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
         import pyarrow as pa
@@ -2675,7 +2675,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_INCREMENTAL_UDF:
         import pyarrow as pa
@@ -2770,7 +2770,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF:
         import pandas as pd
@@ -2858,7 +2858,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF:
         import pyarrow as pa
@@ -2919,7 +2919,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2983,7 +2983,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     pass
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         import pandas as pd
@@ -3054,7 +3054,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 del result
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_ITER_UDF:
         import pandas as pd
@@ -3130,7 +3130,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     pass
 
         # profiling is not supported for UDF
-        return grouped_func, None, ser, ser
+        return grouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF:
         import pyarrow as pa
@@ -3183,7 +3183,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
         # profiling is not supported for UDF
-        return cogrouped_func, None, ser, ser
+        return cogrouped_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         import pandas as pd
@@ -3260,7 +3260,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF:
         import pandas as pd
@@ -3329,7 +3329,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 del result
 
         # profiling is not supported for UDF
-        return cogrouped_func, None, ser, ser
+        return cogrouped_func, ser, ser
 
     if (
         eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
@@ -3422,7 +3422,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if (
         eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
@@ -3512,7 +3512,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_ARROW_ELEMENTWISE_UDF:
         # This path exchanges data with the JVM over Arrow, so PyArrow is required. Fail with a
@@ -3642,7 +3642,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ELEMENTWISE_UDF,
@@ -3768,7 +3768,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ITER_ELEMENTWISE_UDF,
@@ -3933,7 +3933,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from process_results()
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
         import pandas as pd
@@ -4005,7 +4005,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF:
         import pandas as pd
@@ -4082,7 +4082,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_UDF:
         import pandas as pd
@@ -4225,7 +4225,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return transform_with_state_func, None, ser, ser
+        return transform_with_state_func, ser, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF:
         import pandas as pd
@@ -4438,7 +4438,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
         import pandas as pd
@@ -4772,7 +4772,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF:
         import pyarrow as pa
@@ -4874,7 +4874,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF:
         import pyarrow as pa
@@ -5055,7 +5055,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     elif eval_type == PythonEvalType.SQL_BATCHED_UDF:
         # Plain Python (pickle) UDFs, the only eval type reaching this branch. read_single_udf
@@ -5073,7 +5073,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, None, ser, ser
+        return func, ser, ser
 
     else:
         raise ValueError("Unknown eval type: {}".format(eval_type))
@@ -5116,20 +5116,22 @@ def invoke_udf(message_receiver: SparkMessageReceiver, outfile: BinaryIO):
         runner_conf = RunnerConf(init_info.runner_conf)
         eval_conf = EvalConf(init_info.eval_conf)
         if eval_type == PythonEvalType.NON_UDF:
+            # The classic RDD command carries its own profiler in the pickled command.
             assert isinstance(init_info.udf_info, (bytes, memoryview))
             func, profiler, deserializer, serializer = read_command(pickleSer, init_info.udf_info)
-        elif eval_type in (
-            PythonEvalType.SQL_TABLE_UDF,
-            PythonEvalType.SQL_ARROW_TABLE_UDF,
-            PythonEvalType.SQL_ARROW_UDTF,
-        ):
-            func, profiler, deserializer, serializer = read_udtf(
-                pickleSer, init_info.udf_info, eval_type, runner_conf, eval_conf
-            )
         else:
-            func, profiler, deserializer, serializer = read_udfs(
+            # UDF and UDTF runners fold profiling into func at construction time
+            # (see read_single_udf), so no profiler is returned separately here.
+            is_udtf = eval_type in (
+                PythonEvalType.SQL_TABLE_UDF,
+                PythonEvalType.SQL_ARROW_TABLE_UDF,
+                PythonEvalType.SQL_ARROW_UDTF,
+            )
+            read = read_udtf if is_udtf else read_udfs
+            func, deserializer, serializer = read(
                 pickleSer, init_info.udf_info, eval_type, runner_conf, eval_conf
             )
+            profiler = None
 
         init_time = time.time()
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -5115,14 +5115,14 @@ def invoke_udf(message_receiver: SparkMessageReceiver, outfile: BinaryIO):
         eval_type = init_info.eval_type
         runner_conf = RunnerConf(init_info.runner_conf)
         eval_conf = EvalConf(init_info.eval_conf)
+        # UDF and UDTF runners fold profiling into func at construction time (see
+        # read_single_udf); only the classic RDD command carries a profiler of its own.
+        profiler = None
         if eval_type == PythonEvalType.NON_UDF:
-            # The classic RDD command carries its own profiler in the pickled command.
             assert isinstance(init_info.udf_info, (bytes, memoryview))
             func, profiler, deserializer, serializer = read_command(pickleSer, init_info.udf_info)
         else:
-            # UDF and UDTF runners fold profiling into func at construction time
-            # (see read_single_udf), so no profiler is returned separately here, and they
-            # read input and write output through a single serializer.
+            # UDF and UDTF runners read input and write output through a single serializer.
             is_udtf = eval_type in (
                 PythonEvalType.SQL_TABLE_UDF,
                 PythonEvalType.SQL_ARROW_TABLE_UDF,
@@ -5132,7 +5132,7 @@ def invoke_udf(message_receiver: SparkMessageReceiver, outfile: BinaryIO):
             func, serializer = read(
                 pickleSer, init_info.udf_info, eval_type, runner_conf, eval_conf
             )
-            profiler, deserializer = None, serializer
+            deserializer = serializer
 
         init_time = time.time()
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -1522,7 +1522,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, ser, ser
+        return func, ser
 
     elif (
         eval_type == PythonEvalType.SQL_ARROW_TABLE_UDF
@@ -1686,7 +1686,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, ser, ser
+        return func, ser
 
     elif eval_type == PythonEvalType.SQL_ARROW_UDTF:
         import pyarrow as pa
@@ -1794,7 +1794,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return func, ser, ser
+        return func, ser
 
     else:
 
@@ -1896,7 +1896,7 @@ def read_udtf(pickleSer, udtf_info, eval_type, runner_conf, eval_conf):
                 if cleanup is not None:
                     cleanup()
 
-        return mapper, ser, ser
+        return mapper, ser
 
 
 def _elementwise_renest(flat_values, shape_lengths, is_large):
@@ -2187,7 +2187,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from map(ArrowBatchTransformer.wrap_struct, verified_iter)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_UDF:
         import pyarrow as pa
@@ -2220,7 +2220,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield output_batch
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2280,7 +2280,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_UDF:
         import pyarrow as pa
@@ -2320,7 +2320,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2351,7 +2351,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_PARTIAL_UDF:
         import pyarrow as pa
@@ -2470,7 +2470,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield make_batch(entries[start : start + cap])
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_ARROW_INCREMENTAL_FINAL_UDF:
         import pyarrow as pa
@@ -2517,7 +2517,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF:
         import pandas as pd
@@ -2561,7 +2561,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_AGG_PANDAS_ITER_UDF:
         import pandas as pd
@@ -2607,7 +2607,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_UDF:
         import pyarrow as pa
@@ -2675,7 +2675,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_ARROW_INCREMENTAL_UDF:
         import pyarrow as pa
@@ -2770,7 +2770,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield ArrowBatchTransformer.enforce_schema(batch, return_schema)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_WINDOW_AGG_PANDAS_UDF:
         import pandas as pd
@@ -2858,7 +2858,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF:
         import pyarrow as pa
@@ -2919,7 +2919,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_ARROW_ITER_UDF:
         import pyarrow as pa
@@ -2983,7 +2983,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     pass
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF:
         import pandas as pd
@@ -3054,7 +3054,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 del result
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_ITER_UDF:
         import pandas as pd
@@ -3130,7 +3130,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     pass
 
         # profiling is not supported for UDF
-        return grouped_func, ser, ser
+        return grouped_func, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF:
         import pyarrow as pa
@@ -3183,7 +3183,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                     yield ArrowBatchTransformer.wrap_struct(batch)
 
         # profiling is not supported for UDF
-        return cogrouped_func, ser, ser
+        return cogrouped_func, ser
 
     if eval_type == PythonEvalType.SQL_MAP_PANDAS_ITER_UDF:
         import pandas as pd
@@ -3260,7 +3260,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF:
         import pandas as pd
@@ -3329,7 +3329,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 del result
 
         # profiling is not supported for UDF
-        return cogrouped_func, ser, ser
+        return cogrouped_func, ser
 
     if (
         eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
@@ -3422,7 +3422,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if (
         eval_type == PythonEvalType.SQL_ARROW_BATCHED_UDF
@@ -3512,7 +3512,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_ARROW_ELEMENTWISE_UDF:
         # This path exchanges data with the JVM over Arrow, so PyArrow is required. Fail with a
@@ -3642,7 +3642,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ELEMENTWISE_UDF,
@@ -3768,7 +3768,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 yield pa.RecordBatch.from_arrays(output_arrays, col_names)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type in (
         PythonEvalType.SQL_SCALAR_PANDAS_ITER_ELEMENTWISE_UDF,
@@ -3933,7 +3933,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             yield from process_results()
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_UDF:
         import pandas as pd
@@ -4005,7 +4005,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_SCALAR_PANDAS_ITER_UDF:
         import pandas as pd
@@ -4082,7 +4082,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             verify_iterator_exhausted(args_iter)
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_UDF:
         import pandas as pd
@@ -4225,7 +4225,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return transform_with_state_func, ser, ser
+        return transform_with_state_func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PANDAS_INIT_STATE_UDF:
         import pandas as pd
@@ -4438,7 +4438,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE:
         import pandas as pd
@@ -4772,7 +4772,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
                 )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_UDF:
         import pyarrow as pa
@@ -4874,7 +4874,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     if eval_type == PythonEvalType.SQL_TRANSFORM_WITH_STATE_PYTHON_ROW_INIT_STATE_UDF:
         import pyarrow as pa
@@ -5055,7 +5055,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     elif eval_type == PythonEvalType.SQL_BATCHED_UDF:
         # Plain Python (pickle) UDFs, the only eval type reaching this branch. read_single_udf
@@ -5073,7 +5073,7 @@ def read_udfs(pickleSer, udf_info_list, eval_type, runner_conf, eval_conf):
             )
 
         # profiling is not supported for UDF
-        return func, ser, ser
+        return func, ser
 
     else:
         raise ValueError("Unknown eval type: {}".format(eval_type))
@@ -5121,17 +5121,18 @@ def invoke_udf(message_receiver: SparkMessageReceiver, outfile: BinaryIO):
             func, profiler, deserializer, serializer = read_command(pickleSer, init_info.udf_info)
         else:
             # UDF and UDTF runners fold profiling into func at construction time
-            # (see read_single_udf), so no profiler is returned separately here.
+            # (see read_single_udf), so no profiler is returned separately here, and they
+            # read input and write output through a single serializer.
             is_udtf = eval_type in (
                 PythonEvalType.SQL_TABLE_UDF,
                 PythonEvalType.SQL_ARROW_TABLE_UDF,
                 PythonEvalType.SQL_ARROW_UDTF,
             )
             read = read_udtf if is_udtf else read_udfs
-            func, deserializer, serializer = read(
+            func, serializer = read(
                 pickleSer, init_info.udf_info, eval_type, runner_conf, eval_conf
             )
-            profiler = None
+            profiler, deserializer = None, serializer
 
         init_time = time.time()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

`read_udfs` and `read_udtf` in `python/pyspark/worker.py` previously returned a four-element tuple `(func, profiler, deserializer, serializer)` in which, for every UDF/UDTF eval type, `profiler` was always `None` and `deserializer` was always the same object as `serializer`. Both now return just `(func, serializer)`, and the UDF/UDTF branches of the worker dispatch are merged since the two functions share a signature. The classic RDD command path (`NON_UDF`, via `read_command`) keeps the four-element contract because its pickled command genuinely carries an independent input deserializer (distinct from the output serializer) and its own profiler.

### Why are the changes needed?

This is preparatory refactoring for the extensible eval-type handler model tracked by the parent SPARK-59415: shrinking the contract now means each future handler produces `(func, serializer)` rather than a four-element tuple. The dropped elements were dead weight for UDF/UDTF, and the boundary between them and `NON_UDF` is intrinsic rather than incidental:

- Profiler: SQL UDF profiling is folded into `func` in `read_single_udf` (per-UDF `result_id`, per-batch, scoped to the user function), so no profiler is returned separately. The RDD profiler is instead a pluggable instance sent over the wire that must wrap the whole task (`profiler.profile(run_process)`) to capture its lazily-consumed output. Neither can move to the other's boundary without changing what is measured, so only `NON_UDF` returns a profiler.
- Deserializer: UDF/UDTF read input and write output through a single serializer; only the RDD command has an input deserializer distinct from its output serializer.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No behavior change; the existing per-eval-type UDF/UDTF suites cover these paths. Also verified locally across representative eval types via `read_udfs` (plain Python UDF, scalar pandas UDF, grouped-map and cogrouped-map `applyInPandas`, grouped-agg pandas UDF, `mapInPandas`), via `read_udtf` (a Python UDTF), and via the `NON_UDF` classic RDD path (`rdd.map`), all with identical results.

### Was this patch authored or co-authored using generative AI tooling?

No.