### PR TITLE
[SPARK-59456][SQL] Fix: RuleExecutor.PlanChangeLogger does work even when it doesn't log

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -307,6 +307,10 @@ trait Logging {
     log.isTraceEnabled
   }
 
+  protected def withLogLevel(level: Slf4jLevel)(f: => Unit): Unit = {
+    if (log.isEnabledForLevel(level)) f
+  }
+
   protected def logBasedOnLevel(level: Slf4jLevel)(f: => MessageWithContext): Unit = {
     level match {
       case Slf4jLevel.TRACE => logTrace(f.message)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -55,25 +55,24 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
   private val logBatches = SQLConf.get.planChangeBatches.map(Utils.stringToSeq)
 
   def logRule(ruleName: String, oldPlan: TreeType, newPlan: TreeType): Unit = {
-    if (!newPlan.fastEquals(oldPlan)) {
-      if (logRules.isEmpty || logRules.get.contains(ruleName)) {
-        def message(): MessageWithContext = {
-          val oldPlanStringWithOutput = oldPlan.treeString(verbose = false,
-            printOutputColumns = true)
-          val newPlanStringWithOutput = newPlan.treeString(verbose = false,
-            printOutputColumns = true)
-          // scalastyle:off line.size.limit
+    withLogLevel(logLevel) {
+      if ((logRules.isEmpty || logRules.get.contains(ruleName)) &&
+          !newPlan.fastEquals(oldPlan)) {
+        val oldPlanStringWithOutput = oldPlan.treeString(verbose = false,
+          printOutputColumns = true)
+        val newPlanStringWithOutput = newPlan.treeString(verbose = false,
+          printOutputColumns = true)
+        // scalastyle:off line.size.limit
+        logBasedOnLevel(logLevel) {
           log"""
-             |=== Applying Rule ${MDC(RULE_NAME, ruleName)} ===
-             |${MDC(QUERY_PLAN, sideBySide(oldPlan.treeString, newPlan.treeString).mkString("\n"))}
-             |
-             |Output Information:
-             |${MDC(QUERY_PLAN, sideBySide(oldPlanStringWithOutput, newPlanStringWithOutput).mkString("\n"))}
-           """.stripMargin
-           // scalastyle:on line.size.limit
+            |=== Applying Rule ${MDC(RULE_NAME, ruleName)} ===
+            |${MDC(QUERY_PLAN, sideBySide(oldPlan.treeString, newPlan.treeString).mkString("\n"))}
+            |
+            |Output Information:
+            |${MDC(QUERY_PLAN, sideBySide(oldPlanStringWithOutput, newPlanStringWithOutput).mkString("\n"))}
+          """.stripMargin
         }
-
-        logBasedOnLevel(logLevel)(message())
+        // scalastyle:on line.size.limit
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Added a functional `withLogLevel` helper to Logging to make it easy to skip work when the log level is below a target.

Then used that in `RuleExecutor.PlanChangeLogger` to avoid calling `fastEquals` unnecessarily.

### Why are the changes needed?

The existing code always called `fastEquals`, even when it couldn't log anything because of the log leve..

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The change itself is trivial.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex CLI 0.147.0 (GPT-5)