### PR TITLE
[SPARK-59460][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1072

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -8134,6 +8134,12 @@
     },
     "sqlState" : "42601"
   },
+  "TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE" : {
+    "message" : [
+      "Cannot retrieve tables or views that do not belong to the same database. Requested: <qualifiedTableNames>."
+    ],
+    "sqlState" : "0A000"
+  },
   "TABLE_LOCATION_URI_NOT_SPECIFIED" : {
     "message" : [
       "Table <identifier> did not specify locationUri."
@@ -10307,11 +10313,6 @@
   "_LEGACY_ERROR_TEMP_1071" : {
     "message" : [
       "Some existing schema fields (<nonExistentColumnNames>) are not present in the new schema. We don't support dropping columns yet."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1072" : {
-    "message" : [
-      "Only the tables/views belong to the same database can be retrieved. Querying tables/views are <qualifiedTableNames>."
     ]
   },
   "_LEGACY_ERROR_TEMP_1079" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1402,7 +1402,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def cannotRetrieveTableOrViewNotInSameDatabaseError(
       qualifiedTableNames: Seq[QualifiedTableName]): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1072",
+      errorClass = "TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE",
       messageParameters = Map("qualifiedTableNames" -> qualifiedTableNames.toString()))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -820,20 +820,30 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
 
   test("get tables by name when tables belong to different databases") {
     withBasicCatalog { catalog =>
-      intercept[AnalysisException](catalog.getTablesByName(
-        Seq(
-          TableIdentifier("tbl1", Some("db1")),
-          TableIdentifier("tbl2", Some("db2"))
-        )
-      ))
+      checkError(
+        exception = intercept[AnalysisException](catalog.getTablesByName(
+          Seq(
+            TableIdentifier("tbl1", Some("db1")),
+            TableIdentifier("tbl2", Some("db2"))
+          )
+        )),
+        condition = "TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE",
+        parameters = Map(
+          "qualifiedTableNames" ->
+            "List(spark_catalog.db1.tbl1, spark_catalog.db2.tbl2)"))
       // Get table without explicitly specifying database
       catalog.setCurrentDatabase("db2")
-      intercept[AnalysisException](catalog.getTablesByName(
-        Seq(
-          TableIdentifier("tbl1", Some("db1")),
-          TableIdentifier("tbl2")
-        )
-      ))
+      checkError(
+        exception = intercept[AnalysisException](catalog.getTablesByName(
+          Seq(
+            TableIdentifier("tbl1", Some("db1")),
+            TableIdentifier("tbl2")
+          )
+        )),
+        condition = "TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE",
+        parameters = Map(
+          "qualifiedTableNames" ->
+            "List(spark_catalog.db1.tbl1, spark_catalog.db2.tbl2)"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1072` to `TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE` (SQLSTATE `0A000`). It is raised by `SessionCatalog.getTablesByName` when the requested tables/views span more than one database. The message is also reworded for clarity.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one (part of SPARK-37935).

### Does this PR introduce _any_ user-facing change?

Yes. The condition becomes `TABLES_OR_VIEWS_NOT_IN_SAME_DATABASE`, and the message is reworded to "Cannot retrieve tables or views that do not belong to the same database. Requested: <qualifiedTableNames>."

### How was this patch tested?

Strengthened the existing `SessionCatalogSuite` test to assert the condition and parameters via `checkError` (it previously only intercepted the exception). `SparkThrowableSuite` passes.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8