### PR TITLE
[SPARK-59442][SQL] Zero the reserved payload when writing a null nanosecond timestamp to UnsafeRow

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -166,7 +166,8 @@ public abstract class UnsafeWriter {
       // Zero the reserved payload so that a null value is byte-identical no matter what stale bytes
       // the reused buffer holds. The buffer is not cleared between rows, so without this two null
       // keys can carry different bytes and split into separate groups (a nullable nanosecond
-      // GROUP BY / join key produced several null groups). Mirrors UnsafeRow#setTimestampNanos.
+      // GROUP BY / join key produced several null groups). Mirrors the in-place null-update path
+      // UnsafeRow#setTimestampNanosPayload, which zeroes the payload the same way.
       TimestampNanosRowValues.zeroPayload(getBuffer(), 0, (int) cursor());
     } else {
       TimestampNanosRowValues.writePayload(

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/codegen/UnsafeWriter.java
@@ -163,6 +163,11 @@ public abstract class UnsafeWriter {
     grow(TimestampNanosRowValues.SIZE_IN_BYTES);
     if (input == null) {
       BitSetMethods.set(getBuffer(), startingOffset, ordinal);
+      // Zero the reserved payload so that a null value is byte-identical no matter what stale bytes
+      // the reused buffer holds. The buffer is not cleared between rows, so without this two null
+      // keys can carry different bytes and split into separate groups (a nullable nanosecond
+      // GROUP BY / join key produced several null groups). Mirrors UnsafeRow#setTimestampNanos.
+      TimestampNanosRowValues.zeroPayload(getBuffer(), 0, (int) cursor());
     } else {
       TimestampNanosRowValues.writePayload(
         getBuffer(), 0, (int) cursor(), input.epochMicros, input.nanosWithinMicro);

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/UnsafeRowConverterSuite.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types.{IntegerType, LongType, _}
 import org.apache.spark.unsafe.array.ByteArrayMethods
-import org.apache.spark.unsafe.types.{CalendarInterval, UTF8String}
+import org.apache.spark.unsafe.types.{CalendarInterval, TimestampNanosVal, UTF8String}
 import org.apache.spark.util.ArrayImplicits._
 
 class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with ExpressionEvalHelper {
@@ -71,6 +71,35 @@ class UnsafeRowConverterSuite extends SparkFunSuite with Matchers with Expressio
     assert(unsafeRow2.getLong(0) === 0)
     assert(unsafeRow2.getLong(1) === 1)
     assert(unsafeRow2.getInt(2) === 2)
+  }
+
+  testBothCodegenAndInterpreted(
+      "null nanosecond timestamp keys are byte-identical regardless of prior rows") {
+    // The nanosecond timestamp types occupy a 16-byte variable-length payload. The projection
+    // reuses its output buffer across rows, so a null value must zero that payload; otherwise it
+    // inherits the previous non-null value's bytes and two null rows compare unequal -- which
+    // splits a nullable nanosecond GROUP BY / join key into several null groups.
+    Seq(TimestampNTZNanosType(9), TimestampLTZNanosType(9)).foreach { dt =>
+      val fieldTypes: Array[DataType] = Array(dt)
+      val converter = UnsafeProjection.create(fieldTypes)
+      val row = new SpecificInternalRow(fieldTypes.toImmutableArraySeq)
+
+      // Dirty the reused buffer with one non-null value, then project a null.
+      row.update(0, TimestampNanosVal.fromParts(1234567L, 111.toShort))
+      converter.apply(row)
+      row.setNullAt(0)
+      val nullAfterA = converter.apply(row).copy()
+
+      // Dirty the buffer with a *different* non-null value, then project a null again.
+      row.update(0, TimestampNanosVal.fromParts(987654321L, 222.toShort))
+      converter.apply(row)
+      row.setNullAt(0)
+      val nullAfterB = converter.apply(row).copy()
+
+      assert(nullAfterA.isNullAt(0) && nullAfterB.isNullAt(0))
+      assert(nullAfterA == nullAfterB,
+        s"two null $dt projections must be byte-identical but differed (stale payload)")
+    }
   }
 
   testBothCodegenAndInterpreted("basic conversion with primitive, string and binary types") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

`UnsafeWriter.write(int, TimestampNanosVal)` stores a nanosecond timestamp as a 16-byte variable-length payload (modeled on `CalendarInterval`) and reserves that space even for a null value so the slot can be updated in place later. On the null branch it set the null bit but left the reserved 16 bytes untouched. The writer's buffer is reused across rows, so a null nanosecond value inherited whatever bytes the previously written row left in that slot.

Two logically-equal null rows could therefore produce different `UnsafeRow` byte contents, breaking the invariant that equal rows encode identically -- the invariant that `UnsafeRow` hashing and equality rely on. This is the root cause of a nullable nanosecond-timestamp GROUP BY / join key splitting its NULLs across multiple groups.

The fix zeroes the reserved payload on the null branch, mirroring the in-place update path (`UnsafeRow.setTimestampNTZNanos` / `setTimestampLTZNanos`), which already calls `TimestampNanosRowValues.zeroPayload`.

### Why are the changes needed?

Correctness: a null nanosecond timestamp must encode canonically so that null grouping/join keys compare and hash identically. Without it, `GROUP BY` (and any key-based operator) over a nullable `TIMESTAMP_NTZ(p)` / `TIMESTAMP_LTZ(p)` column can silently scatter NULL rows across several groups. The array path (`UnsafeArrayWriter`) is unaffected: it writes a null element through `setNull8Bytes`, which zeroes the element's offset-and-size slot (size 0).

### Does this PR introduce any user-facing change?

No change in a default configuration -- the nanosecond timestamp types are behind the `spark.sql.timestampNanosTypes.enabled` preview flag (off by default). With the flag enabled, null nanosecond keys now group and compare canonically.

### How was this patch tested?

New `UnsafeRowConverterSuite` test asserting that two null nanosecond projections built after different non-null values are byte-identical, in both the interpreted and the codegen paths. It fails without this change and passes with it.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
