### PR TITLE
[SPARK-58274][SQL] Assign a name to the error condition _LEGACY_ERROR_TEMP_1068

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -975,6 +975,12 @@
     ],
     "sqlState" : "42000"
   },
+  "CANNOT_USE_RESERVED_DATABASE_AS_CURRENT" : {
+    "message" : [
+      "Cannot use <database> as the current database because the name is reserved for system use. To access global temporary views, use a qualified name, e.g. SELECT * FROM <database>.viewName."
+    ],
+    "sqlState" : "42939"
+  },
   "CANNOT_WRITE_STATE_STORE" : {
     "message" : [
       "Error writing state store files for provider <providerClass>."
@@ -10297,11 +10303,6 @@
   "_LEGACY_ERROR_TEMP_1060" : {
     "message" : [
       "<command> does not support nested column: <column>."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_1068" : {
-    "message" : [
-      "<database> is a system preserved database, you cannot use it as current database. To access global temporary views, you should use qualified name with the GLOBAL_TEMP_DATABASE, e.g. SELECT * FROM <database>.viewName."
     ]
   },
   "_LEGACY_ERROR_TEMP_1071" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1381,8 +1381,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
 
   def cannotUsePreservedDatabaseAsCurrentDatabaseError(database: String): Throwable = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1068",
-      messageParameters = Map("database" -> database))
+      errorClass = "CANNOT_USE_RESERVED_DATABASE_AS_CURRENT",
+      messageParameters = Map("database" -> toSQLId(database)))
   }
 
   def createExternalTableWithoutLocationError(): Throwable = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/GlobalTempViewSuite.scala
@@ -98,8 +98,10 @@ class GlobalTempViewSuite extends SharedSparkSession {
       condition = "RESERVED_DATABASE_NAME",
       parameters = Map("database" -> s"`$globalTempDB`"))
 
-    val e2 = intercept[AnalysisException](sql(s"USE $globalTempDB"))
-    assert(e2.message.contains("system preserved database"))
+    checkError(
+      exception = intercept[AnalysisException](sql(s"USE $globalTempDB")),
+      condition = "CANNOT_USE_RESERVED_DATABASE_AS_CURRENT",
+      parameters = Map("database" -> s"`$globalTempDB`"))
   }
 
   test("CREATE GLOBAL TEMP VIEW USING") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Rename the legacy error condition `_LEGACY_ERROR_TEMP_1068` to the new named condition `CANNOT_USE_RESERVED_DATABASE_AS_CURRENT` (SQLSTATE `42939`). It is raised when a session sets the current database to the global temporary view database, e.g. `USE global_temp`.

### Why are the changes needed?

The error-conditions README disallows new `_LEGACY_ERROR_TEMP_*` entries and asks existing ones to be resolved. This resolves one (part of SPARK-37935).

### Does this PR introduce _any_ user-facing change?

Yes. The condition becomes `CANNOT_USE_RESERVED_DATABASE_AS_CURRENT`, and the message is reworded and now quotes the database name with backticks, e.g. ``Cannot use `global_temp` as the current database because the name is reserved for system use. To access global temporary views, use a qualified name, e.g. SELECT * FROM `global_temp`.viewName.``

### How was this patch tested?

Converted the message assertion in `GlobalTempViewSuite` to `checkError`. `SparkThrowableSuite` and `GlobalTempViewSuite` pass.

### Was this patch authored or co-authored using generative AI tooling?

Co-authored with Claude Opus 4.8
