### PR TITLE
[MINOR][SQL] Centralize static and runtime filter eligibility checks

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -58,6 +58,10 @@ object PushDownUtils extends Logging {
       filters: Seq[Expression],
       partitionFields: Option[Seq[PartitionPredicateField]])
       : (Either[Seq[sources.Filter], Seq[Predicate]], Seq[Expression]) = {
+    // Both V2 filter APIs keep non-deterministic filters for post-scan evaluation. A source may
+    // evaluate a pushed predicate a different number of times or at a different point than Spark,
+    // so a partial push could evaluate a non-deterministic predicate twice with different results.
+    lazy val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
     scanBuilder match {
       case r: SupportsPushDownFilters =>
         // A map from translated data source leaf node filters to original catalyst filter
@@ -93,13 +97,6 @@ object PushDownUtils extends Logging {
           (postScanFilters ++ untranslatableExprs).toImmutableArraySeq)
 
       case r: SupportsPushDownV2Filters =>
-        // Non-deterministic filters should not be pushed down: a data source may evaluate a pushed
-        // predicate a different number of times or at a different point than Spark, and a partial
-        // push (a predicate used for pruning yet also returned for post-scan re-evaluation, e.g. a
-        // parquet row group filter) would evaluate a non-deterministic predicate twice with
-        // different results. Keep them as post-scan filters, matching the
-        // SupportsPushDownCatalystFilters branch below.
-        val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
         // Divide the filters into those translatable and untranslatable to data source filters.
         // For the translated filters, we will try to push them down to the data source,
         // and the data source will return the filters that it cannot guarantee to be true
@@ -141,7 +138,6 @@ object PushDownUtils extends Logging {
           ExpressionSet(untranslatableExprs)) ++ nonDeterministicFilters
         (Right(r.pushedPredicates.toImmutableArraySeq), orderedPostScanFilters)
       case r: SupportsPushDownCatalystFilters =>
-        val (deterministicFilters, nonDeterministicFilters) = filters.partition(_.deterministic)
         val postScanFilters = r.pushFilters(deterministicFilters) ++ nonDeterministicFilters
         (Right(r.pushedFilters.toImmutableArraySeq), postScanFilters)
       case _ => (Left(Nil), filters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/PushDownUtils.scala
@@ -172,10 +172,9 @@ object PushDownUtils extends Logging {
    * group-based UPDATE), each pushing its own copy of the runtime filters. Successive calls are
    * additive: a scan ANDs the newly pushed predicates with those it already holds.
    *
-   * Note: `runtimeFilters` must not contain non-deterministic filters. A runtime filter is also
-   * evaluated by the `FilterExec` above the scan, so pushing a non-deterministic one would
-   * evaluate it twice with different results. `DataSourceV2Strategy` enforces this where
-   * `runtimeFilters` is built (SPARK-58207).
+   * Non-deterministic filters are not pushed. A runtime filter is also evaluated by the
+   * `FilterExec` above the scan, so pushing a non-deterministic one would evaluate it twice with
+   * different results.
    *
    * A scan implementing [[SupportsRuntimeCatalystFiltering]] takes a separate path: all
    * runtime filters are pushed as Catalyst expressions in a single call, with no translation to
@@ -188,15 +187,17 @@ object PushDownUtils extends Logging {
       runtimeFilters: Seq[Expression],
       table: Table,
       output: Seq[AttributeReference]): Boolean = {
+    val pushableFilters = runtimeFilters.filter(
+      isPushablePartitionFilter(_, includeSubquery = true))
     scan match {
       case _: SupportsRuntimeV2Filtering with SupportsRuntimeCatalystFiltering =>
         throw SparkException.internalError(
           "A scan must not implement both SupportsRuntimeV2Filtering and " +
           s"SupportsRuntimeCatalystFiltering, but ${scan.getClass.getName} implements both.")
 
-      case filterableScan: SupportsRuntimeV2Filtering if runtimeFilters.nonEmpty =>
+      case filterableScan: SupportsRuntimeV2Filtering if pushableFilters.nonEmpty =>
         // Push down translatable runtime filters.
-        val filtersToTranslated = runtimeFilters.flatMap { f =>
+        val filtersToTranslated = pushableFilters.flatMap { f =>
           (f match {
             case DynamicPruningExpression(e) => DataSourceV2Strategy.translateRuntimeFilterV2(e)
             case o => DataSourceV2Strategy.translateScalarSubqueryFilterV2(o)
@@ -218,7 +219,7 @@ object PushDownUtils extends Logging {
             "filterAttributes()",
             filterableScan.getClass.getName)
           val pushed = filterableScan.pushedPredicates().toSet
-          val candidates = runtimeFilters.filter { f =>
+          val candidates = pushableFilters.filter { f =>
             !filtersToTranslated.get(f).exists(pushed.contains) &&
               f.references.subsetOf(filterAttrs)
           }
@@ -233,7 +234,7 @@ object PushDownUtils extends Logging {
 
         translatedFiltersPushed || partPredicatesPushed
 
-      case catalystScan: SupportsRuntimeCatalystFiltering if runtimeFilters.nonEmpty =>
+      case catalystScan: SupportsRuntimeCatalystFiltering if pushableFilters.nonEmpty =>
         // A runtime filter is normally evaluated twice: the source prunes with it, and the
         // FilterExec above the scan applies it again. The two have to agree, so this screen
         // pushes only predicates the source can be trusted to evaluate in Spark's place.
@@ -247,17 +248,10 @@ object PushDownUtils extends Logging {
         // below, and we use the same method (isPushablePartitionFilter) to determine if we
         // should push it.
         //
-        // Note: today every filter reaching either site passes this check
-        // (deleted by DataSourceV2Strategy, and pushed by this method), since runtimeFilters
-        // holds only deterministic filters (SPARK-58207) and ExtractPythonUDFs has already
-        // lifted any Python UDF out of the post-scan filters. But sharing the check keeps the two
-        // decisions consistent if non-deterministic filters reach the site.
-        //
         // A DPP filter degrades to TrueLiteral once its subquery is pruned away, so it matches
         // every row. The V2 path above drops these implicitly, since translateRuntimeFilterV2
         // returns None; here we push Catalyst expressions directly, so we remove them explicitly.
-        val catalystFilters = runtimeFilters
-          .filter(isPushablePartitionFilter(_, includeSubquery = true))
+        val catalystFilters = pushableFilters
           .flatMap(unwrapRuntimeFilterExpression)
           .filterNot(_ == Literal.TrueLiteral)
         if (catalystFilters.nonEmpty) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR centralizes filter eligibility checks in `PushDownUtils`:

- Static filters are partitioned by determinism once and reused by the `SupportsPushDownV2Filters` and `SupportsPushDownCatalystFilters` paths. The shared value is lazy, so the legacy `SupportsPushDownFilters` path remains unchanged.
- Runtime filters are screened once before dispatching to the `SupportsRuntimeV2Filtering` or `SupportsRuntimeCatalystFiltering` path.

It also updates the runtime-filter method documentation to describe the enforced behavior instead of requiring callers to satisfy a precondition.

### Why are the changes needed?

Filter eligibility is independent of the connector interface. Applying each shared check before interface dispatch removes duplicated screening and keeps equivalent connector paths aligned.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No new tests were added because existing tests cover non-deterministic static and runtime filters for the affected connector paths.

The following focused runtime-filter tests passed:

    SPARK_LOCAL_IP=127.0.0.1 build/sbt 'sql/testOnly org.apache.spark.sql.connector.DataSourceV2SQLSuiteV2Filter -- -z "SPARK-58207: non-deterministic scalar subquery filters are not pushed into runtimeFilters"'

    SPARK_LOCAL_IP=127.0.0.1 build/sbt 'sql/testOnly org.apache.spark.sql.connector.DataSourceV2CatalystRuntimeFilterSuite -- -z "non-deterministic predicate on fully pushed attributes"'

Also ran `dev/lint-scala`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
