### PR TITLE
[SPARK-59437][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1060

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -9129,6 +9129,11 @@
           "The target JDBC server hosting table <tableName> does not support ALTER TABLE with multiple actions. Split the ALTER TABLE up into individual actions to avoid this error."
         ]
       },
+      "NESTED_COLUMN" : {
+        "message" : [
+          "<command> does not support nested column `<column>`."
+        ]
+      },
       "OBJECT_LEVEL_COLLATIONS" : {
         "message" : [
           "Default collation for the specified object."
@@ -10292,11 +10297,6 @@
   "_LEGACY_ERROR_TEMP_1059" : {
     "message" : [
       "STORED AS with file format '<serdeInfo>' is invalid."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1060" : {
-    "message" : [
-      "<command> does not support nested column: <column>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1068" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1341,7 +1341,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def commandNotSupportNestedColumnError(command: String, quoted: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1060",
+      errorClass = "UNSUPPORTED_FEATURE.NESTED_COLUMN",
       messageParameters = Map(
         "command" -> command,
         "column" -> quoted))

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -341,7 +341,7 @@ class DataSourceV2SQLSuiteV1Filter
       sql(s"CREATE TABLE $t (d struct<a: INT, b: INT>) USING foo")
       checkError(
         exception = analysisException(s"describe $t d.a"),
-        condition = "_LEGACY_ERROR_TEMP_1060",
+        condition = "UNSUPPORTED_FEATURE.NESTED_COLUMN",
         parameters = Map(
           "command" -> "DESC TABLE COLUMN",
           "column" -> "d.a"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DescribeTableSuiteBase.scala
@@ -173,10 +173,14 @@ trait DescribeTableSuiteBase extends QueryTest with DDLCommandTestUtils {
   test("describe a nested column") {
     withNamespaceAndTable("ns", "tbl") { tbl =>
       sql(s"CREATE TABLE $tbl (`a.b` int, col struct<x:int, y:string>) $defaultUsing")
-      val errMsg = intercept[AnalysisException] {
-        sql(s"DESCRIBE TABLE $tbl col.x")
-      }.getMessage
-      assert(errMsg === "DESC TABLE COLUMN does not support nested column: col.x.")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(s"DESCRIBE TABLE $tbl col.x")
+        },
+        condition = "UNSUPPORTED_FEATURE.NESTED_COLUMN",
+        parameters = Map(
+          "command" -> "DESC TABLE COLUMN",
+          "column" -> "col.x"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1060` to the named subclass `UNSUPPORTED_FEATURE.NESTED_COLUMN` (SQLSTATE `0A000`). It is raised when a command such as `DESC TABLE COLUMN` or JDBC filter push down is given a nested column it cannot operate on.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one (part of SPARK-37935).

### Does this PR introduce _any_ user-facing change?

Yes. The condition becomes `UNSUPPORTED_FEATURE.NESTED_COLUMN`, and the rendered message gains the standard `The feature is not supported:` prefix and quotes the column with backticks, e.g. ``The feature is not supported: DESC TABLE COLUMN does not support nested column `col.x`.``

### How was this patch tested?

Updated the existing `checkError` test in `DataSourceV2SQLSuite` and converted the message assertion in `DescribeTableSuiteBase` to `checkError`. `SparkThrowableSuite` passes.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8