### PR TITLE
[SPARK-59499][SQL] Avoid eager debug log rendering in Hive Thrift server

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/CLIService.java
@@ -179,7 +179,7 @@ public class CLIService extends CompositeService implements ICLIService {
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password,
       Map<String, String> configuration) throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password, null, configuration, false, null);
-    LOG.debug(sessionHandle + ": openSession()");
+    LOG.debug("{}: openSession()", sessionHandle);
     return sessionHandle;
   }
 
@@ -192,14 +192,14 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password, null, configuration,
         true, delegationToken);
-    LOG.debug(sessionHandle + ": openSessionWithImpersonation()");
+    LOG.debug("{}: openSessionWithImpersonation()", sessionHandle);
     return sessionHandle;
   }
 
   public SessionHandle openSession(TProtocolVersion protocol, String username, String password, String ipAddress,
       Map<String, String> configuration) throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password, ipAddress, configuration, false, null);
-    LOG.debug(sessionHandle + ": openSession()");
+    LOG.debug("{}: openSession()", sessionHandle);
     return sessionHandle;
   }
 
@@ -208,7 +208,7 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(protocol, username, password, ipAddress, configuration,
         true, delegationToken);
-    LOG.debug(sessionHandle + ": openSession()");
+    LOG.debug("{}: openSession()", sessionHandle);
     return sessionHandle;
   }
 
@@ -219,7 +219,7 @@ public class CLIService extends CompositeService implements ICLIService {
   public SessionHandle openSession(String username, String password, Map<String, String> configuration)
       throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(SERVER_VERSION, username, password, null, configuration, false, null);
-    LOG.debug(sessionHandle + ": openSession()");
+    LOG.debug("{}: openSession()", sessionHandle);
     return sessionHandle;
   }
 
@@ -231,7 +231,7 @@ public class CLIService extends CompositeService implements ICLIService {
       String delegationToken) throws HiveSQLException {
     SessionHandle sessionHandle = sessionManager.openSession(SERVER_VERSION, username, password, null, configuration,
         true, delegationToken);
-    LOG.debug(sessionHandle + ": openSession()");
+    LOG.debug("{}: openSession()", sessionHandle);
     return sessionHandle;
   }
 
@@ -242,7 +242,7 @@ public class CLIService extends CompositeService implements ICLIService {
   public void closeSession(SessionHandle sessionHandle)
       throws HiveSQLException {
     sessionManager.closeSession(sessionHandle);
-    LOG.debug(sessionHandle + ": closeSession()");
+    LOG.debug("{}: closeSession()", sessionHandle);
   }
 
   /* (non-Javadoc)
@@ -253,7 +253,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     GetInfoValue infoValue = sessionManager.getSession(sessionHandle)
         .getInfo(getInfoType);
-    LOG.debug(sessionHandle + ": getInfo()");
+    LOG.debug("{}: getInfo()", sessionHandle);
     return infoValue;
   }
 
@@ -269,7 +269,7 @@ public class CLIService extends CompositeService implements ICLIService {
     // monitor should be associated with the operation handle.
     session.getSessionState().updateProgressMonitor(null);
     OperationHandle opHandle = session.executeStatement(statement, confOverlay);
-    LOG.debug(sessionHandle + ": executeStatement()");
+    LOG.debug("{}: executeStatement()", sessionHandle);
     return opHandle;
   }
 
@@ -284,7 +284,7 @@ public class CLIService extends CompositeService implements ICLIService {
     // monitor should be associated with the operation handle.
     session.getSessionState().updateProgressMonitor(null);
     OperationHandle opHandle = session.executeStatement(statement, confOverlay, queryTimeout);
-    LOG.debug(sessionHandle + ": executeStatement()");
+    LOG.debug("{}: executeStatement()", sessionHandle);
     return opHandle;
   }
 
@@ -299,7 +299,7 @@ public class CLIService extends CompositeService implements ICLIService {
     // monitor should be associated with the operation handle.
     session.getSessionState().updateProgressMonitor(null);
     OperationHandle opHandle = session.executeStatementAsync(statement, confOverlay);
-    LOG.debug(sessionHandle + ": executeStatementAsync()");
+    LOG.debug("{}: executeStatementAsync()", sessionHandle);
     return opHandle;
   }
 
@@ -314,7 +314,7 @@ public class CLIService extends CompositeService implements ICLIService {
     // monitor should be associated with the operation handle.
     session.getSessionState().updateProgressMonitor(null);
     OperationHandle opHandle = session.executeStatementAsync(statement, confOverlay, queryTimeout);
-    LOG.debug(sessionHandle + ": executeStatementAsync()");
+    LOG.debug("{}: executeStatementAsync()", sessionHandle);
     return opHandle;
   }
 
@@ -327,7 +327,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getTypeInfo();
-    LOG.debug(sessionHandle + ": getTypeInfo()");
+    LOG.debug("{}: getTypeInfo()", sessionHandle);
     return opHandle;
   }
 
@@ -339,7 +339,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getCatalogs();
-    LOG.debug(sessionHandle + ": getCatalogs()");
+    LOG.debug("{}: getCatalogs()", sessionHandle);
     return opHandle;
   }
 
@@ -352,7 +352,7 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getSchemas(catalogName, schemaName);
-    LOG.debug(sessionHandle + ": getSchemas()");
+    LOG.debug("{}: getSchemas()", sessionHandle);
     return opHandle;
   }
 
@@ -365,7 +365,7 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getTables(catalogName, schemaName, tableName, tableTypes);
-    LOG.debug(sessionHandle + ": getTables()");
+    LOG.debug("{}: getTables()", sessionHandle);
     return opHandle;
   }
 
@@ -377,7 +377,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getTableTypes();
-    LOG.debug(sessionHandle + ": getTableTypes()");
+    LOG.debug("{}: getTableTypes()", sessionHandle);
     return opHandle;
   }
 
@@ -390,7 +390,7 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getColumns(catalogName, schemaName, tableName, columnName);
-    LOG.debug(sessionHandle + ": getColumns()");
+    LOG.debug("{}: getColumns()", sessionHandle);
     return opHandle;
   }
 
@@ -403,7 +403,7 @@ public class CLIService extends CompositeService implements ICLIService {
           throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getFunctions(catalogName, schemaName, functionName);
-    LOG.debug(sessionHandle + ": getFunctions()");
+    LOG.debug("{}: getFunctions()", sessionHandle);
     return opHandle;
   }
 
@@ -415,7 +415,7 @@ public class CLIService extends CompositeService implements ICLIService {
       String catalog, String schema, String table) throws HiveSQLException {
     OperationHandle opHandle = sessionManager.getSession(sessionHandle)
         .getPrimaryKeys(catalog, schema, table);
-    LOG.debug(sessionHandle + ": getPrimaryKeys()");
+    LOG.debug("{}: getPrimaryKeys()", sessionHandle);
     return opHandle;
   }
 
@@ -430,7 +430,7 @@ public class CLIService extends CompositeService implements ICLIService {
         .getCrossReference(primaryCatalog, primarySchema, primaryTable,
          foreignCatalog,
          foreignSchema, foreignTable);
-    LOG.debug(sessionHandle + ": getCrossReference()");
+    LOG.debug("{}: getCrossReference()", sessionHandle);
     return opHandle;
   }
 
@@ -455,10 +455,12 @@ public class CLIService extends CompositeService implements ICLIService {
         operation.getBackgroundHandle().get(timeout, TimeUnit.MILLISECONDS);
       } catch (TimeoutException e) {
         // No Op, return to the caller since long polling timeout has expired
-        LOG.trace(opHandle + ": Long polling timed out");
+        LOG.trace("{}: Long polling timed out", opHandle);
       } catch (CancellationException e) {
         // The background operation thread was cancelled
-        LOG.trace(opHandle + ": The background operation was cancelled", e);
+        if (LOG.isTraceEnabled()) {
+          LOG.trace(opHandle + ": The background operation was cancelled", e);
+        }
       } catch (ExecutionException e) {
         // The background operation thread was aborted
         LOG.warn("{}: The background operation was aborted", e,
@@ -469,7 +471,7 @@ public class CLIService extends CompositeService implements ICLIService {
       }
     }
     OperationStatus opStatus = operation.getStatus();
-    LOG.debug(opHandle + ": getOperationStatus()");
+    LOG.debug("{}: getOperationStatus()", opHandle);
     return opStatus;
   }
 
@@ -485,7 +487,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     sessionManager.getOperationManager().getOperation(opHandle)
     .getParentSession().cancelOperation(opHandle);
-    LOG.debug(opHandle + ": cancelOperation()");
+    LOG.debug("{}: cancelOperation()", opHandle);
   }
 
   /* (non-Javadoc)
@@ -496,7 +498,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     sessionManager.getOperationManager().getOperation(opHandle)
     .getParentSession().closeOperation(opHandle);
-    LOG.debug(opHandle + ": closeOperation");
+    LOG.debug("{}: closeOperation", opHandle);
   }
 
   /* (non-Javadoc)
@@ -507,7 +509,7 @@ public class CLIService extends CompositeService implements ICLIService {
       throws HiveSQLException {
     TTableSchema tableSchema = sessionManager.getOperationManager()
         .getOperation(opHandle).getParentSession().getResultSetMetadata(opHandle);
-    LOG.debug(opHandle + ": getResultSetMetadata()");
+    LOG.debug("{}: getResultSetMetadata()", opHandle);
     return tableSchema;
   }
 
@@ -526,7 +528,7 @@ public class CLIService extends CompositeService implements ICLIService {
       long maxRows, FetchType fetchType) throws HiveSQLException {
     TRowSet rowSet = sessionManager.getOperationManager().getOperation(opHandle)
         .getParentSession().fetchResults(opHandle, orientation, maxRows, fetchType);
-    LOG.debug(opHandle + ": fetchResults()");
+    LOG.debug("{}: fetchResults()", opHandle);
     return rowSet;
   }
 
@@ -580,7 +582,7 @@ public class CLIService extends CompositeService implements ICLIService {
         new OperationHandle(opHandle));
     final String queryId = operation.getParentSession().getHiveConf().getVar(
       HiveConf.getConfVars("hive.query.id"));
-    LOG.debug(opHandle + ": getQueryId() " + queryId);
+    LOG.debug("{}: getQueryId() {}", opHandle, queryId);
     return queryId;
   }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/ThreadWithGarbageCleanup.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/ThreadWithGarbageCleanup.java
@@ -55,8 +55,8 @@ public class ThreadWithGarbageCleanup extends Thread {
     Long threadId = this.getId();
     RawStore threadLocalRawStore = threadRawStoreMap.get(threadId);
     if (threadLocalRawStore != null) {
-      LOG.debug("RawStore: " + threadLocalRawStore + ", for the thread: " +
-          this.getName()  +  " will be closed now.");
+      LOG.debug("RawStore: {}, for the thread: {} will be closed now.",
+          threadLocalRawStore, this.getName());
       threadLocalRawStore.shutdown();
       threadRawStoreMap.remove(threadId);
     }
@@ -69,8 +69,8 @@ public class ThreadWithGarbageCleanup extends Thread {
     Long threadId = this.getId();
     RawStore threadLocalRawStore = HiveMetaStore.HMSHandler.getRawStore();
     if (threadLocalRawStore != null && !threadRawStoreMap.containsKey(threadId)) {
-      LOG.debug("Adding RawStore: " + threadLocalRawStore + ", for the thread: " +
-          this.getName() + " to threadRawStoreMap for future cleanup.");
+      LOG.debug("Adding RawStore: {}, for the thread: {} " +
+          "to threadRawStoreMap for future cleanup.", threadLocalRawStore, this.getName());
       threadRawStoreMap.put(threadId, threadLocalRawStore);
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'common/utils/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

There are a number of places in Hive Thrift server where we do string allocation work for logging, even if the log level would not make use of that work. By switching the logging pattern we avoid these allocations, which may be minor but represent good memory hygiene.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We are allocating string that are in most cases immediately discarded.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as new features, bug fixes, or other behavior changes. Documentation-only updates are not considered user-facing changes.

If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

The changes are trivially equivalent.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Generated-by: OpenAI Codex CLI 0.147.0 (GPT-5)